### PR TITLE
Add traceOnly flag for non-destructive tracing

### DIFF
--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -19,6 +19,7 @@ interface VisitorOptions {
 	legacyModule: boolean;
 	all: boolean;
 	outlets: string[];
+	traceOnly: boolean;
 }
 
 function createArrowFuncForDefaultImport(modulePath: string) {
@@ -39,6 +40,7 @@ class Visitor {
 	private all = false;
 	private outlets: string[] = [];
 	private registryItems: any = {};
+	private traceOnly = false;
 
 	constructor(options: VisitorOptions) {
 		this.context = options.context;
@@ -47,6 +49,7 @@ class Visitor {
 		this.basePath = options.basePath;
 		this.all = options.all;
 		this.outlets = options.outlets;
+		this.traceOnly = options.traceOnly;
 	}
 
 	public visit(node: ts.Node) {
@@ -77,7 +80,7 @@ class Visitor {
 	public end(node: ts.SourceFile) {
 		let statements = [...node.statements];
 
-		if (Object.keys(this.registryItems).length) {
+		if (Object.keys(this.registryItems).length && !this.traceOnly) {
 			const registryItems = Object.keys(this.registryItems).map((label) => {
 				const modulePath = this.registryItems[label];
 				const importCall = createArrowFuncForDefaultImport(modulePath);
@@ -191,48 +194,51 @@ class Visitor {
 
 			const outletName = this.outletName ? this.getOutletName(node) : undefined;
 			if (
+				this.traceOnly ||
 				this.all ||
 				this.bundlePaths.indexOf(targetPath) !== -1 ||
 				(outletName && this.outlets.indexOf(outletName) !== -1)
 			) {
 				this.registryItems[text] = this.modulesMap.get(text) as string;
-				const registryItem = ts.createPropertyAccess(
-					ts.createIdentifier('__autoRegistryItems'),
-					ts.createIdentifier(text)
-				);
-				const registryExpr = ts.createObjectLiteral([
-					ts.createPropertyAssignment(
-						ts.createIdentifier('label'),
-						ts.createLiteral(`__autoRegistryItem_${text}`)
-					),
-					ts.createPropertyAssignment(ts.createIdentifier('registryItem'), registryItem)
-				]);
-				const registryAttribute = ts.createJsxAttribute(
-					ts.createIdentifier('__autoRegistryItem'),
-					ts.createJsxExpression(undefined, registryExpr)
-				);
 				this.setSharedModules(`__autoRegistryItem_${text}`, {
 					path: this.registryItems[text],
 					outletName
 				});
-				const attrs = ts.updateJsxAttributes(node.attributes, [
-					...node.attributes.properties,
-					registryAttribute
-				]);
-				this.needsLoadable = true;
-				if (ts.isJsxElement(inputNode)) {
-					const openingElement = ts.updateJsxOpeningElement(
-						node as ts.JsxOpeningElement,
-						ts.createIdentifier(fakeComponentName),
-						attrs
+				if (!this.traceOnly) {
+					const registryItem = ts.createPropertyAccess(
+						ts.createIdentifier('__autoRegistryItems'),
+						ts.createIdentifier(text)
 					);
-					const closingElement = ts.updateJsxClosingElement(
-						inputNode.closingElement,
-						ts.createIdentifier(fakeComponentName)
+					const registryExpr = ts.createObjectLiteral([
+						ts.createPropertyAssignment(
+							ts.createIdentifier('label'),
+							ts.createLiteral(`__autoRegistryItem_${text}`)
+						),
+						ts.createPropertyAssignment(ts.createIdentifier('registryItem'), registryItem)
+					]);
+					const registryAttribute = ts.createJsxAttribute(
+						ts.createIdentifier('__autoRegistryItem'),
+						ts.createJsxExpression(undefined, registryExpr)
 					);
-					return ts.updateJsxElement(inputNode, openingElement, inputNode.children, closingElement);
-				} else {
-					return ts.updateJsxSelfClosingElement(inputNode, ts.createIdentifier(fakeComponentName), attrs);
+					const attrs = ts.updateJsxAttributes(node.attributes, [
+						...node.attributes.properties,
+						registryAttribute
+					]);
+					this.needsLoadable = true;
+					if (ts.isJsxElement(inputNode)) {
+						const openingElement = ts.updateJsxOpeningElement(
+							node as ts.JsxOpeningElement,
+							ts.createIdentifier(fakeComponentName),
+							attrs
+						);
+						const closingElement = ts.updateJsxClosingElement(
+							inputNode.closingElement,
+							ts.createIdentifier(fakeComponentName)
+						);
+						return ts.updateJsxElement(inputNode, openingElement, inputNode.children, closingElement);
+					} else {
+						return ts.updateJsxSelfClosingElement(inputNode, ts.createIdentifier(fakeComponentName), attrs);
+					}
 				}
 			}
 		}
@@ -259,24 +265,30 @@ class Visitor {
 
 		const outletName = this.outletName ? this.getOutletName(node) : undefined;
 		if (
+			this.traceOnly ||
 			this.all ||
 			this.bundlePaths.indexOf(targetPath) !== -1 ||
 			(outletName && this.outlets.indexOf(outletName) !== -1)
 		) {
 			this.registryItems[text] = this.modulesMap.get(text) as string;
-			const registryItem = ts.createPropertyAccess(
-				ts.createIdentifier('__autoRegistryItems'),
-				ts.createIdentifier(text)
-			);
-			const registryExpr = ts.createObjectLiteral([
-				ts.createPropertyAssignment(
-					ts.createIdentifier('label'),
-					ts.createLiteral(`__autoRegistryItem_${text}`)
-				),
-				ts.createPropertyAssignment(ts.createIdentifier('registryItem'), registryItem)
-			]);
 			this.setSharedModules(`__autoRegistryItem_${text}`, { path: this.registryItems[text], outletName });
-			return ts.updateCall(node, node.expression, node.typeArguments, [registryExpr, ...node.arguments.slice(1)]);
+			if (!this.traceOnly) {
+				const registryItem = ts.createPropertyAccess(
+					ts.createIdentifier('__autoRegistryItems'),
+					ts.createIdentifier(text)
+				);
+				const registryExpr = ts.createObjectLiteral([
+					ts.createPropertyAssignment(
+						ts.createIdentifier('label'),
+						ts.createLiteral(`__autoRegistryItem_${text}`)
+					),
+					ts.createPropertyAssignment(ts.createIdentifier('registryItem'), registryItem)
+				]);
+				return ts.updateCall(node, node.expression, node.typeArguments, [
+					registryExpr,
+					...node.arguments.slice(1)
+				]);
+			}
 		}
 		return node;
 	}
@@ -358,13 +370,14 @@ class Visitor {
 }
 
 const registryTransformer = function(
-	this: { basePath: string; bundlePaths: string[]; all: boolean; outlets: string[] },
+	this: { basePath: string; bundlePaths: string[]; all: boolean; outlets: string[]; traceOnly: boolean },
 	context: ts.TransformationContext
 ) {
 	const basePath = this.basePath;
 	const bundlePaths = this.bundlePaths;
 	const all = this.all;
 	const outlets = this.outlets;
+	const traceOnly = this.traceOnly;
 	const opts = context.getCompilerOptions();
 	const { module } = opts;
 	const legacyModule =
@@ -372,11 +385,26 @@ const registryTransformer = function(
 	return function(node: ts.SourceFile) {
 		const root = node;
 		const contextPath = path.dirname(path.relative(basePath, node.getSourceFile().fileName));
-		const visitor = new Visitor({ context, contextPath, bundlePaths, basePath, legacyModule, root, all, outlets });
+		const visitor = new Visitor({
+			context,
+			contextPath,
+			bundlePaths,
+			basePath,
+			legacyModule,
+			root,
+			all,
+			outlets,
+			traceOnly
+		});
 		let result = ts.visitNode(node, visitor.visit.bind(visitor));
 		return visitor.end(result);
 	};
 };
 
-export default (basePath: string, bundlePaths: string[], all: boolean = false, outlets: string[] = []) =>
-	registryTransformer.bind({ bundlePaths, basePath, all, outlets });
+export default (
+	basePath: string,
+	bundlePaths: string[],
+	all: boolean = false,
+	outlets: string[] = [],
+	traceOnly: boolean = false
+) => registryTransformer.bind({ bundlePaths, basePath, all, outlets, traceOnly });

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -452,4 +452,50 @@ export class Foo extends WidgetBase {
 			}
 		});
 	});
+
+	it('does not transform, but logs to shared modules in traceOnly mode', () => {
+		const transformer = registryTransformer(process.cwd(), [], false, [], true);
+		const result = ts.transpileModule(source, {
+			compilerOptions: {
+				importHelpers: true,
+				module: ts.ModuleKind.ESNext,
+				target: ts.ScriptTarget.ESNext
+			},
+			transformers: {
+				before: [transformer]
+			}
+		});
+
+		const expected = `import { v, w } from '@dojo/framework/widget-core/d';
+import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import Bar from './widgets/Bar';
+import Baz from './Baz';
+import Quz from './Quz';
+import { Blah } from './Qux';
+export class Foo extends WidgetBase {
+    render() {
+        return v('div'[v('div', ['Foo']),
+            w(Bar, {}),
+            w(Baz, {}),
+            w(Blah, {})]);
+    }
+}
+export class Another extends WidgetBase {
+    render() {
+        return v('div'[w(Bar, {}),
+            w(Baz, {}),
+            w(Quz, {})]);
+    }
+}
+export default HelloWorld;
+`;
+		assert.equal(nl(result.outputText), expected);
+		assert.deepEqual(shared, {
+			modules: {
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: [] },
+				__autoRegistryItem_Baz: { path: 'Baz', outletName: [] },
+				__autoRegistryItem_Quz: { path: 'Quz', outletName: [] }
+			}
+		});
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Adds a trace only mode to the registry transformer. This will not modify the source at all, but log the info of things it found to the shared module. We will be able to leverage this mode for detecting potential changes across builds.