### PR TITLE
Add support for imports in static-features

### DIFF
--- a/src/static-build-loader/recast.d.ts
+++ b/src/static-build-loader/recast.d.ts
@@ -14,7 +14,8 @@ declare module 'recast/main' {
 		CallExpression,
 		ExpressionStatement,
 		VariableDeclaration,
-		MemberExpression
+		MemberExpression,
+		ImportDeclaration
 	} from 'estree';
 
 	namespace recast {
@@ -30,6 +31,7 @@ declare module 'recast/main' {
 			MemberExpression: MemberExpression;
 			ExpressionStatement: ExpressionStatement;
 			VariableDeclaration: VariableDeclaration;
+			ImportDeclaration: ImportDeclaration;
 		}
 
 		interface AST {
@@ -61,6 +63,7 @@ declare module 'recast/main' {
 					visitCallExpression: VisitFunction<CallExpression>;
 					visitVariableDeclaration: VisitFunction<VariableDeclaration>;
 					visitExpressionStatement: VisitFunction<ExpressionStatement>;
+					visitDeclaration: VisitFunction<ImportDeclaration>;
 				}>
 			): void;
 		}


### PR DESCRIPTION
**Type:** feature

**Description:**
static-features currently only supports `require` statements for checking, which is fine for our es5 modules as our imports are down emitted to requires. With our added support for `.mjs` this is no longer the case though and we now need to support `import` statements also.