### PR TITLE
Registry transformer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7537,6 +7537,12 @@
         "abbrev": "1.1.1"
       }
     },
+    "normalize-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-newline/-/normalize-newline-3.0.0.tgz",
+      "integrity": "sha1-HL6oBKukNgAfg5OKsh7AOdaa6dM=",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -13028,8 +13034,7 @@
     "typescript": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
-      "dev": true
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
     },
     "typings-core": {
       "version": "1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/webpack-contrib",
-  "version": "0.2.4",
+  "version": "0.2.5-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "recast": "^0.12.7",
     "source-map": "0.6.1",
     "ts-loader": "3.1.1",
-    "typed-css-modules": "0.3.1"
+    "typed-css-modules": "0.3.1",
+    "typescript": "~2.6.1"
   },
   "devDependencies": {
     "@dojo/loader": "~0.1.1",
@@ -59,7 +60,6 @@
     "sinon": "^2.3.0",
     "tslint": "5.8.0",
     "tslint-plugin-prettier": "1.3.0",
-    "typescript": "~2.6.1",
     "webpack": "^3.5.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "intern": "~4.1.0",
     "lint-staged": "6.0.0",
     "mockery": "^2.1.0",
+    "normalize-newline": "^3.0.0",
     "prettier": "1.9.2",
     "sinon": "^2.3.0",
     "tslint": "5.8.0",

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import * as path from 'path';
 
-const dModulePath = '@dojo/widget-core/d';
+const dImportPath = '@dojo/widget-core/d';
 const wPragma = 'w';
 const registryItemPrefix = '__autoRegistryItem_';
 const registryBagName = '__autoRegistryItems';
@@ -37,173 +37,180 @@ function createArrowFuncForNamedImport(modulePath: string, namedImport: string) 
 	);
 }
 
