### PR TITLE
Hacky hack to fix typescript factory api breakages 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2876,7 +2876,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
@@ -7090,7 +7090,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -245,7 +245,7 @@ class Visitor {
 						openingElement = (ts as any).updateJsxOpeningElement(
 							node as ts.JsxOpeningElement,
 							ts.createIdentifier(fakeComponentName),
-							undefined,
+							(node as any).typeArguments,
 							attrs
 						);
 					}
@@ -261,7 +261,7 @@ class Visitor {
 						return (ts as any).updateJsxSelfClosingElement(
 							inputNode,
 							ts.createIdentifier(fakeComponentName),
-							undefined,
+							(inputNode as any).typeArguments,
 							attrs
 						);
 					}

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -233,18 +233,38 @@ class Visitor {
 				this.needsLoadable = true;
 				this.ctorCountMap.set(text, (this.ctorCountMap.get(text) || 0) - 1);
 				if (ts.isJsxElement(inputNode)) {
-					const openingElement = ts.updateJsxOpeningElement(
-						node as ts.JsxOpeningElement,
-						ts.createIdentifier(fakeComponentName),
-						attrs
-					);
+					let openingElement;
+
+					if (ts.updateJsxOpeningElement.length === 3) {
+						openingElement = ts.updateJsxOpeningElement(
+							node as ts.JsxOpeningElement,
+							ts.createIdentifier(fakeComponentName),
+							attrs
+						);
+					} else {
+						openingElement = (ts as any).updateJsxOpeningElement(
+							node as ts.JsxOpeningElement,
+							ts.createIdentifier(fakeComponentName),
+							undefined,
+							attrs
+						);
+					}
 					const closingElement = ts.updateJsxClosingElement(
 						inputNode.closingElement,
 						ts.createIdentifier(fakeComponentName)
 					);
 					return ts.updateJsxElement(inputNode, openingElement, inputNode.children, closingElement);
 				} else {
-					return ts.updateJsxSelfClosingElement(inputNode, ts.createIdentifier(fakeComponentName), attrs);
+					if (ts.updateJsxSelfClosingElement.length === 3) {
+						return ts.updateJsxSelfClosingElement(inputNode, ts.createIdentifier(fakeComponentName), attrs);
+					} else {
+						return (ts as any).updateJsxSelfClosingElement(
+							inputNode,
+							ts.createIdentifier(fakeComponentName),
+							undefined,
+							attrs
+						);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**Type:** feature
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
TypeScript lovingly broke some of their factory api's in 2.9 and 3.0. The easiest way for me to sniff this was just to check the arity.

No tests included (this is super hard to test without toggling the dependency versions)


Resolves https://github.com/dojo/webpack-contrib/issues/89
