### PR TITLE
Converting to commonjs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"version": "2.2.0",
 	"compilerOptions": {
 		"declaration": false,
-		"module": "umd",
+		"module": "commonjs",
 		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,


### PR DESCRIPTION
Title says it all. Moving from `umd` module format to `commonjs`.  Not only are the rest of the cli tools on commonjs, but using commonjs will disable esm in future grunt-dojo2 builds.