### PR TITLE
Move css module loaders to webpack contrib

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "@dojo/shim": "^0.1.0",
     "loader-utils": "^1.1.0",
     "recast": "^0.12.7"
   },
@@ -45,6 +46,8 @@
     "intern": "4.0.2",
     "mockery": "^2.1.0",
     "sinon": "^2.3.0",
+    "ts-loader": "2.3.1",
+    "typed-css-modules": "0.2.0",
     "typescript": "~2.4.2",
     "webpack": "^3.5.0"
   }

--- a/src/css-module-decorator-loader/index.ts
+++ b/src/css-module-decorator-loader/index.ts
@@ -1,0 +1,3 @@
+import loader from './loader';
+
+module.exports = loader;

--- a/src/css-module-decorator-loader/loader.ts
+++ b/src/css-module-decorator-loader/loader.ts
@@ -1,0 +1,18 @@
+import webpack = require('webpack');
+import { basename } from 'path';
+
+const themeKey = ' _key';
+
+export default function (this: webpack.LoaderContext, content: string, map?: any): string {
+	let response = content;
+	const localsRexExp = /exports.locals = {([.\s\S]*)};/;
+	const matches = content.match(localsRexExp);
+
+	if (matches && matches.length > 0) {
+		const key = basename(this.resourcePath, '.m.css');
+		const localExports = `{"${themeKey}": "${key}",${matches[1]}}`;
+		response = content.replace(localsRexExp, `exports.locals = ${localExports};`);
+	}
+
+	return response;
+};

--- a/src/css-module-dts-loader/index.ts
+++ b/src/css-module-dts-loader/index.ts
@@ -1,0 +1,3 @@
+import loader from './loader';
+
+module.exports = loader;

