### PR TITLE
Remove typescript as a dep, make it a dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1584,7 +1584,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -6110,7 +6110,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -6138,7 +6138,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
@@ -10180,7 +10180,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -10932,7 +10932,8 @@
     "typescript": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -11789,7 +11790,7 @@
     },
     "widest-line": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "requires": {
         "string-width": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "source-map": "0.6.1",
     "ts-loader": "3.1.1",
     "typed-css-modules": "0.3.1",
-    "typescript": "~2.6.1",
     "workbox-webpack-plugin": "3.2.0"
   },
   "devDependencies": {
@@ -103,6 +102,7 @@
     "sinon": "~4.5.0",
     "stream-combiner2": "1.1.1",
     "style-loader": "0.20.1",
+    "typescript": "~2.6.1",
     "webpack": "3.8.1"
   },
   "lint-staged": {


### PR DESCRIPTION
**Type:** bug

**Description:**
This should fix the issues with using later versions of typescript that we don't currently ship (ie 3.0)

Move typescript to be a dev dep because things like the registry transformer depend on the version aligning with whatever the end user is using.  It actually should probably be a peer dep in the long run, but this repo/lib is currently more of an internal lib so doesn't matter as much.
