### PR TITLE
Fix: allow relative cldr paths in dojorc

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The plugin accepts an options object with the following properties:
 
 | Property | Type | Optional | Description |
 | -------- | ---- | -------- | ----------- |
-| cldrData | string[] | Yes | An array of paths to CLDR JSON modules that should be included in the build and registered with the i18n ecosystem. |
+| cldrData | string[] | Yes | An array of paths to CLDR JSON modules that should be included in the build and registered with the i18n ecosystem. If a path begins with a ".", then it is treated as relative to the current working directory. Otherwise, it is treated as a valid mid. |
 | defaultLocale | string | No | The default locale. |
 | supportedLocales | string[] | Yes | An array of supported locales beyond the default. |
 | target | string | Yes | The entry point into which the i18n module should be injected. Defaults to `src/main.ts`. |

--- a/src/i18n-plugin/I18nPlugin.ts
+++ b/src/i18n-plugin/I18nPlugin.ts
@@ -5,6 +5,8 @@ import { Compiler, DefinePlugin } from 'webpack';
 import NormalModule = require('webpack/lib/NormalModule');
 import InjectedModuleDependency from './dependencies/InjectedModuleDependency';
 
+const basePath = process.cwd();
+
 export interface I18nPluginOptions {
 	/**
 	 * An optional list of CLDR JSON paths used to inject CLDR data into the application.
@@ -109,6 +111,9 @@ export default class I18nPlugin {
 
 		return this.cldrPaths
 			.map((url) => {
+				if (url.charAt(0) === '.') {
+					url = join(basePath, url);
+				}
 				return locales.map((locale) => url.replace('{locale}', locale));
 			})
 			.reduce((left, right) => left.concat(right), [])

--- a/tests/unit/i18n-plugin/I18nPlugin.ts
+++ b/tests/unit/i18n-plugin/I18nPlugin.ts
@@ -105,9 +105,9 @@ describe('I18nPlugin', () => {
 		};
 		const plugin = new I18nPlugin({
 			defaultLocale: 'en',
-			cldrPaths: ['{locale}/main.json', 'supplemental.json'].map((file) =>
-				join(process.cwd(), 'tests/support/fixtures/cldr/', file)
-			)
+			cldrPaths: ['{locale}/main.json', 'supplemental.json'].map((file) => {
+				return `./tests/support/fixtures/cldr/${file}`;
+			})
 		});
 		applyModule(plugin);
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Allows `cldrPaths` in the dojorc to contain paths that are relative to the application root (cwd). I have verified this locally with a test application.

Resolves #25 