### PR TITLE
Fix: allow string mid in i18n template

### DIFF
--- a/src/i18n-plugin/dependencies/InjectedModuleDependency.ts
+++ b/src/i18n-plugin/dependencies/InjectedModuleDependency.ts
@@ -26,7 +26,7 @@ InjectedModuleDependency.Template = class {
 	 */
 	apply(dep: InjectedModuleDependency, source: ReplaceSource) {
 		const content = dep.module
-			? `__webpack_require__(${dep.module.id});`
+			? `__webpack_require__(${JSON.stringify(dep.module.id)});`
 			: webpackMissingModule.module(dep.request);
 
 		const prefix = dep.variable ? `var ${dep.variable} = ` : '';

--- a/tests/unit/i18n-plugin/dependencies/InjectedModuleDependency.ts
+++ b/tests/unit/i18n-plugin/dependencies/InjectedModuleDependency.ts
@@ -30,6 +30,20 @@ describe('InjectedModuleDependency', () => {
 		assert.sameDeepMembers(source.insertions, [[0, 'var answer = __webpack_require__(42);\n']]);
 	});
 
+	it('should account for string mids', () => {
+		const source = new ReplaceSource('');
+		const dep = new InjectedModuleDependency('/resource');
+		const template = new InjectedModuleDependency.Template();
+		const id = '/path/to/module.js';
+		const module = { id } as any;
+
+		dep.variable = 'answer';
+		dep.module = module;
+		template.apply(dep, source);
+
+		assert.sameDeepMembers(source.insertions, [[0, `var answer = __webpack_require__(${JSON.stringify(id)});\n`]]);
+	});
+
 	it('inject a missing module error without a module', () => {
 		const source = new ReplaceSource('');
 		const dep = new InjectedModuleDependency('/resource');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensures the i18n template is injected with a properly-formatted mid.

Resolves #23 
