### PR TITLE
Support widgets in multiple outlets

### DIFF
--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -283,7 +283,10 @@ class Visitor {
 			.resolve(this.contextPath, meta.path)
 			.replace(`${this.basePath}${path.posix.sep}`, '');
 		shared.modules = shared.modules || {};
-		shared.modules[registryItemName] = { path: targetPath, outletName: meta.outletName };
+		shared.modules[registryItemName] = shared.modules[registryItemName] || { path: targetPath, outletName: [] };
+		if (meta.outletName) {
+			shared.modules[registryItemName].outletName.push(meta.outletName);
+		}
 	}
 
 	private replaceWidgetClassWithString(node: ts.CallExpression) {

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -368,9 +368,9 @@ export default HelloWorld;
 		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared, {
 			modules: {
-				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: undefined },
-				__autoRegistryItem_Baz: { path: 'Baz', outletName: undefined },
-				__autoRegistryItem_Quz: { path: 'Quz', outletName: undefined }
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: [] },
+				__autoRegistryItem_Baz: { path: 'Baz', outletName: [] },
+				__autoRegistryItem_Quz: { path: 'Quz', outletName: [] }
 			}
 		});
 	});
@@ -481,10 +481,10 @@ export default HelloWorld;
 		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared, {
 			modules: {
-				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: undefined },
-				__autoRegistryItem_Blah: { path: 'Qux', outletName: 'my-blah-outlet' },
-				__autoRegistryItem_Quz: { path: 'Quz', outletName: undefined },
-				__autoRegistryItem_Something: { outletName: 'my-foo-outlet', path: 'Something' }
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: [] },
+				__autoRegistryItem_Blah: { path: 'Qux', outletName: ['my-blah-outlet'] },
+				__autoRegistryItem_Quz: { path: 'Quz', outletName: [] },
+				__autoRegistryItem_Something: { outletName: ['my-foo-outlet'], path: 'Something' }
 			}
 		});
 	});
@@ -553,7 +553,7 @@ export { Foo };
 		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared, {
 			modules: {
-				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: 'my-bar-outlet' }
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: ['my-bar-outlet'] }
 			}
 		});
 	});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
It's possible to have a registry item contained in multiple outlets. Change the shared module structure to be an array of outlet names to support this.
