### PR TITLE
Fix module path for lookup in registry transformer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/webpack-contrib",
-  "version": "0.2.5",
+  "version": "0.2.6-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -66,7 +66,9 @@ class Visitor {
 	public visit(node: ts.Node) {
 		if (ts.isImportDeclaration(node)) {
 			const importPath = (node.moduleSpecifier as ts.StringLiteral).text;
-			const targetPath = path.resolve(this.contextPath, importPath).replace(`${this.basePath}${path.sep}`, '');
+			const targetPath = path.posix
+				.resolve(this.contextPath, importPath)
+				.replace(`${this.basePath}${path.posix.sep}`, '');
 
 			if (this.bundlePaths.indexOf(targetPath) !== -1) {
 				this.setLazyImport(node);

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -8,7 +8,7 @@ const { assert } = intern.getPlugin('chai');
 const source = `
 import { v, w } from '@dojo/widget-core/d';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
-import Bar from './Bar';
+import Bar from './widgets/Bar';
 import Baz from './Baz';
 import Quz from './Quz';
 import { Blah } from './Qux';
@@ -52,7 +52,7 @@ describe('registry-transformer', () => {
 
 		const expected = `import { v, w } from '@dojo/widget-core/d';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
-import Bar from './Bar';
+import Bar from './widgets/Bar';
 import Baz from './Baz';
 import Quz from './Quz';
 import { Blah } from './Qux';
@@ -77,7 +77,7 @@ export default HelloWorld;
 	});
 
 	it('does add import and decorator for esm', () => {
-		const transformer = registryTransformer(process.cwd(), ['Bar', 'Qux']);
+		const transformer = registryTransformer(process.cwd(), ['widgets/Bar', 'Qux']);
 		const result = ts.transpileModule(source, {
 			compilerOptions: {
 				importHelpers: true,
@@ -91,8 +91,8 @@ export default HelloWorld;
 
 		const expected = `import * as tslib_1 from "tslib";
 import { registry as __autoRegistry } from "@dojo/widget-core/decorators/registry";
-var __autoRegistryItems_1 = { '__autoRegistryItem_Bar': () => import("./Bar") };
-var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => import("./Bar") };
+var __autoRegistryItems_1 = { '__autoRegistryItem_Bar': () => import("./widgets/Bar") };
+var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => import("./widgets/Bar") };
 import { v, w } from '@dojo/widget-core/d';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import Baz from './Baz';
@@ -127,7 +127,7 @@ export default HelloWorld;
 	});
 
 	it('does add import and decorator for commonjs', () => {
-		const transformer = registryTransformer(process.cwd(), ['Bar', 'Qux', 'Quz']);
+		const transformer = registryTransformer(process.cwd(), ['widgets/Bar', 'Qux', 'Quz']);
 		const result = ts.transpileModule(source, {
 			compilerOptions: {
 				importHelpers: true,
@@ -143,8 +143,8 @@ export default HelloWorld;
 Object.defineProperty(exports, "__esModule", { value: true });
 const tslib_1 = require("tslib");
 const registry_1 = require("@dojo/widget-core/decorators/registry");
-var __autoRegistryItems_1 = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./Bar")) };
-var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./Bar")), '__autoRegistryItem_Quz': () => Promise.resolve().then(() => require("./Quz")) };
+var __autoRegistryItems_1 = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./widgets/Bar")) };
+var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => Promise.resolve().then(() => require("./widgets/Bar")), '__autoRegistryItem_Quz': () => Promise.resolve().then(() => require("./Quz")) };
 const d_1 = require("@dojo/widget-core/d");
 const WidgetBase_1 = require("@dojo/widget-core/WidgetBase");
 const Baz_1 = require("./Baz");


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The separator for module path should always be `/` regardless of the platform it is run on.
