### PR TITLE
Has flags support strings and number - do not coerce value to boolean

### DIFF
--- a/src/static-build-loader/loader.ts
+++ b/src/static-build-loader/loader.ts
@@ -179,7 +179,7 @@ export default function loader(this: LoaderContext, content: string, sourceMap?:
 					if (namedTypes.Literal.check(arg) && typeof arg.value === 'string') {
 						// check to see if we have a flag that we want to statically swap
 						if (arg.value in features) {
-							path.replace(builders.literal(Boolean(features[arg.value])));
+							path.replace(builders.literal(features[arg.value]));
 						} else {
 							dynamicFlags.add(arg.value);
 						}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Do not coerce the has value to a boolean for has values.
