### PR TITLE
Handle paths ending in forward slashes and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,8 @@ properties:
 
  | Property | Type | optional | Description |
  | -------- | ---- | -------- | ----------- |
- | `from` | `string` | `false`  | A path relative to `node_modules` specifying the dependency location to copy into the build application. |
- | `to` | `string` | `true` | A path that replaces `from` as the location to copy this dependency to. By default, dependencies will be copied to `${externalsOutputPath}/${to}` or `${externalsOutputPath}/${from}` if `to` is not specified. |
+ | `from` | `string` | `false`  | A path relative to the root of the project specifying the dependency location to copy into the build application. |
+ | `to` | `string` | `true` | A path that replaces `from` as the location to copy this dependency to. By default, dependencies will be copied to `${externalsOutputPath}/${to}` or `${externalsOutputPath}/${from}` if `to` is not specified. If the path includes `.` characters, it must end in a forward slash to be treated as a directory |
  | `name` | `string` | `true` | Indicates that this path, and any children of this path, should be loaded via the external loader |
  | `inject` | `string, string[], or boolean` | `true` | This property indicates that this dependency defines, or includes, scripts or stylesheets that should be loaded on the page. If `inject` is set to `true`, then the file at the location specified by `to` or `from` will be loaded on the page. If this dependency is a folder, then `inject` can be set to a string or array of strings to define one or more files to inject. Each path in `inject` should be relative to `${externalsOutputPath}/${to}` or `${externalsOutputPath}/${from}` depending on whether `to` was provided. |
 

--- a/src/external-loader-plugin/ExternalLoaderPlugin.ts
+++ b/src/external-loader-plugin/ExternalLoaderPlugin.ts
@@ -89,12 +89,13 @@ export default class ExternalLoaderPlugin {
 				}
 
 				const base = to || from;
+				const baseDir = base[base.length - 1] === '/' ? base : `${base}/`;
 
 				if (Array.isArray(inject)) {
-					return assets.concat(inject.map((path) => prefixPath(`${base}/${path}`)));
+					return assets.concat(inject.map((path) => prefixPath(`${baseDir}${path}`)));
 				}
 
-				return assets.concat(prefixPath(`${base}${typeof inject === 'string' ? `/${inject}` : ''}`));
+				return assets.concat(prefixPath(typeof inject === 'string' ? `${baseDir}${inject}` : base));
 			},
 			[] as string[]
 		);

--- a/tests/unit/external-loader-plugin/ExternalLoaderPlugin.ts
+++ b/tests/unit/external-loader-plugin/ExternalLoaderPlugin.ts
@@ -28,7 +28,7 @@ describe('ExternalLoaderPlugin', () => {
 			'a',
 			{ from: 'abc', inject: true },
 			{ from: 'abc', to: 'def', inject: true },
-			{ from: 'abc', to: 'def', inject: 'main' },
+			{ from: 'abc', to: 'def/', inject: 'main' },
 			{ from: 'abc', inject: ['one', 'two', 'three', 'four'] },
 			{ from: 'abc' },
 			{ to: 'ignore', name: 'no-from' }
@@ -36,7 +36,7 @@ describe('ExternalLoaderPlugin', () => {
 		const expectedCopyArgs = [
 			{ from: 'abc', to: 'OUTPUT_PATH/abc' },
 			{ from: 'abc', to: 'OUTPUT_PATH/def' },
-			{ from: 'abc', to: 'OUTPUT_PATH/def' },
+			{ from: 'abc', to: 'OUTPUT_PATH/def/' },
 			{ from: 'abc', to: 'OUTPUT_PATH/abc' },
 			{ from: 'abc', to: 'OUTPUT_PATH/abc' }
 		];


### PR DESCRIPTION
**Type:** bug
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR
