### PR TITLE
Use full package identifier for theme key

### DIFF
--- a/src/css-module-decorator-loader/loader.ts
+++ b/src/css-module-decorator-loader/loader.ts
@@ -1,7 +1,13 @@
 import webpack = require('webpack');
-import { basename } from 'path';
+import { join, basename } from 'path';
+import { existsSync } from 'fs';
 
 const themeKey = ' _key';
+
+const basePath = process.cwd();
+const packageJsonPath = join(basePath, 'package.json');
+const packageJson = existsSync(packageJsonPath) ? require(packageJsonPath) : {};
+const packageName = packageJson.name || '';
 
 export default function(this: webpack.LoaderContext, content: string, map?: any): string {
 	let response = content;
@@ -9,7 +15,7 @@ export default function(this: webpack.LoaderContext, content: string, map?: any)
 	const matches = content.match(localsRexExp);
 
 	if (matches && matches.length > 0) {
-		const key = basename(this.resourcePath, '.m.css');
+		const key = `${packageName}/${basename(this.resourcePath, '.m.css')}`;
 		const localExports = `{"${themeKey}": "${key}",${matches[1]}}`;
 		response = content.replace(localsRexExp, `exports.locals = ${localExports};`);
 	}

--- a/tests/unit/css-module-decorator-loader/loader.ts
+++ b/tests/unit/css-module-decorator-loader/loader.ts
@@ -16,7 +16,10 @@ describe('css-module-decorator-loader', () => {
 		const content = `exports.locals = { "hello": "world" };`;
 
 		const result = loader.bind({ resourcePath: 'testFile.m.css' })(content);
-		assert.equal(result.replace(/\n|\t/g, ''), 'exports.locals = {" _key": "testFile", "hello": "world" };');
+		assert.equal(
+			result.replace(/\n|\t/g, ''),
+			'exports.locals = {" _key": "@dojo/webpack-contrib/testFile", "hello": "world" };'
+		);
 	});
 
 	it('should wrap multi line local exports with decorator', () => {
@@ -28,7 +31,7 @@ describe('css-module-decorator-loader', () => {
 		const result = loader.bind({ resourcePath: 'testFile.m.css' })(content);
 		assert.equal(
 			result.replace(/\n|\t/g, ''),
-			'exports.locals = {" _key": "testFile","hello": "world","foo": "bar"};'
+			'exports.locals = {" _key": "@dojo/webpack-contrib/testFile","hello": "world","foo": "bar"};'
 		);
 	});
 
@@ -41,7 +44,7 @@ describe('css-module-decorator-loader', () => {
 		const result = loader.bind({ resourcePath: 'testFile.m.css' })(content);
 		assert.equal(
 			result.replace(/\n|\t/g, ''),
-			'exports.locals = {" _key": "testFile", "hello": "world " + require("-!stuff!./base.css").locals["hello"] + "", "foo": "bar"};'
+			'exports.locals = {" _key": "@dojo/webpack-contrib/testFile", "hello": "world " + require("-!stuff!./base.css").locals["hello"] + "", "foo": "bar"};'
 		);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The theme keys that are generated should be consistent whether they are built for libraries or built by widgets - using the package name and widget name
