### PR TITLE
Remove comments and blank lines from inlined css in build time rendering

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -136,7 +136,7 @@ window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };`)
 		var target;
 		paths.some(function (path, i) {
 			target = html[i];
-			return path && ((typeof path === 'string' && path === window.location.hash) || (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash)));
+			return (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
 		});
 		if (target && element) {
 			var frag = document.createRange().createContextualFragment(target);

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -120,7 +120,9 @@ window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };`)
 							}
 							return true;
 						}
-					}).replace(/\/\*# sourceMappingURL\=.*/, '');
+					})
+						.replace(/\/\*.*\*\//g, '')
+						.replace(/^(\s*)(\r\n?|\n)/gm, '');
 					result = `${result}\n${filteredCss}`;
 				}
 				return result;

--- a/tests/support/fixtures/build-time-render/expected/index.html
+++ b/tests/support/fixtures/build-time-render/expected/index.html
@@ -4,10 +4,10 @@
 .hello {
   background: red;
 }
-
 span {
   width: 100%;
-}</style>
+}
+</style>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/tests/support/fixtures/build-time-render/expected/index.html
+++ b/tests/support/fixtures/build-time-render/expected/index.html
@@ -19,7 +19,7 @@ span {
 		var target;
 		paths.some(function (path, i) {
 			target = html[i];
-			return path && ((typeof path === 'string' && path === window.location.hash) || (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash)));
+			return (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
 		});
 		if (target && element) {
 			var frag = document.createRange().createContextualFragment(target);

--- a/tests/support/fixtures/build-time-render/expected/indexWithPaths.html
+++ b/tests/support/fixtures/build-time-render/expected/indexWithPaths.html
@@ -4,10 +4,10 @@
 .hello {
   background: red;
 }
-
 span {
   width: 100%;
-}</style>
+}
+</style>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/tests/support/fixtures/build-time-render/expected/indexWithPaths.html
+++ b/tests/support/fixtures/build-time-render/expected/indexWithPaths.html
@@ -19,7 +19,7 @@ span {
 		var target;
 		paths.some(function (path, i) {
 			target = html[i];
-			return path && ((typeof path === 'string' && path === window.location.hash) || (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash)));
+			return (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
 		});
 		if (target && element) {
 			var frag = document.createRange().createContextualFragment(target);

--- a/tests/support/fixtures/build-time-render/main.css
+++ b/tests/support/fixtures/build-time-render/main.css
@@ -2,6 +2,8 @@
 	margin: 10px;
 }
 
+/* example comment */
+
 .hello {
 	background: red;
 }
@@ -9,3 +11,5 @@
 span {
 	width: 100%;
 }
+
+/*# sourceMappingURL=main.16469ae7e579bf3f6af50cbfcb734efa.bundle.css.map*/


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Remove comments and blank lines from inlined critical CSS
