### PR TITLE
Only append the html when the hashes match

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -135,8 +135,11 @@ window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };`)
 		var element = document.getElementById('${this._root}');
 		var target;
 		paths.some(function (path, i) {
-			target = html[i];
-			return (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
+			var match = (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
+			if (match) {
+				target = html[i];
+			}
+			return match;
 		});
 		if (target && element) {
 			var frag = document.createRange().createContextualFragment(target);

--- a/tests/support/fixtures/build-time-render/expected/index.html
+++ b/tests/support/fixtures/build-time-render/expected/index.html
@@ -18,8 +18,11 @@ span {
 		var element = document.getElementById('app');
 		var target;
 		paths.some(function (path, i) {
-			target = html[i];
-			return (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
+			var match = (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
+			if (match) {
+				target = html[i];
+			}
+			return match;
 		});
 		if (target && element) {
 			var frag = document.createRange().createContextualFragment(target);

--- a/tests/support/fixtures/build-time-render/expected/indexWithPaths.html
+++ b/tests/support/fixtures/build-time-render/expected/indexWithPaths.html
@@ -18,8 +18,11 @@ span {
 		var element = document.getElementById('app');
 		var target;
 		paths.some(function (path, i) {
-			target = html[i];
-			return (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
+			var match = (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
+			if (match) {
+				target = html[i];
+			}
+			return match;
 		});
 		if (target && element) {
 			var frag = document.createRange().createContextualFragment(target);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The build time render HTML should only be append when the `window.location.hash` matches the path for the HTML.

Resolves #39 
