### PR TITLE
Trailing slash on pathname is optional

### DIFF
--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -93,7 +93,7 @@ export function generateRouteInjectionScript(html: string[], paths: any[], root:
 
 export function generateBasePath(route = '__app_root__') {
 	return `<script>
-window.__public_path__ = window.location.pathname.replace('${route}/', '');
+window.__public_path__ = window.location.pathname.replace(${new RegExp(`${route}(\/)?`)}, '');
 </script>`;
 }
 

--- a/tests/support/fixtures/build-time-render/state/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state/my-path/index.html
@@ -9,6 +9,6 @@ span {
 	<body>
 		<div id="app"><div class="hello">{"staticFeatures":{"build-time-render":true}}</div></div>
 		<script>
-window.__public_path__ = window.location.pathname.replace('my-path/', '');
+window.__public_path__ = window.location.pathname.replace(/my-path(\/)?/, '');
 </script><link rel="stylesheet" href="../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
 </body></html>

--- a/tests/support/fixtures/build-time-render/state/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/my-path/other/index.html
@@ -17,6 +17,6 @@ span {
 	<body>
 		<div id="app"><div class="other">Other</div></div>
 		<script>
-window.__public_path__ = window.location.pathname.replace('my-path/other/', '');
+window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/, '');
 </script><link rel="stylesheet" href="../../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
 </body></html>

--- a/tests/support/fixtures/build-time-render/state/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/other/index.html
@@ -9,6 +9,6 @@ span {
 	<body>
 		<div id="app"><div class="hello">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src=".././relative-image.svg"><img src="../../other-relative-image.svg"></div></div>
 		<script>
-window.__public_path__ = window.location.pathname.replace('other/', '');
+window.__public_path__ = window.location.pathname.replace(/other(\/)?/, '');
 </script><link rel="stylesheet" href="../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
 </body></html>


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The trailing slash on path is optional, replace the route and optionally the slash if it exists.

