### PR TITLE
Move to Acorn parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/webpack-contrib",
-  "version": "2.0.0",
+  "version": "2.0.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -460,20 +460,11 @@
       "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
     },
     "acorn-dynamic-import": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
+        "acorn": "5.5.3"
       }
     },
     "acorn-globals": {
@@ -7435,7 +7426,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -13501,6 +13492,23 @@
         "yargs": "8.0.2"
       },
       "dependencies": {
+        "acorn-dynamic-import": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+          "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+          "dev": true,
+          "requires": {
+            "acorn": "4.0.13"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+              "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+              "dev": true
+            }
+          }
+        },
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@dojo/shim": "^2.0.0",
+    "acorn-dynamic-import": "3.0.0",
     "copy-webpack-plugin": "4.0.1",
     "filter-css": "0.1.2",
     "html-webpack-include-assets-plugin": "1.0.2",

--- a/src/static-build-loader/loader.ts
+++ b/src/static-build-loader/loader.ts
@@ -7,6 +7,7 @@ const types = recast.types;
 const namedTypes = types.namedTypes;
 const builders = types.builders;
 const compose = require('recast/lib/util').composeSourceMaps;
+const acorn = require('acorn-dynamic-import').default;
 
 /**
  * A map of features that should be statically replaced in the code
@@ -50,6 +51,15 @@ export default function loader(this: LoaderContext, content: string, sourceMap?:
 	const { features: featuresOption } = options;
 	const parseOptions =
 		(sourceMap && {
+			parser: {
+				parse(source: string) {
+					return acorn.parse(source, {
+						plugins: { dynamicImport: true },
+						locations: true,
+						sourceType: 'module'
+					});
+				}
+			},
 			sourceFileName: sourceMap.file
 		}) ||
 		undefined;

--- a/tests/support/fixtures/static-has-base.js
+++ b/tests/support/fixtures/static-has-base.js
@@ -23,7 +23,6 @@ require("qat");
 
 somename.default.add('foo');
 
-var foo = 'foo';
 var dynamicHas = somename.default(foo);
 
 function doX() {

--- a/tests/support/fixtures/static-has-foo-true-bar-false.js
+++ b/tests/support/fixtures/static-has-foo-true-bar-false.js
@@ -25,7 +25,6 @@ require("qat");
 
 somename.default.add('foo');
 
-var foo = 'foo';
 var dynamicHas = somename.default(foo);
 
 function doX() {

--- a/tests/support/fixtures/static-has-no-flags.js
+++ b/tests/support/fixtures/static-has-no-flags.js
@@ -23,7 +23,6 @@ require("qat");
 
 somename.default.add('foo');
 
-var foo = 'foo';
 var dynamicHas = somename.default(foo);
 
 function doX() {

--- a/tests/support/fixtures/static-has-qat-true.js
+++ b/tests/support/fixtures/static-has-qat-true.js
@@ -23,7 +23,6 @@ require("qat");
 
 somename.default.add('foo');
 
-var foo = 'foo';
 var dynamicHas = somename.default(foo);
 
 function doX() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Moves to using the acorn parser over esprima. With TypeScript keeping `import()`'s when using our esnext builds, esprima is incapable of parsing it.