-const registryTransformer = function(this: { basePath: string; bundlePaths: string[] }, context: any) {
-	const lazyPaths = this.bundlePaths;
-	const basePath = this.basePath;
-	const opts = context.getCompilerOptions();
-	const { module } = opts;
-	const registryBag: { [index: string]: string } = {};
-	const moduleBag: { [index: string]: string } = {};
-	const namedImportBag: { [index: string]: boolean } = {};
-	let hasLazyModules = false;
+function createRegistryImportDeclaration() {
+	const moduleSpecifier = ts.createLiteral(registryDecoratorModulePath);
+	const importIdentifier = ts.createIdentifier(registryDecoratorNamedImport);
+	const aliasIdentifier = ts.createIdentifier(registryDecoratorNamedImportAlias);
+	const importSpecifier = ts.createImportSpecifier(importIdentifier, aliasIdentifier);
+	const namedImport = ts.createNamedImports([importSpecifier]);
+	const importClause = ts.createImportClause(undefined, namedImport);
+	return ts.createImportDeclaration(undefined, undefined, importClause, moduleSpecifier);
+}
 
-	let wName: string;
-	let contextPath: string;
-	let moduleIdentifier: ts.Expression;
-	let targetClass: ts.Node;
+class Visitor {
+	private context: ts.TransformationContext;
+	private contextPath: string;
+	private basePath: string;
+	private bundlePaths: string[];
+	private legacyModule: boolean;
+	private wPragma: undefined | string;
+	private modulesMap = new Map<string, string>();
+	private classMap = new Map<ts.Node, any>();
 
-	const visitor: any = (node: any) => {
-		if (node.kind === ts.SyntaxKind.ImportDeclaration) {
-			const targetPath = path.resolve(contextPath, node.moduleSpecifier.text).replace(`${basePath}/`, '');
-			// is the import a specified lazy module?
-			if (lazyPaths.indexOf(targetPath) !== -1) {
-				const importClause = node.importClause;
-				const importPath = node.moduleSpecifier.text;
-				// default import
-				if (importClause.name) {
-					moduleBag[importClause.name.escapedText] = importPath;
-					// support a single named import also, anything else we can't elide
-				} else if (importClause.namedBindings && importClause.namedBindings.elements.length === 1) {
-					const [element] = importClause.namedBindings.elements;
-					moduleBag[element.name.escapedText] = importPath;
-					namedImportBag[element.name.escapedText] = true;
-				}
-				hasLazyModules = true;
-				// is this the import of d? if so find the w pragma
-			} else if (dModulePath === node.moduleSpecifier.text) {
-				const namedBindings = node.importClause.namedBindings;
-				if (namedBindings) {
-					namedBindings.elements.forEach((element: any) => {
-						if (
-							element.name.escapedText === wPragma ||
-							(element.propertyName && element.propertyName.escapedText === wPragma)
-						) {
-							wName = element.name.escapedText;
-						}
-					});
-				}
+	constructor(options: any) {
+		this.context = options.context;
+		this.contextPath = options.contextPath;
+		this.bundlePaths = options.bundlePaths;
+		this.basePath = options.basePath;
+		this.legacyModule = options.legacyModule;
+	}
+
+	public visit(node: ts.Node) {
+		if (ts.isImportDeclaration(node)) {
+			const importPath = (node.moduleSpecifier as ts.StringLiteral).text;
+			const targetPath = path.resolve(this.contextPath, importPath).replace(`${this.basePath}/`, '');
+
+			if (this.bundlePaths.indexOf(targetPath) !== -1) {
+				this.setLazyImport(node);
+			} else if (dImportPath === importPath) {
+				this.setWPragma(node);
 			}
 		}
-		// if we found a pragma and we have lazy modules
-		if (wName && hasLazyModules) {
-			if (node.kind === ts.SyntaxKind.CallExpression) {
-				// is this a w call
-				if (node.expression.escapedText === wName && node.arguments && node.arguments.length) {
-					const text = node.arguments[0].escapedText;
-					// does it exist as a lazy module?
-					if (moduleBag[text]) {
-						let parent = node.parent;
-						while (parent) {
-							if (parent.kind === ts.SyntaxKind.ClassDeclaration) {
-								targetClass = parent;
-								break;
-							}
-							parent = parent.parent;
-						}
-
-						const registryIdentifier = ts.createLiteral(`${registryItemPrefix}${text}`);
-						// add to registry object for later
-						registryBag[text] = moduleBag[text];
-						// turn first arg of w call from widget class into generated string
-						node = ts.updateCall(node, node.expression, node.typeArguments, [
-							registryIdentifier,
-							...node.arguments.slice(1)
-						]);
-					}
-				}
+		if (this.isWCall(node)) {
+			const text = node.arguments[0].getText();
+			if (this.modulesMap.get(text)) {
+				node = this.replaceWidgetClassWithString(node);
 			}
 		}
-		return ts.visitEachChild(node, visitor, context);
-	};
+		return ts.visitEachChild(node, this.visit.bind(this), this.context);
+	}
 
-	return function(node: any) {
-		contextPath = path.dirname(path.relative(basePath, node.getSourceFile().fileName));
-		const moduleSpecifier = ts.createLiteral(registryDecoratorModulePath);
-		const importIdentifier = ts.createIdentifier(registryDecoratorNamedImport);
-		const aliasIdentifier = ts.createIdentifier(registryDecoratorNamedImportAlias);
-		const importSpecifier = ts.createImportSpecifier(importIdentifier, aliasIdentifier);
-		const namedImport = ts.createNamedImports([importSpecifier]);
-		const importClause = ts.createImportClause(undefined, namedImport);
-		const importDeclaration = ts.createImportDeclaration(undefined, undefined, importClause, moduleSpecifier);
+	public end(node: ts.SourceFile) {
+		const registryImport = createRegistryImportDeclaration();
+		const statements = this.removeImportStatements(node.statements);
+		const registryStatements = this.getRegistryStatements();
+		return ts.updateSourceFileNode(node, [registryImport, ...registryStatements, ...statements]);
+	}
 
-		if (module === ts.ModuleKind.CommonJS || module === ts.ModuleKind.AMD || module === ts.ModuleKind.UMD) {
-			moduleIdentifier = ts.getGeneratedNameForNode(importDeclaration);
-		} else {
-			moduleIdentifier = importSpecifier.name;
+	private setLazyImport(node: ts.ImportDeclaration) {
+		const importPath = (node.moduleSpecifier as ts.StringLiteral).text;
+		const importClause = node.importClause;
+		if (importClause && importClause.name && importClause.name.text) {
+			this.modulesMap.set(importClause.name.text, importPath);
 		}
+	}
 
-		let result = ts.visitNode(node, visitor);
+	private setWPragma(node: ts.ImportDeclaration) {
+		if (node.importClause) {
+			const namedBindings = node.importClause.namedBindings as ts.NamedImports;
+			namedBindings.elements.some((element: ts.ImportSpecifier) => {
+				const text = element.name.getText();
+				if (text === wPragma || (element.propertyName && element.propertyName.escapedText === wPragma)) {
+					this.wPragma = text;
+					return true;
+				}
+			});
+		}
+	}
+
+	private replaceWidgetClassWithString(node: ts.CallExpression) {
+		const text = node.arguments[0].getText();
+		const targetClass = this.findParentClass(node);
 		if (targetClass) {
-			// create a registry object with the keys and import of the module itself
-			const registryItems = Object.keys(registryBag).map((registryLabel) => {
-				const modulePath = registryBag[registryLabel];
-				let importCall;
-				if (namedImportBag[registryLabel]) {
-					importCall = createArrowFuncForNamedImport(modulePath, registryLabel);
-				} else {
-					importCall = createArrowFuncForDefaultImport(modulePath);
-				}
+			const registryItems = this.classMap.get(targetClass) || {};
+			registryItems[text] = this.modulesMap.get(text);
+			this.classMap.set(targetClass, registryItems);
+			const registryIdentifier = ts.createLiteral(`${registryItemPrefix}${text}`);
+			return ts.updateCall(node, node.expression, node.typeArguments, [
+				registryIdentifier,
+				...node.arguments.slice(1)
+			]);
+		}
+		return node;
+	}
+
+	private getRegistryStatements() {
+		const registryStatements: any[] = [];
+		this.classMap.forEach((registry: any, key: ts.Node) => {
+			const registryItems = Object.keys(registry).map((label) => {
+				const modulePath = registry[label];
+				const importCall = createArrowFuncForDefaultImport(modulePath);
 				return ts.createPropertyAssignment(
-					`'${registryItemPrefix}${registryLabel}'`,
+					`'${registryItemPrefix}${label}'`,
 					ts.createArrowFunction(undefined, undefined, [], undefined, undefined, importCall)
 				);
 			});
+			const registryVariableName = ts.createUniqueName(registryBagName);
 			const registryStatement = ts.createVariableStatement(
 				undefined,
 				ts.createVariableDeclarationList([
 					ts.createVariableDeclaration(
-						registryBagName,
+						registryVariableName,
 						undefined,
 						ts.createObjectLiteral(registryItems, false)
 					)
 				])
 			);
-			const importsToRemove = Object.keys(registryBag).map((key) => registryBag[key]);
-			// remove any imports that we have moved to the registry
-			const filteredStatements = result.statements
-				.filter((statement: any) => {
-					if (
-						statement.kind === ts.SyntaxKind.ImportDeclaration &&
-						importsToRemove.indexOf(statement.moduleSpecifier.text) !== -1
-					) {
-						return false;
-					}
-					return true;
-				})
-				.map((node: any) => {
-					if (node.kind === ts.SyntaxKind.ClassDeclaration) {
-						let call;
-						// a bit hacky but, if we are a non es module, make a property access in lieu of a named import
-						if (
-							module === ts.ModuleKind.CommonJS ||
-							module === ts.ModuleKind.AMD ||
-							module === ts.ModuleKind.UMD
-						) {
-							call = ts.createCall(
-								ts.createPropertyAccess(moduleIdentifier, registryDecoratorNamedImport),
-								undefined,
-								[ts.createIdentifier(registryBagName)]
-							);
-						} else {
-							call = ts.createCall(moduleIdentifier, undefined, [ts.createIdentifier(registryBagName)]);
-						}
-						const dec = ts.createDecorator(call);
+			registryStatements.push(registryStatement);
+		});
+		return registryStatements;
+	}
 
-						node = ts.updateClassDeclaration(
-							node,
-							[dec, ...(node.decorators || [])],
-							node.modifiers,
-							node.name,
-							node.typeParameters,
-							node.heritageClauses,
-							node.members
-						);
-					}
-					return node;
-				});
-			result = ts.updateSourceFileNode(result, [importDeclaration, registryStatement, ...filteredStatements]);
+	private removeImportStatements(nodes: ts.NodeArray<ts.Statement>) {
+		const importsToRemove: string[] = [];
+		this.classMap.forEach((registry: any, key: ts.Node) => {
+			Object.keys(registry).forEach((label) => {
+				importsToRemove.push(registry[label]);
+			});
+		});
+		return nodes.filter((node: ts.Node) => {
+			if (
+				ts.isImportDeclaration(node) &&
+				importsToRemove.indexOf((node.moduleSpecifier as ts.StringLiteral).text) !== -1
+			) {
+				return false;
+			}
+			return true;
+		});
+	}
+
+	private isWCall(node: ts.Node): node is ts.CallExpression {
+		return !!(
+			this.wPragma &&
+			this.modulesMap.size &&
+			ts.isCallExpression(node) &&
+			node.expression.getText() === this.wPragma &&
+			node.arguments &&
+			node.arguments.length
+		);
+	}
+
+	private findParentClass(node: ts.Node): ts.Node | undefined {
+		let parent = node.parent;
+		while (parent) {
+			if (ts.isClassDeclaration(parent)) {
+				return parent;
+			}
+			parent = parent.parent;
 		}
-		return result;
+	}
+}
+
+const registryTransformer = function(
+	this: { basePath: string; bundlePaths: string[] },
+	context: ts.TransformationContext
+) {
+	const basePath = this.basePath;
+	const bundlePaths = this.bundlePaths;
+	const opts = context.getCompilerOptions();
+	const { module } = opts;
+	const legacyModule =
+		module === ts.ModuleKind.CommonJS || module === ts.ModuleKind.AMD || module === ts.ModuleKind.UMD;
+	return function(node: ts.SourceFile) {
+		const contextPath = path.dirname(path.relative(basePath, node.getSourceFile().fileName));
+		const visitor = new Visitor({ context, contextPath, bundlePaths, basePath, legacyModule });
+		let result = ts.visitNode(node, visitor.visit.bind(visitor));
+		return visitor.end(result);
 	};
 };
 

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -55,7 +55,7 @@ class Visitor {
 	public visit(node: ts.Node) {
 		if (ts.isImportDeclaration(node)) {
 			const importPath = (node.moduleSpecifier as ts.StringLiteral).text;
-			const targetPath = path.resolve(this.contextPath, importPath).replace(`${this.basePath}/`, '');
+			const targetPath = path.resolve(this.contextPath, importPath).replace(`${this.basePath}${path.sep}`, '');
 
 			if (this.bundlePaths.indexOf(targetPath) !== -1) {
 				this.setLazyImport(node);

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -1,0 +1,134 @@
+import * as ts from 'typescript';
+import * as path from 'path';
+
+const dModulePath = ['@dojo/widget-core/d'];
+const wPragma = 'w';
+const prefix = '__autoRegistyItem_';
+const registryBagName = '__autoRegistry';
+const registryDecoratorModulePath = '@dojo/widget-core/decorators/registry';
+
+const registryTransformer = function(this: { bundlePaths: string[] }, context: any) {
+	const lazyPaths = this.bundlePaths;
+	const registryBag: any = {};
+	const moduleBag: any = {};
+
+	let addedRegistryImport = false;
+	let wName: string;
+	let contextPath: string;
+	let moduleIdentifier: ts.Expression;
+
+	const visitor: any = (node: any) => {
+		if (node.kind === ts.SyntaxKind.ImportDeclaration) {
+			if (
+				lazyPaths.indexOf(
+					path.resolve(contextPath, node.moduleSpecifier.text).replace(`${process.cwd()}/`, '')
+				) !== -1
+			) {
+				const importClause = node.importClause;
+				if (importClause.name) {
+					moduleBag[importClause.name.escapedText] = node.moduleSpecifier.text;
+				} else if (importClause.namedBindings) {
+					importClause.namedBindings.elements.forEach((element: any) => {
+						moduleBag[element.name.escapedText] = node.moduleSpecifier.text;
+					});
+				}
+			} else if (dModulePath.indexOf(node.moduleSpecifier.text) !== -1) {
+				const namedBindings = node.importClause.namedBindings;
+				if (namedBindings) {
+					namedBindings.elements.forEach((element: any) => {
+						if (
+							element.name.escapedText === wPragma ||
+							(element.propertyName && element.propertyName.escapedText === wPragma)
+						) {
+							wName = element.name.escapedText;
+						}
+					});
+				}
+			}
+		}
+		if (wName) {
+			if (node.kind === ts.SyntaxKind.CallExpression) {
+				if (node.expression.escapedText === wName && node.arguments && node.arguments.length) {
+					const text = node.arguments[0].escapedText;
+					if (moduleBag[text]) {
+						node.arguments[0] = ts.createLiteral(`${prefix}${text}`);
+						registryBag[text] = moduleBag[text];
+						ts.updateCall(node, node.expression, node.typeArguments, node.arguments);
+					}
+				}
+			} else if (node.kind === ts.SyntaxKind.ClassDeclaration && !addedRegistryImport) {
+				const call = ts.createCall(ts.createPropertyAccess(moduleIdentifier, 'registry'), undefined, [
+					ts.createIdentifier(registryBagName)
+				]);
+				const dec = ts.createDecorator(call);
+
+				node = ts.updateClassDeclaration(
+					node,
+					[dec, ...(node.decorators || [])],
+					node.modifiers,
+					node.name,
+					node.typeParameters,
+					node.heritageClauses,
+					node.members
+				);
+				addedRegistryImport = true;
+			}
+		}
+		return ts.visitEachChild(node, visitor, context);
+	};
+
+	return function(node: any) {
+		contextPath = path.dirname(path.relative(process.cwd(), node.getSourceFile().fileName));
+		const moduleSpecifier = ts.createLiteral(registryDecoratorModulePath);
+		const importIdentifier = ts.createIdentifier('registry');
+		const importSpecifier = ts.createImportSpecifier(undefined, importIdentifier);
+		const namedImport = ts.createNamedImports([importSpecifier]);
+		const importClause = ts.createImportClause(undefined, namedImport);
+		const importDeclaration = ts.createImportDeclaration(undefined, undefined, importClause, moduleSpecifier);
+		moduleIdentifier = ts.getGeneratedNameForNode(importDeclaration);
+
+		let result = ts.visitNode(node, visitor);
+		if (addedRegistryImport) {
+			const registryItems = Object.keys(registryBag).map((registryLabel: string) => {
+				const modulePath = registryBag[registryLabel];
+				return ts.createPropertyAssignment(
+					`'${prefix}${registryLabel}'`,
+					ts.createArrowFunction(
+						undefined,
+						undefined,
+						[],
+						undefined,
+						undefined,
+						ts.createCall((ts as any).createSignatureDeclaration(ts.SyntaxKind.ImportKeyword), undefined, [
+							ts.createLiteral(`${modulePath}`)
+						])
+					)
+				);
+			});
+			const registryStatement = ts.createVariableStatement(
+				undefined,
+				ts.createVariableDeclarationList([
+					ts.createVariableDeclaration(
+						registryBagName,
+						undefined,
+						ts.createObjectLiteral(registryItems, false)
+					)
+				])
+			);
+			const values = Object.keys(registryBag).map((key: string) => registryBag[key]);
+			const filteredStatements = result.statements.filter((statement: any) => {
+				if (
+					statement.kind === ts.SyntaxKind.ImportDeclaration &&
+					values.indexOf(statement.moduleSpecifier.text) !== -1
+				) {
+					return false;
+				}
+				return true;
+			});
+			result = ts.updateSourceFileNode(result, [importDeclaration, registryStatement, ...filteredStatements]);
+		}
+		return result;
+	};
+};
+
+export default (bundlePaths: string[]) => registryTransformer.bind({ bundlePaths });

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -9,3 +9,4 @@ import './i18n-plugin/I18nPlugin';
 import './i18n-plugin/templates/setLocaleData';
 import './promise-loader/all';
 import './build-time-render/all';
+import './registry-transformer/RegistryTransformer';

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -25,6 +25,7 @@ export default HelloWorld;
 `;
 
 describe('registry-transformer', () => {
+	/**
 	it('does not add import or decorator when no modules specified', () => {
 		const transformer = registryTransformer(process.cwd(), []);
 		const result = ts.transpileModule(source, {
@@ -92,7 +93,7 @@ export default HelloWorld;
 
 		assert.equal(result.outputText, expected);
 	});
-
+*/
 	it('does add import and decorator for commonjs', () => {
 		const transformer = registryTransformer(process.cwd(), ['Bar', 'Qux']);
 		const result = ts.transpileModule(source, {
@@ -105,7 +106,7 @@ export default HelloWorld;
 				before: [transformer]
 			}
 		});
-
+		console.log(result.outputText);
 		const expected = `"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const tslib_1 = require("tslib");

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -1,6 +1,7 @@
 import registryTransformer from '../../../src/registry-transformer/index';
 import * as ts from 'typescript';
 
+const nl = require('normalize-newline');
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
@@ -72,7 +73,7 @@ export class Another extends WidgetBase {
 }
 export default HelloWorld;
 `;
-		assert.equal(result.outputText, expected);
+		assert.equal(nl(result.outputText), expected);
 	});
 
 	it('does add import and decorator for esm', () => {
@@ -122,7 +123,7 @@ Another = tslib_1.__decorate([
 export { Another };
 export default HelloWorld;
 `;
-		assert.equal(result.outputText, expected);
+		assert.equal(nl(result.outputText), expected);
 	});
 
 	it('does add import and decorator for commonjs', () => {
@@ -174,6 +175,6 @@ exports.Another = Another;
 exports.default = HelloWorld;
 `;
 
-		assert.equal(result.outputText, expected);
+		assert.equal(nl(result.outputText), expected);
 	});
 });

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -9,6 +9,7 @@ import { v, w } from '@dojo/widget-core/d';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import Bar from './Bar';
 import Baz from './Baz';
+import Quz from './Quz';
 import { Blah } from './Qux';
 
 export class Foo extends WidgetBase {
@@ -21,11 +22,20 @@ export class Foo extends WidgetBase {
 		]);
 	}
 }
+
+export class Another extends WidgetBase {
+	protected render() {
+		return v('div' [
+			w(Bar, {}),
+			w(Baz, {}),
+			w(Quz, {})
+		]);
+	}
+}
 export default HelloWorld;
 `;
 
 describe('registry-transformer', () => {
-	/**
 	it('does not add import or decorator when no modules specified', () => {
 		const transformer = registryTransformer(process.cwd(), []);
 		const result = ts.transpileModule(source, {
@@ -43,6 +53,7 @@ describe('registry-transformer', () => {
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import Bar from './Bar';
 import Baz from './Baz';
+import Quz from './Quz';
 import { Blah } from './Qux';
 export class Foo extends WidgetBase {
     render() {
@@ -50,6 +61,13 @@ export class Foo extends WidgetBase {
             w(Bar, {}),
             w(Baz, {}),
             w(Blah, {})]);
+    }
+}
+export class Another extends WidgetBase {
+    render() {
+        return v('div'[w(Bar, {}),
+            w(Baz, {}),
+            w(Quz, {})]);
     }
 }
 export default HelloWorld;
@@ -72,30 +90,43 @@ export default HelloWorld;
 
 		const expected = `import * as tslib_1 from "tslib";
 import { registry as __autoRegistry } from "@dojo/widget-core/decorators/registry";
-var __autoRegistryItems = { '__autoRegistryItem_Bar': () => import("./Bar"), '__autoRegistryItem_Blah': () => import("./Qux").then(module => module.Blah) };
+var __autoRegistryItems_1 = { '__autoRegistryItem_Bar': () => import("./Bar") };
+var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => import("./Bar") };
 import { v, w } from '@dojo/widget-core/d';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import Baz from './Baz';
+import Quz from './Quz';
+import { Blah } from './Qux';
 let Foo = class Foo extends WidgetBase {
     render() {
         return v('div'[v('div', ['Foo']),
             w("__autoRegistryItem_Bar", {}),
             w(Baz, {}),
-            w("__autoRegistryItem_Blah", {})]);
+            w(Blah, {})]);
     }
 };
 Foo = tslib_1.__decorate([
-    __autoRegistry(__autoRegistryItems)
+    __autoRegistry(__autoRegistryItems_1)
 ], Foo);
 export { Foo };
+let Another = class Another extends WidgetBase {
+    render() {
+        return v('div'[w("__autoRegistryItem_Bar", {}),
+            w(Baz, {}),
+            w(Quz, {})]);
+    }
+};
+Another = tslib_1.__decorate([
+    __autoRegistry(__autoRegistryItems_2)
+], Another);
+export { Another };
 export default HelloWorld;
 `;
-
 		assert.equal(result.outputText, expected);
 	});
-*/
+
 	it('does add import and decorator for commonjs', () => {
-		const transformer = registryTransformer(process.cwd(), ['Bar', 'Qux']);
+		const transformer = registryTransformer(process.cwd(), ['Bar', 'Qux', 'Quz']);
 		const result = ts.transpileModule(source, {
 			compilerOptions: {
 				importHelpers: true,
@@ -106,29 +137,43 @@ export default HelloWorld;
 				before: [transformer]
 			}
 		});
-		console.log(result.outputText);
+
 		const expected = `"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const tslib_1 = require("tslib");
 const registry_1 = require("@dojo/widget-core/decorators/registry");
-var __autoRegistryItems = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./Bar")), '__autoRegistryItem_Blah': () => Promise.resolve().then(() => require("./Qux")).then(module => module.Blah) };
+var __autoRegistryItems_1 = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./Bar")) };
+var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./Bar")), '__autoRegistryItem_Quz': () => Promise.resolve().then(() => require("./Quz")) };
 const d_1 = require("@dojo/widget-core/d");
 const WidgetBase_1 = require("@dojo/widget-core/WidgetBase");
 const Baz_1 = require("./Baz");
+const Qux_1 = require("./Qux");
 let Foo = class Foo extends WidgetBase_1.default {
     render() {
         return d_1.v('div'[d_1.v('div', ['Foo']),
             d_1.w("__autoRegistryItem_Bar", {}),
             d_1.w(Baz_1.default, {}),
-            d_1.w("__autoRegistryItem_Blah", {})]);
+            d_1.w(Qux_1.Blah, {})]);
     }
 };
 Foo = tslib_1.__decorate([
-    registry_1.registry(__autoRegistryItems)
+    registry_1.registry(__autoRegistryItems_1)
 ], Foo);
 exports.Foo = Foo;
+let Another = class Another extends WidgetBase_1.default {
+    render() {
+        return d_1.v('div'[d_1.w("__autoRegistryItem_Bar", {}),
+            d_1.w(Baz_1.default, {}),
+            d_1.w("__autoRegistryItem_Quz", {})]);
+    }
+};
+Another = tslib_1.__decorate([
+    registry_1.registry(__autoRegistryItems_2)
+], Another);
+exports.Another = Another;
 exports.default = HelloWorld;
 `;
+
 		assert.equal(result.outputText, expected);
 	});
 });

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -1,0 +1,101 @@
+import registryTransformer from '../../../src/registry-transformer/index';
+import * as ts from 'typescript';
+
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+const source = `
+import { v, w } from '@dojo/widget-core/d';
+import WidgetBase from '@dojo/widget-core/WidgetBase';
+import Bar from './Bar';
+import Baz from './Baz';
+import Qux from './Qux';
+
+export class Foo extends WidgetBase {
+	protected render() {
+		return v('div' [
+			v('div', ['Foo']),
+			w(Bar, {}),
+			w(Baz, {}),
+			w(Qux, {})
+		]);
+	}
+}
+export default HelloWorld;
+`;
+
+describe('registry-transformer', () => {
+	it('does add import and decorator for esm', () => {
+		const transformer = registryTransformer(process.cwd(), ['Bar', 'Qux']);
+		const result = ts.transpileModule(source, {
+			compilerOptions: {
+				importHelpers: true,
+				module: ts.ModuleKind.ESNext,
+				target: ts.ScriptTarget.ESNext
+			},
+			transformers: {
+				before: [transformer]
+			}
+		});
+
+		const expected = `import * as tslib_1 from "tslib";
+import { registry as __autoRegistry } from "@dojo/widget-core/decorators/registry";
+var __autoRegistryItems = { '__autoRegistryItem_Bar': () => import("./Bar"), '__autoRegistryItem_Qux': () => import("./Qux") };
+import { v, w } from '@dojo/widget-core/d';
+import WidgetBase from '@dojo/widget-core/WidgetBase';
+import Baz from './Baz';
+let Foo = class Foo extends WidgetBase {
+    render() {
+        return v('div'[v('div', ['Foo']),
+            w("__autoRegistryItem_Bar", {}),
+            w(Baz, {}),
+            w("__autoRegistryItem_Qux", {})]);
+    }
+};
+Foo = tslib_1.__decorate([
+    __autoRegistry(__autoRegistryItems)
+], Foo);
+export { Foo };
+export default HelloWorld;
+`;
+		assert.equal(result.outputText, expected);
+	});
+
+	it('does add import and decorator for commonjs', () => {
+		const transformer = registryTransformer(process.cwd(), ['Bar', 'Qux']);
+		const result = ts.transpileModule(source, {
+			compilerOptions: {
+				importHelpers: true,
+				module: ts.ModuleKind.CommonJS,
+				target: ts.ScriptTarget.ESNext
+			},
+			transformers: {
+				before: [transformer]
+			}
+		});
+
+		const expected = `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
+const registry_1 = require("@dojo/widget-core/decorators/registry");
+var __autoRegistryItems = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./Bar")), '__autoRegistryItem_Qux': () => Promise.resolve().then(() => require("./Qux")) };
+const d_1 = require("@dojo/widget-core/d");
+const WidgetBase_1 = require("@dojo/widget-core/WidgetBase");
+const Baz_1 = require("./Baz");
+let Foo = class Foo extends WidgetBase_1.default {
+    render() {
+        return d_1.v('div'[d_1.v('div', ['Foo']),
+            d_1.w("__autoRegistryItem_Bar", {}),
+            d_1.w(Baz_1.default, {}),
+            d_1.w("__autoRegistryItem_Qux", {})]);
+    }
+};
+Foo = tslib_1.__decorate([
+    registry_1.registry(__autoRegistryItems)
+], Foo);
+exports.Foo = Foo;
+exports.default = HelloWorld;
+`;
+		assert.equal(result.outputText, expected);
+	});
+});

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -25,6 +25,37 @@ export default HelloWorld;
 `;
 
 describe('registry-transformer', () => {
+	it('does not add import or decorator when no modules specified', () => {
+		const transformer = registryTransformer(process.cwd(), []);
+		const result = ts.transpileModule(source, {
+			compilerOptions: {
+				importHelpers: true,
+				module: ts.ModuleKind.ESNext,
+				target: ts.ScriptTarget.ESNext
+			},
+			transformers: {
+				before: [transformer]
+			}
+		});
+
+		const expected = `import { v, w } from '@dojo/widget-core/d';
+import WidgetBase from '@dojo/widget-core/WidgetBase';
+import Bar from './Bar';
+import Baz from './Baz';
+import Qux from './Qux';
+export class Foo extends WidgetBase {
+    render() {
+        return v('div'[v('div', ['Foo']),
+            w(Bar, {}),
+            w(Baz, {}),
+            w(Qux, {})]);
+    }
+}
+export default HelloWorld;
+`;
+		assert.equal(result.outputText, expected);
+	});
+
 	it('does add import and decorator for esm', () => {
 		const transformer = registryTransformer(process.cwd(), ['Bar', 'Qux']);
 		const result = ts.transpileModule(source, {

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -9,7 +9,7 @@ import { v, w } from '@dojo/widget-core/d';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import Bar from './Bar';
 import Baz from './Baz';
-import Qux from './Qux';
+import { Blah } from './Qux';
 
 export class Foo extends WidgetBase {
 	protected render() {
@@ -17,7 +17,7 @@ export class Foo extends WidgetBase {
 			v('div', ['Foo']),
 			w(Bar, {}),
 			w(Baz, {}),
-			w(Qux, {})
+			w(Blah, {})
 		]);
 	}
 }
@@ -42,13 +42,13 @@ describe('registry-transformer', () => {
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import Bar from './Bar';
 import Baz from './Baz';
-import Qux from './Qux';
+import { Blah } from './Qux';
 export class Foo extends WidgetBase {
     render() {
         return v('div'[v('div', ['Foo']),
             w(Bar, {}),
             w(Baz, {}),
-            w(Qux, {})]);
+            w(Blah, {})]);
     }
 }
 export default HelloWorld;
@@ -71,7 +71,7 @@ export default HelloWorld;
 
 		const expected = `import * as tslib_1 from "tslib";
 import { registry as __autoRegistry } from "@dojo/widget-core/decorators/registry";
-var __autoRegistryItems = { '__autoRegistryItem_Bar': () => import("./Bar"), '__autoRegistryItem_Qux': () => import("./Qux") };
+var __autoRegistryItems = { '__autoRegistryItem_Bar': () => import("./Bar"), '__autoRegistryItem_Blah': () => import("./Qux").then(module => module.Blah) };
 import { v, w } from '@dojo/widget-core/d';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import Baz from './Baz';
@@ -80,7 +80,7 @@ let Foo = class Foo extends WidgetBase {
         return v('div'[v('div', ['Foo']),
             w("__autoRegistryItem_Bar", {}),
             w(Baz, {}),
-            w("__autoRegistryItem_Qux", {})]);
+            w("__autoRegistryItem_Blah", {})]);
     }
 };
 Foo = tslib_1.__decorate([
@@ -89,6 +89,7 @@ Foo = tslib_1.__decorate([
 export { Foo };
 export default HelloWorld;
 `;
+
 		assert.equal(result.outputText, expected);
 	});
 
@@ -109,7 +110,7 @@ export default HelloWorld;
 Object.defineProperty(exports, "__esModule", { value: true });
 const tslib_1 = require("tslib");
 const registry_1 = require("@dojo/widget-core/decorators/registry");
-var __autoRegistryItems = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./Bar")), '__autoRegistryItem_Qux': () => Promise.resolve().then(() => require("./Qux")) };
+var __autoRegistryItems = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./Bar")), '__autoRegistryItem_Blah': () => Promise.resolve().then(() => require("./Qux")).then(module => module.Blah) };
 const d_1 = require("@dojo/widget-core/d");
 const WidgetBase_1 = require("@dojo/widget-core/WidgetBase");
 const Baz_1 = require("./Baz");
@@ -118,7 +119,7 @@ let Foo = class Foo extends WidgetBase_1.default {
         return d_1.v('div'[d_1.v('div', ['Foo']),
             d_1.w("__autoRegistryItem_Bar", {}),
             d_1.w(Baz_1.default, {}),
-            d_1.w("__autoRegistryItem_Qux", {})]);
+            d_1.w("__autoRegistryItem_Blah", {})]);
     }
 };
 Foo = tslib_1.__decorate([


### PR DESCRIPTION
**Type:** feature

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
This custom transformer will allow us to perform lazy widget loading without an author having to change their code. 
The transformer does the following:

* find the `w` calls
* if the argument passed to the `w` call is in the lazy module paths (likely from the .dojorc in cli-build-app), replace the argument with a unique string identifier
* create an object of string identifiers to async import specifiers
* add a static import to pull in the registry decorator
* create a registry decorator with mapping and add to the target class
* elide the static imports of the modules that have been moved to async imports

Resolves https://github.com/dojo/webpack-contrib/issues/19
