### PR TITLE
implement promise loader that deals with absolute paths

### DIFF
--- a/src/promise-loader/index.ts
+++ b/src/promise-loader/index.ts
@@ -1,0 +1,32 @@
+import * as path from 'path';
+const loaderUtils = require('loader-utils');
+
+export function pitch (this: any, remainingRequest: string) {
+	this.cacheable && this.cacheable();
+	const query = this.query.substring(1).split(',');
+	const promiseLib = query[0];
+	const filename = path.basename(remainingRequest);
+	const name = path.basename(remainingRequest, path.extname(filename));
+	let bundleName = query[1] || '';
+
+	bundleName = bundleName.replace(/\[filename\]/g, filename).replace(/\[name\]/g, name);
+
+	if (!promiseLib) {
+		throw new Error('You need to specify your Promise library of choice, e.g. require("promise?bluebird!./file.js")');
+	}
+
+	const requirePromise = promiseLib !== 'global' ? 'var Promise = require(' + JSON.stringify(promiseLib) + ');\n' : '';
+
+	const result = `${requirePromise}
+module.exports = function () {
+	return new Promise(function (resolve) {
+	require.ensure([], function (require) {
+		resolve(require(${loaderUtils.stringifyRequest(this, '!!' + remainingRequest)}));
+	}${bundleName && (', ' + JSON.stringify(bundleName))});
+	});
+}`;
+
+	return result;
+};
+
+export default () => {};

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -7,3 +7,4 @@ import './css-module-plugin/CssModulePlugin';
 import './i18n-plugin/dependencies/InjectedModuleDependency';
 import './i18n-plugin/I18nPlugin';
 import './i18n-plugin/templates/setLocaleData';
+import './promise-loader/all';

--- a/tests/unit/promise-loader/all.ts
+++ b/tests/unit/promise-loader/all.ts
@@ -1,0 +1,1 @@
+import './index';

--- a/tests/unit/promise-loader/index.ts
+++ b/tests/unit/promise-loader/index.ts
@@ -1,0 +1,26 @@
+import * as loader from '../../../src/promise-loader/index';
+
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+describe('promise-loader', () => {
+	it('loader', () => {
+		const context = {
+			query: '?global,Foo',
+			context: '/absolute/path/to'
+		};
+		const expectedResult = `
+module.exports = function () {
+	return new Promise(function (resolve) {
+	require.ensure([], function (require) {
+		resolve(require("!!./node_modules/umd-compat-loader/index.js??ref--3-0!./node_modules/ts-loader/index.js??ref--3-1!./node_modules/@dojo/webpack-contrib/css-module-dts-loader/index.js?type=ts&instanceName=0_dojo!./src/Foo.ts"));
+	}, "Foo");
+	});
+}`;
+		const result = loader.pitch.call(
+			context,
+			'/absolute/path/to/node_modules/umd-compat-loader/index.js??ref--3-0!/absolute/path/to/node_modules/ts-loader/index.js??ref--3-1!/absolute/path/to/node_modules/@dojo/webpack-contrib/css-module-dts-loader/index.js?type=ts&instanceName=0_dojo!/absolute/path/to/src/Foo.ts'
+		);
+		assert.strictEqual(result, expectedResult);
+	});
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Implements a promise loader that ensures absolute paths are converted to relative paths.

Resolves #15 
