### PR TITLE
Fix bug with dts-loader and new version of ts-loader

### DIFF
--- a/src/css-module-dts-loader/loader.ts
+++ b/src/css-module-dts-loader/loader.ts
@@ -107,7 +107,7 @@ export default function (this: webpack.LoaderContext, content: string, sourceMap
 						const instanceWrapper = instances.getTypeScriptInstance({ instance: instanceName });
 
 						if (instanceWrapper.instance) {
-							instanceWrapper.instance.files[ this.resourcePath ] = false;
+							instanceWrapper.instance.files[this.resourcePath] = undefined;
 						}
 					}
 

--- a/tests/unit/css-module-dts-loader/loader.ts
+++ b/tests/unit/css-module-dts-loader/loader.ts
@@ -234,7 +234,7 @@ describe('css-module-dts-loader', () => {
 				}
 			}, tsContentWithCss);
 		}).then(() => {
-			assert.isFalse(instance.files[resourcePath]);
+			assert.isUndefined(instance.files[resourcePath]);
 		});
 	});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
Newer versions of `ts-loader` check for `instance[file] === undefined` whereas previous they checked for `!instance[file]`. The dts loader needs to be updated to be compatible with this change, otherwise the build breaks when upgrading ts-loader.
