### PR TITLE
Fix: use tapAsync for btr afterEmit hook

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -149,7 +149,7 @@ export default class BuildTimeRender {
 		if (!this._root) {
 			return;
 		}
-		compiler.hooks.afterEmit.tap(this.constructor.name, async (compilation, callback) => {
+		compiler.hooks.afterEmit.tapAsync(this.constructor.name, async (compilation, callback) => {
 			this._output = compiler.options.output && compiler.options.output.path;
 			if (!this._output) {
 				return Promise.resolve().then(() => {

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -41,7 +41,7 @@ describe('build-time-render', () => {
 			compiler = {
 				hooks: {
 					afterEmit: {
-						tap: tapStub
+						tapAsync: tapStub
 					}
 				},
 				options: {
@@ -172,7 +172,7 @@ describe('build-time-render', () => {
 			compiler = {
 				hooks: {
 					afterEmit: {
-						tap: tapStub
+						tapAsync: tapStub
 					}
 				},
 				options: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Update the build time render plugin to use `compiler.hooks.afterEmit.tapAsync` instead of `compiler.hooks.emit.tap`.