### PR TITLE
Outlet detection

### DIFF
--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -322,6 +322,8 @@ class Visitor {
 				if (
 					ts.isCallExpression(w) &&
 					w.expression.getText() === this.wPragma &&
+					ts.isIdentifier(w.arguments[0]) &&
+					w.arguments[0].getText() === this.outletName &&
 					ts.isObjectLiteralExpression(w.arguments[1])
 				) {
 					const objectLiteral = w.arguments[1] as ts.ObjectLiteralExpression;

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -186,15 +186,23 @@ class Visitor {
 
 	private setOutletName(node: ts.ImportDeclaration) {
 		if (node.importClause) {
-			const namedBindings = node.importClause.namedBindings as ts.NamedImports;
-			namedBindings.elements.some((element: ts.ImportSpecifier) => {
-				const text = element.name.getText();
-				if (text === outletName || (element.propertyName && element.propertyName.escapedText === outletName)) {
-					this.outletName = text;
-					return true;
-				}
-				return false;
-			});
+			const importClause = node.importClause;
+			if (importClause && importClause.name && importClause.name.text) {
+				this.outletName = importClause.name.text;
+			} else if (importClause.namedBindings) {
+				const namedBindings = importClause.namedBindings as ts.NamedImports;
+				namedBindings.elements.some((element: ts.ImportSpecifier) => {
+					const text = element.name.getText();
+					if (
+						text === outletName ||
+						(element.propertyName && element.propertyName.escapedText === outletName)
+					) {
+						this.outletName = text;
+						return true;
+					}
+					return false;
+				});
+			}
 		}
 	}
 

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -230,6 +230,7 @@ class Visitor {
 		const text = node.tagName.getText();
 		if (this.modulesMap.get(text)) {
 			const targetClass = this.findParentClass(inputNode);
+			const outletName = this.outletName ? this.getOutletName(node) : undefined;
 			if (targetClass) {
 				const registryItems = this.classMap.get(targetClass) || {};
 				registryItems[text] = this.modulesMap.get(text) as string;
@@ -241,7 +242,7 @@ class Visitor {
 				);
 				this.setSharedModules(`${registryItemPrefix}${text}`, {
 					path: registryItems[text],
-					outletName: undefined
+					outletName
 				});
 				const attrs = ts.updateJsxAttributes(node.attributes, [
 					...node.attributes.properties,
@@ -343,6 +344,21 @@ class Visitor {
 							ts.isStringLiteral(property.initializer)
 						) {
 							return property.initializer.text;
+						}
+					}
+				}
+			} else if (ts.isJsxAttribute(parent) && parent.name.getText() === outletRendererName) {
+				const tsx = parent.parent!.parent as ts.JsxOpeningLikeElement;
+				if (ts.isJsxOpeningLikeElement(tsx) && tsx.tagName.getText() === this.outletName) {
+					const properties = tsx.attributes.properties;
+					for (let i = 0; i < properties.length; i++) {
+						const attribute = properties[i] as ts.JsxAttribute;
+						if (
+							attribute.name.getText() === outletIdName &&
+							attribute.initializer &&
+							ts.isStringLiteral(attribute.initializer)
+						) {
+							return attribute.initializer.text;
 						}
 					}
 				}

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -7,6 +7,7 @@ const { assert } = intern.getPlugin('chai');
 
 const source = `
 import { v, w } from '@dojo/framework/widget-core/d';
+import { Outlet } from '@dojo/framework/routing/Outlet';
 import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import Bar from './widgets/Bar';
 import Baz from './Baz';
@@ -339,6 +340,7 @@ import { registry as __autoRegistry } from "@dojo/framework/widget-core/decorato
 var __autoRegistryItems_1 = { '__autoRegistryItem_Something': () => import("./Something"), '__autoRegistryItem_Bar': () => import("./widgets/Bar"), '__autoRegistryItem_Baz': () => import("./Baz") };
 var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => import("./widgets/Bar"), '__autoRegistryItem_Baz': () => import("./Baz"), '__autoRegistryItem_Quz': () => import("./Quz") };
 import { v, w } from '@dojo/framework/widget-core/d';
+import { Outlet } from '@dojo/framework/routing/Outlet';
 import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import { Blah } from './Qux';
 let Foo = class Foo extends WidgetBase {
@@ -372,7 +374,7 @@ Another = tslib_1.__decorate([
 export { Another };
 export default HelloWorld;
 `;
-		/*assert.equal(nl(result.outputText), expected);*/
+		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared, {
 			modules: {
 				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: undefined },

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -11,11 +11,18 @@ import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import Bar from './widgets/Bar';
 import Baz from './Baz';
 import Quz from './Quz';
+import Something from './Something';
 import { Blah } from './Qux';
 
 export class Foo extends WidgetBase {
 	protected render() {
 		return v('div' [
+			w(Outlet, {
+				id: 'my-foo-outlet',
+				renderer() {
+					return w(Something, {});
+				}
+			}),
 			v('div', ['Foo']),
 			w(Bar, {}),
 			w(Baz, {}),
@@ -329,14 +336,20 @@ exports.default = HelloWorld;
 
 		const expected = `import * as tslib_1 from "tslib";
 import { registry as __autoRegistry } from "@dojo/framework/widget-core/decorators/registry";
-var __autoRegistryItems_1 = { '__autoRegistryItem_Bar': () => import("./widgets/Bar"), '__autoRegistryItem_Baz': () => import("./Baz") };
+var __autoRegistryItems_1 = { '__autoRegistryItem_Something': () => import("./Something"), '__autoRegistryItem_Bar': () => import("./widgets/Bar"), '__autoRegistryItem_Baz': () => import("./Baz") };
 var __autoRegistryItems_2 = { '__autoRegistryItem_Bar': () => import("./widgets/Bar"), '__autoRegistryItem_Baz': () => import("./Baz"), '__autoRegistryItem_Quz': () => import("./Quz") };
 import { v, w } from '@dojo/framework/widget-core/d';
 import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import { Blah } from './Qux';
 let Foo = class Foo extends WidgetBase {
     render() {
-        return v('div'[v('div', ['Foo']),
+        return v('div'[w(Outlet, {
+            id: 'my-foo-outlet',
+            renderer() {
+                return w("__autoRegistryItem_Something", {});
+            }
+        }),
+            v('div', ['Foo']),
             w("__autoRegistryItem_Bar", {}),
             w("__autoRegistryItem_Baz", {}),
             w(Blah, {})]);
@@ -359,12 +372,13 @@ Another = tslib_1.__decorate([
 export { Another };
 export default HelloWorld;
 `;
-		assert.equal(nl(result.outputText), expected);
+		/*assert.equal(nl(result.outputText), expected);*/
 		assert.deepEqual(shared, {
 			modules: {
-				__autoRegistryItem_Bar: 'widgets/Bar',
-				__autoRegistryItem_Baz: 'Baz',
-				__autoRegistryItem_Quz: 'Quz'
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: undefined },
+				__autoRegistryItem_Baz: { path: 'Baz', outletName: undefined },
+				__autoRegistryItem_Quz: { path: 'Quz', outletName: undefined },
+				__autoRegistryItem_Something: { path: 'Something', outletName: 'my-foo-outlet' }
 			}
 		});
 	});

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -2,7 +2,7 @@ import registryTransformer from '../../../src/registry-transformer/index';
 import * as ts from 'typescript';
 
 const nl = require('normalize-newline');
-const { describe, it } = intern.getInterface('bdd');
+const { beforeEach, describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
 const source = `
@@ -74,6 +74,13 @@ export class Another extends WidgetBase {
 `;
 
 describe('registry-transformer', () => {
+	let shared: any = {};
+
+	beforeEach(() => {
+		shared = require('../../../src/registry-transformer/shared');
+		shared.modules = {};
+	});
+
 	it('does not add import or decorator when no modules specified', () => {
 		const transformer = registryTransformer(process.cwd(), []);
 		const result = ts.transpileModule(source, {
@@ -325,7 +332,6 @@ exports.default = HelloWorld;
 				before: [transformer]
 			}
 		});
-		const shared = require('../../../src/registry-transformer/shared');
 
 		const expected = `import * as tslib_1 from "tslib";
 import { registry as __autoRegistry } from "@dojo/framework/widget-core/decorators/registry";
@@ -419,7 +425,6 @@ export default HelloWorld;
 				before: [transformer]
 			}
 		});
-		const shared = require('../../../src/registry-transformer/shared');
 
 		const expected = `import * as tslib_1 from "tslib";
 import { registry as __autoRegistry } from "@dojo/framework/widget-core/decorators/registry";
@@ -467,6 +472,77 @@ export default HelloWorld;
 				__autoRegistryItem_Baz: { path: 'Baz', outletName: undefined },
 				__autoRegistryItem_Quz: { path: 'Quz', outletName: undefined },
 				__autoRegistryItem_Something: { outletName: 'my-foo-outlet', path: 'Something' }
+			}
+		});
+	});
+
+	it('can distinguish widgets in an outlet renderer tsx', () => {
+		const source = `
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import Bar from './widgets/Bar';
+import Baz from './Baz';
+import Quz from './Quz';
+import { Blah } from './Qux';
+import Outlet from '@dojo/framework/routing/Outlet';
+
+export class Foo extends WidgetBase {
+	protected render() {
+		return (
+			<div>
+				<div>
+					<div>Foo</div>
+					<Baz>
+						<div>child</div>
+					</Baz>
+					<Outlet id="my-bar-outlet" renderer={ () => (<Bar />) } />
+				</div>
+			</div>
+		);
+	}
+}
+`;
+		const transformer = registryTransformer(process.cwd(), [], true);
+		const result = ts.transpileModule(source, {
+			compilerOptions: {
+				importHelpers: true,
+				module: ts.ModuleKind.ESNext,
+				target: ts.ScriptTarget.ESNext,
+				jsx: ts.JsxEmit.Preserve,
+				jsxFactory: 'tsx'
+			},
+			transformers: {
+				before: [transformer]
+			}
+		});
+		const expected = `import * as tslib_1 from "tslib";
+import { registry as __autoRegistry } from "@dojo/framework/widget-core/decorators/registry";
+var Loadable__ = { type: "registry" };
+var __autoRegistryItems_1 = { '__autoRegistryItem_Baz': () => import("./Baz"), '__autoRegistryItem_Bar': () => import("./widgets/Bar") };
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import Outlet from '@dojo/framework/routing/Outlet';
+let Foo = class Foo extends WidgetBase {
+    render() {
+        return (<div>
+				<div>
+					<div>Foo</div>
+					<Loadable__ __autoRegistryItem="__autoRegistryItem_Baz">
+						<div>child</div>
+					</Loadable__>
+					<Outlet id="my-bar-outlet" renderer={() => (<Loadable__ __autoRegistryItem="__autoRegistryItem_Bar"/>)}/>
+				</div>
+			</div>);
+    }
+};
+Foo = tslib_1.__decorate([
+    __autoRegistry(__autoRegistryItems_1)
+], Foo);
+export { Foo };
+`;
+		assert.equal(nl(result.outputText), expected);
+		assert.deepEqual(shared, {
+			modules: {
+				__autoRegistryItem_Baz: { path: 'Baz', outletName: undefined },
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: 'my-bar-outlet' }
 			}
 		});
 	});


### PR DESCRIPTION
**Type:** feature

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
The `registry-transformer` is now capable of detecting outlets when traversing for lazy loadable widgets. The outlet information is written to the existing shared module, which now contains the renamed/generated registry string, the path to the module, and the outlet it belongs to.

example:
```ts
export class Foo extends WidgetBase {
  protected render() {
    return v('div' [
      w(Outlet, {
        id: 'my-foo-outlet',
        renderer() {
          return w(Something, {});
        }
      })
    ]);
  }
}
```
shared module:
```ts
modules: {
  __autoRegistryItem_Something: { path: 'widgets/Something', outletName: 'my-foot-outlet' }
}
```
