### PR TITLE
Inject static html when there are no paths provided

### DIFF
--- a/tests/support/fixtures/build-time-render/expected/index.html
+++ b/tests/support/fixtures/build-time-render/expected/index.html
@@ -10,25 +10,7 @@ span {
 </style>
 	</head>
 	<body>
-		<div id="app"></div>
-		<script>
-	(function () {
-		var paths = [""];
-		var html = ["<div id=\"app\"><div class=\"hello\">Hello</div></div>"];
-		var element = document.getElementById('app');
-		var target;
-		paths.some(function (path, i) {
-			var match = (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
-			if (match) {
-				target = html[i];
-			}
-			return match;
-		});
-		if (target && element) {
-			var frag = document.createRange().createContextualFragment(target);
-			element.parentNode.replaceChild(frag, element);
-		}
-	}())
-</script><link rel="stylesheet" href="main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+		<div id="app"><div class="hello">Hello</div></div>
+		<link rel="stylesheet" href="main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

When there are no paths configured for build time rendering, statically inject the rendered HTML as there is reason to run a script to choose the correct output.

