### PR TITLE
Make sure templates are es5

### DIFF
--- a/src/build-time-render/hasBuildTimeRender.ts
+++ b/src/build-time-render/hasBuildTimeRender.ts
@@ -1,5 +1,6 @@
-import { add, exists } from '@dojo/core/has';
+// tslint:disable-next-line
+var has = require('@dojo/core/has');
 
-if (!exists('build-time-render')) {
-	add('build-time-render', false, false);
+if (!has.exists('build-time-render')) {
+	has.add('build-time-render', false, false);
 }

--- a/src/i18n-plugin/templates/setLocaleData.ts
+++ b/src/i18n-plugin/templates/setLocaleData.ts
@@ -1,13 +1,14 @@
-const i18n = require('@dojo/i18n/i18n');
-const loadCldrData = require('@dojo/i18n/cldr/load').default;
-const systemLocale = i18n.systemLocale;
+// tslint:disable
+var i18n = require('@dojo/i18n/i18n');
+var loadCldrData = require('@dojo/i18n/cldr/load').default;
+var systemLocale = i18n.systemLocale;
 
 declare const __cldrData__: any;
 declare const __defaultLocale__: string;
 declare const __supportedLocales__: string[];
 
-const userLocale = systemLocale.replace(/^([a-z]{2}).*/i, '$1');
-const isUserLocaleSupported =
+var userLocale = systemLocale.replace(/^([a-z]{2}).*/i, '$1');
+var isUserLocaleSupported =
 	userLocale === __defaultLocale__ ||
 	__supportedLocales__.some(function(locale: string) {
 		return locale === systemLocale || locale === userLocale;

--- a/src/service-worker-plugin/service-worker-entry.ts
+++ b/src/service-worker-plugin/service-worker-entry.ts
@@ -1,5 +1,5 @@
 if ('serviceWorker' in navigator) {
-	window.addEventListener('load', () => {
+	window.addEventListener('load', function() {
 		navigator.serviceWorker.register('./service-worker.js');
 	});
 }


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**
This package is targeted at es6, but some of the templates in it are leveraged by cli-build-app at runtime so they need to support es5. I tried to just change the target to es5 for this entire repo, but the i18n plugin extends real classes from webpack itself so not possible. In the future we may want to have different targets for these kind of files and keep them in a separate folder, but for now i've just manually changed them.
