### PR TITLE
Always log to shared module

### DIFF
--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -189,6 +189,7 @@ class Visitor {
 				.resolve(this.contextPath, importPath)
 				.replace(`${this.basePath}${path.posix.sep}`, '');
 
+			this.log(text, targetPath);
 			const outletName = this.outletName ? this.getOutletName(node) : undefined;
 			if (
 				this.all ||
@@ -250,6 +251,10 @@ class Visitor {
 		}
 	}
 
+	private log(name: string, path: string) {
+		shared.all[name] = path;
+	}
+
 	private replaceWidgetClassWithString(node: ts.CallExpression) {
 		const text = node.arguments[0].getText();
 		const importPath = this.modulesMap.get(text) as string;
@@ -258,6 +263,7 @@ class Visitor {
 			.replace(`${this.basePath}${path.posix.sep}`, '');
 
 		const outletName = this.outletName ? this.getOutletName(node) : undefined;
+		this.log(text, targetPath);
 		if (
 			this.all ||
 			this.bundlePaths.indexOf(targetPath) !== -1 ||

--- a/src/registry-transformer/shared.ts
+++ b/src/registry-transformer/shared.ts
@@ -1,1 +1,1 @@
-exports = { modules: {} };
+exports = { modules: {}, all: {} };

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -79,6 +79,7 @@ describe('registry-transformer', () => {
 	beforeEach(() => {
 		shared = require('../../../src/registry-transformer/shared');
 		shared.modules = {};
+		shared.all = {};
 	});
 
 	it('does not modify when no modules specified', () => {
@@ -278,6 +279,11 @@ export default HelloWorld;
 `;
 		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared, {
+			all: {
+				Bar: 'widgets/Bar',
+				Baz: 'Baz',
+				Quz: 'Quz'
+			},
 			modules: {
 				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: [] },
 				__autoRegistryItem_Baz: { path: 'Baz', outletName: [] },
@@ -380,6 +386,13 @@ export default HelloWorld;
 `;
 		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared, {
+			all: {
+				Bar: 'widgets/Bar',
+				Baz: 'Baz',
+				Blah: 'Qux',
+				Quz: 'Quz',
+				Something: 'Something'
+			},
 			modules: {
 				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: [] },
 				__autoRegistryItem_Blah: { path: 'Qux', outletName: ['my-blah-outlet'] },
@@ -447,6 +460,10 @@ export class Foo extends WidgetBase {
 `;
 		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared, {
+			all: {
+				Bar: 'widgets/Bar',
+				Baz: 'Baz'
+			},
 			modules: {
 				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: ['my-bar-outlet'] }
 			}


### PR DESCRIPTION
**Type:** feature
The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Supercedes: https://github.com/dojo/webpack-contrib/pull/79, rather than an extra flag, just log all found widgets in all scenarios in a separate section of the shared module.
