### PR TITLE
Add all mode for registry transformer

### DIFF
--- a/src/registry-transformer/shared.ts
+++ b/src/registry-transformer/shared.ts
@@ -1,0 +1,1 @@
+exports = { modules: {} };

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -313,7 +313,7 @@ exports.default = HelloWorld;
 		assert.equal(nl(result.outputText), expected);
 	});
 
-	it('replaces all in analyze mode', () => {
+	it('replaces all widgets in all mode', () => {
 		const transformer = registryTransformer(process.cwd(), [], true);
 		ts.transpileModule(source, {
 			compilerOptions: {

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -312,4 +312,26 @@ exports.default = HelloWorld;
 
 		assert.equal(nl(result.outputText), expected);
 	});
+
+	it('replaces all in analyze mode', () => {
+		const transformer = registryTransformer(process.cwd(), [], true);
+		ts.transpileModule(source, {
+			compilerOptions: {
+				importHelpers: true,
+				module: ts.ModuleKind.ESNext,
+				target: ts.ScriptTarget.ESNext
+			},
+			transformers: {
+				before: [transformer]
+			}
+		});
+		const shared = require('../../../src/registry-transformer/shared');
+		assert.deepEqual(shared, {
+			modules: {
+				__autoRegistryItem_Bar: 'widgets/Bar',
+				__autoRegistryItem_Baz: 'Baz',
+				__autoRegistryItem_Quz: 'Quz'
+			}
+		});
+	});
 });

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -315,7 +315,7 @@ exports.default = HelloWorld;
 
 	it('replaces all widgets in all mode', () => {
 		const transformer = registryTransformer(process.cwd(), [], true);
-		ts.transpileModule(source, {
+		const result = ts.transpileModule(source, {
 			compilerOptions: {
 				importHelpers: true,
 				module: ts.ModuleKind.ESNext,
@@ -326,6 +326,40 @@ exports.default = HelloWorld;
 			}
 		});
 		const shared = require('../../../src/registry-transformer/shared');
+
+		const expected = `import * as tslib_1 from "tslib";
+import { registry as __autoRegistry } from "@dojo/framework/widget-core/decorators/registry";
+var __autoRegistryItems_1 = { '__autoRegistryItem_Bar': () => import("./widgets/Bar"), '__autoRegistryItem_Baz': () => import("./Baz") };
+var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => import("./widgets/Bar"), '__autoRegistryItem_Baz': () => import("./Baz"), '__autoRegistryItem_Quz': () => import("./Quz") };
+import { v, w } from '@dojo/framework/widget-core/d';
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import { Blah } from './Qux';
+let Foo = class Foo extends WidgetBase {
+    render() {
+        return v('div'[v('div', ['Foo']),
+            w("__autoRegistryItem_Bar", {}),
+            w("__autoRegistryItem_Baz", {}),
+            w(Blah, {})]);
+    }
+};
+Foo = tslib_1.__decorate([
+    __autoRegistry(__autoRegistryItems_1)
+], Foo);
+export { Foo };
+let Another = class Another extends WidgetBase {
+    render() {
+        return v('div'[w("__autoRegistryItem_Bar", {}),
+            w("__autoRegistryItem_Baz", {}),
+            w("__autoRegistryItem_Quz", {})]);
+    }
+};
+Another = tslib_1.__decorate([
+    __autoRegistry(__autoRegistryItems_2)
+], Another);
+export { Another };
+export default HelloWorld;
+`;
+		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared, {
 			modules: {
 				__autoRegistryItem_Bar: 'widgets/Bar',


### PR DESCRIPTION
**Type:** feature
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Some preliminary work for support of analyzing the critical path of widgets in build time rendering. In `all` mode the registry transformer will transform every single `w()` call local to the project. The registry items they are changed to and the paths the files are at are stored in a shared module for accessing later by other modules.