--- a/src/css-module-dts-loader/loader.ts
+++ b/src/css-module-dts-loader/loader.ts
@@ -1,0 +1,105 @@
+import webpack = require('webpack');
+import { createSourceFile, forEachChild, Node, ScriptTarget, SyntaxKind } from 'typescript';
+import { statSync } from 'fs';
+import { dirname, resolve } from 'path';
+import Map from '@dojo/shim/Map';
+import '@dojo/shim/Promise';
+const DtsCreator = require('typed-css-modules');
+const { getOptions } = require('loader-utils');
+const instances = require('ts-loader/dist/instances');
+
+type TSLoaderInstances = {
+	files: {
+		[key: string]: boolean;
+	}
+};
+
+type DtsResult = {
+	writeFile(): Promise<void>;
+};
+
+type DtsCreatorInstance = {
+	create(filePath: string, initialContents: boolean, clearCache: boolean): Promise<DtsResult>;
+};
+
+type LoaderArgs = {
+	type: string;
+	instanceName?: string;
+};
+
+const creator: DtsCreatorInstance = new DtsCreator();
+
+const mTimeMap = new Map<string, Date>();
+
+function generateDTSFile(filePath: string): Promise<void> {
+	return Promise.resolve().then(() => {
+		const { mtime } = statSync(filePath);
+		const lastMTime = mTimeMap.get(filePath);
+
+		if (!lastMTime || mtime > lastMTime) {
+			mTimeMap.set(filePath, mtime);
+			return creator.create(filePath, false, true)
+				.then((content) => content.writeFile());
+		}
+	});
+}
+
+function getCssImport(node: Node): string | void {
+	if (node.kind === SyntaxKind.StringLiteral) {
+		const importPath = node.getText().replace(/\'|\"/g, '');
+		if (/\.css$/.test(importPath)) {
+			const parentFileName = node.getSourceFile().fileName;
+			return resolve(dirname(parentFileName), importPath);
+		}
+	}
+}
+
+function traverseNode(node: Node, filePaths: string[] = []): string[] {
+	switch (node.kind) {
+		case SyntaxKind.SourceFile:
+			forEachChild(node, (childNode: Node) => {
+				traverseNode(childNode, filePaths);
+			});
+			break;
+		case SyntaxKind.ImportDeclaration:
+			forEachChild(node, (childNode: Node) => {
+				const path = getCssImport(childNode);
+				path && filePaths.push(path);
+			});
+			break;
+	}
+	return filePaths;
+}
+
+export default function (this: webpack.LoaderContext, content: string, sourceMap?: string) {
+	const callback = this.async();
+	const { type = 'ts', instanceName }: LoaderArgs = getOptions(this);
+
+	Promise.resolve().then(() => {
+		let generationPromises: Promise<void>[] = [];
+		switch (type) {
+			case 'css':
+				generationPromises.push(generateDTSFile(this.resourcePath));
+				break;
+			case 'ts':
+				const sourceFile = createSourceFile(this.resourcePath, content, ScriptTarget.Latest, true);
+				const cssFilePaths = traverseNode(sourceFile);
+
+				if (cssFilePaths.length) {
+
+					if (instanceName) {
+						const instanceWrapper = instances.getTypeScriptInstance({ instance: instanceName });
+
+						if (instanceWrapper.instance) {
+							instanceWrapper.instance.files[ this.resourcePath ] = false;
+						}
+					}
+
+					generationPromises = cssFilePaths.map((cssFilePath) => generateDTSFile(cssFilePath));
+				}
+				break;
+		}
+		return Promise.all(generationPromises);
+	})
+	.then(() => callback(null, content, sourceMap));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,2 +1,8 @@
 export { default as staticOptimizeLoader } from './static-build-loader/loader';
 export * from './static-build-loader/loader';
+
+export { default as cssModuleDtsLoader } from './css-module-dts-loader/loader';
+export * from './css-module-dts-loader/loader';
+
+export { default as cssModuleDecoratorLoader } from './css-module-decorator-loader/loader';
+export * from './css-module-decorator-loader/loader';

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,2 +1,4 @@
 import './main';
 import './static-build-loader/all';
+import './css-module-decorator-loader/all';
+import './css-module-dts-loader/all';

--- a/tests/unit/css-module-decorator-loader/all.ts
+++ b/tests/unit/css-module-decorator-loader/all.ts
@@ -1,0 +1,2 @@
+import './index';
+import './loader';

--- a/tests/unit/css-module-decorator-loader/index.ts
+++ b/tests/unit/css-module-decorator-loader/index.ts
@@ -1,9 +1,9 @@
-import * as loader from '../../../src/static-build-loader/index';
+import * as loader from '../../../src/css-module-decorator-loader/index';
 
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-registerSuite('static-build-loader index', {
+registerSuite('css-module-decorator-loader index', {
 	'exists'() {
 		assert(loader);
 	}

--- a/tests/unit/css-module-decorator-loader/loader.ts
+++ b/tests/unit/css-module-decorator-loader/loader.ts
@@ -1,0 +1,41 @@
+import loader from '../../../src/css-module-decorator-loader/loader';
+
+const { assert } = intern.getPlugin('chai');
+const { describe, it } = intern.getInterface('bdd');
+
+describe('css-module-decorator-loader', () => {
+	it('should not effect content without local exports', () => {
+		const content = `exports = 'abc'
+		exports.push(['a', 'b'])`;
+
+		const result = loader.call({ resourcePath: 'blah' }, content);
+		assert.equal(result, content);
+	});
+
+	it('should wrap local exports with decorator', () => {
+		const content = `exports.locals = { "hello": "world" };`;
+
+		const result = loader.bind({ resourcePath: 'testFile.m.css' })(content);
+		assert.equal(result.replace(/\n|\t/g, ''), 'exports.locals = {" _key": "testFile", "hello": "world" };');
+	});
+
+	it('should wrap multi line local exports with decorator', () => {
+		const content = `exports.locals = {
+			"hello": "world",
+			"foo": "bar"
+		};`;
+
+		const result = loader.bind({ resourcePath: 'testFile.m.css' })(content);
+		assert.equal(result.replace(/\n|\t/g, ''), 'exports.locals = {" _key": "testFile","hello": "world","foo": "bar"};');
+	});
+
+	it('should support inline requires used for composes', () => {
+		const content = `exports.locals = {
+			 "hello": "world " + require("-!stuff!./base.css").locals["hello"] + "",
+			 "foo": "bar"
+		};`;
+
+		const result = loader.bind({ resourcePath: 'testFile.m.css' })(content);
+		assert.equal(result.replace(/\n|\t/g, ''), 'exports.locals = {" _key": "testFile", "hello": "world " + require("-!stuff!./base.css").locals["hello"] + "", "foo": "bar"};');
+	});
+});

--- a/tests/unit/css-module-dts-loader/all.ts
+++ b/tests/unit/css-module-dts-loader/all.ts
@@ -1,0 +1,2 @@
+import './index';
+import './loader';

--- a/tests/unit/css-module-dts-loader/index.ts
+++ b/tests/unit/css-module-dts-loader/index.ts
@@ -1,9 +1,9 @@
-import * as loader from '../../../src/static-build-loader/index';
+import * as loader from '../../../src/css-module-dts-loader/index';
 
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-registerSuite('static-build-loader index', {
+registerSuite('css-module-dts-loader index', {
 	'exists'() {
 		assert(loader);
 	}

--- a/tests/unit/css-module-dts-loader/loader.ts
+++ b/tests/unit/css-module-dts-loader/loader.ts
@@ -1,0 +1,262 @@
+import * as path from 'path';
+import MockModule from '../../support/MockModule';
+import * as sinon from 'sinon';
+import '../../../src/css-module-dts-loader/loader';
+
+const { assert } = intern.getPlugin('chai');
+const { afterEach, beforeEach, describe, it } = intern.getInterface('bdd');
+
+const cssFilePath = '/path/to/file.css';
+const cssFilePath2 = '/path/to/file2.css';
+
+const cssContent = `
+	.foo: {
+		color: red;
+	}
+`;
+
+const tsContentWithCss = `
+	import thing from 'place';
+	import * as css from '${cssFilePath}';
+`;
+
+const tsContentWithMultipleCss = `
+	import thing from 'place';
+	import * as css from '${cssFilePath}';
+	import this from 'that';
+	import * as css2 from '${cssFilePath2}';
+`;
+
+const tsContentWithoutCss = `
+	import thing from 'place';
+	import this from 'that';
+	import other from 'somemoduleendingwithcss';
+`;
+
+describe('css-module-dts-loader', () => {
+	let loaderUnderTest: any;
+	let mockModule: MockModule;
+	let mockDTSGenerator: any;
+	let mockUtils: any;
+	let mockFs: any;
+	let mockInstances: any;
+	let sandbox: sinon.SinonSandbox;
+	const async = () => () => null;
+	let writeFile: sinon.SinonStub;
+	const resourcePath = 'test/path';
+	const dateNow = new Date();
+	let instance: any;
+	const defaultScope = { async, resourcePath };
+
+	function getInstance() {
+		return {
+			files: {
+				[ resourcePath ]: true
+			}
+		};
+	}
+
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+		writeFile = sandbox.stub();
+		mockModule = new MockModule('../../../src/css-module-dts-loader/loader', require);
+		mockModule.dependencies([
+			'typed-css-modules',
+			'ts-loader/dist/instances',
+			'loader-utils',
+			'fs'
+		]);
+		mockDTSGenerator = mockModule.getMock('typed-css-modules');
+		mockDTSGenerator.create = sandbox.stub().returns(Promise.resolve({ writeFile }));
+		mockUtils = mockModule.getMock('loader-utils');
+		mockUtils.getOptions = sandbox.stub();
+		mockFs = mockModule.getMock('fs');
+		mockFs.statSync = sandbox.stub().returns({ mtime: dateNow });
+		mockInstances = mockModule.getMock('ts-loader/dist/instances');
+		instance = getInstance();
+		mockInstances.getTypeScriptInstance = sandbox.stub().returns({ instance });
+		loaderUnderTest = mockModule.getModuleUnderTest().default;
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+		mockModule.destroy();
+	});
+
+	it('should generate a dts file when query type is css', () => {
+		mockUtils.getOptions.returns({
+			type: 'css'
+		});
+
+		return new Promise(resolve => {
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resourcePath
+			}, cssContent);
+		}).then(() => {
+			assert.isTrue(mockDTSGenerator.create.calledOnce);
+			assert.isTrue(writeFile.calledOnce);
+		});
+	});
+
+	it('should not generate a dts file when css mtime has not changed', () => {
+		mockUtils.getOptions.returns({
+			type: 'css'
+		});
+		mockFs.statSync.resetHistory();
+
+		return new Promise(resolve => {
+			loaderUnderTest.call(defaultScope, cssContent);
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resourcePath
+			}, cssContent);
+		}).then(() => {
+			assert.isTrue(mockFs.statSync.calledTwice);
+			assert.isTrue(mockDTSGenerator.create.calledOnce);
+			assert.isTrue(writeFile.calledOnce);
+		});
+	});
+
+	it('should generate a dts file when css mtime has changed', () => {
+		mockUtils.getOptions.returns({
+			type: 'css'
+		});
+		mockFs.statSync.resetHistory();
+		mockFs.statSync.onSecondCall().returns({ mtime: new Date() });
+
+		return new Promise(resolve => {
+			loaderUnderTest.call(defaultScope, cssContent);
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resourcePath
+			}, cssContent);
+		}).then(() => {
+			assert.isTrue(mockFs.statSync.calledTwice);
+			assert.isTrue(mockDTSGenerator.create.calledTwice);
+			assert.isTrue(writeFile.calledTwice);
+		});
+	});
+
+	it('should find css import declarations in ts files and generate dts', () => {
+		mockUtils.getOptions.returns({
+			type: 'ts'
+		});
+
+		return new Promise(resolve => {
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resourcePath
+			}, tsContentWithCss);
+		}).then(() => {
+			assert.isTrue(mockDTSGenerator.create.calledOnce);
+			assert.isTrue(mockDTSGenerator.create.firstCall.calledWith(path.resolve(cssFilePath)));
+			assert.isTrue(writeFile.calledOnce);
+		});
+	});
+
+	it('should find multiple css import declarations in ts files and generate multiple dts files', () => {
+		mockUtils.getOptions.returns({
+			type: 'ts'
+		});
+
+		return new Promise(resolve => {
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resourcePath
+			}, tsContentWithMultipleCss);
+		}).then(() => {
+			assert.isTrue(mockDTSGenerator.create.calledTwice);
+			assert.isTrue(mockDTSGenerator.create.firstCall.calledWith(path.resolve(cssFilePath)));
+			assert.isTrue(mockDTSGenerator.create.secondCall.calledWith(path.resolve(cssFilePath2)));
+			assert.isTrue(writeFile.calledTwice);
+		});
+	});
+
+	it('should remove file from ts-loader cache if instance name is passed', () => {
+		mockUtils.getOptions.returns({
+			type: 'ts',
+			instanceName: 'test'
+		});
+
+		return new Promise(resolve => {
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resourcePath
+			}, tsContentWithCss);
+		}).then(() => {
+			assert.isFalse(instance.files[resourcePath]);
+		});
+	});
+
+	it('should not throw an error if there is an instance name but no instance', () => {
+		mockInstances.getTypeScriptInstance.returns({});
+		mockUtils.getOptions.returns({
+			type: 'ts',
+			instanceName: 'test'
+		});
+
+		return new Promise(resolve => {
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resourcePath
+			}, tsContentWithCss);
+		});
+	});
+
+	it('should not generate dts files if no css imports are found', () => {
+		mockUtils.getOptions.returns({
+			type: 'ts',
+			instanceName: 'test'
+		});
+
+		return new Promise(resolve => {
+			mockFs.statSync.resetHistory();
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resourcePath
+			}, tsContentWithoutCss);
+		}).then(() => {
+			assert.isFalse(mockInstances.getTypeScriptInstance.called);
+			assert.isFalse(mockFs.statSync.called);
+			assert.isFalse(mockDTSGenerator.create.called);
+		});
+	});
+
+	it('should default the type to ts when it cannot be determined', () => {
+		mockUtils.getOptions.returns({});
+
+		const resolvePath = path.resolve;
+		return new Promise(resolve => {
+			loaderUnderTest.call({
+				async() {
+					return () => resolve();
+				},
+				resolve(context: string, path: string, callback: (error: any, path?: string) => void) {
+					callback(null, resolvePath(context, path));
+				},
+				resourcePath
+			}, tsContentWithCss);
+		}).then(() => {
+			assert.isTrue(mockDTSGenerator.create.calledOnce);
+			assert.isTrue(mockDTSGenerator.create.firstCall.calledWith(path.resolve('src', cssFilePath)));
+			assert.isTrue(writeFile.calledOnce);
+		});
+	});
+});

--- a/tests/unit/static-build-loader/loader.ts
+++ b/tests/unit/static-build-loader/loader.ts
@@ -51,6 +51,7 @@ registerSuite('static-build-loader', {
 
 	after() {
 		sandbox.restore();
+		mockModule.destroy();
 	},
 
 	tests: {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
Adds the CSS module loaders from dojo/cli-build-webpack to this repo. This is built on top of #4 so it should be reviewed and merged after that.

This doesn't resolve the issue by itself, but along with changes in dojo/cli-build-webpack this addresses dojo/cli-build-webpack#220
