### PR TITLE
Autogenerate customElement decorator using widget props interface

### DIFF
--- a/src/element-transformer/index.ts
+++ b/src/element-transformer/index.ts
@@ -1,0 +1,132 @@
+import * as ts from 'typescript';
+
+export default function transformer(program: ts.Program): ts.TransformerFactory<ts.SourceFile> {
+	return (context: ts.TransformationContext) => (file: ts.SourceFile) => visitNodeAndChildren(file, program, context);
+}
+
+function visitNodeAndChildren(f: ts.SourceFile, program: ts.Program, context: ts.TransformationContext): ts.SourceFile;
+function visitNodeAndChildren(node: ts.Node, program: ts.Program, context: ts.TransformationContext): ts.Node;
+function visitNodeAndChildren(node: ts.Node, program: ts.Program, context: ts.TransformationContext) {
+	return ts.visitEachChild(
+		decoratorVisit(node, program),
+		(childNode) => visitNodeAndChildren(childNode, program, context),
+		context
+	);
+}
+
+function decoratorVisit(node: ts.Node, program: ts.Program): ts.Node {
+	if (!(ts.isClassDeclaration(node) && node.decorators && node.name)) {
+		return node;
+	}
+	const decorator = node.decorators.find((dec) => {
+		return ts.isCallExpression(dec.expression) && dec.expression.expression.getText() === 'customElement';
+	});
+	if (!decorator) {
+		return node;
+	}
+
+	if (!ts.isCallExpression(decorator.expression) || decorator.expression.arguments.length !== 1) {
+		throw new Error('`customElement` decorator expects a single argument: string (tag name) or object');
+	}
+	let decArg = decorator.expression.arguments[0];
+	let didNormalize = false;
+
+	// normalize pass: transform @customElement('dojo-input') to @customElement({ tag: 'dojo-input' })
+	if (ts.isStringLiteral(decArg)) {
+		decArg = ts.createObjectLiteral([ts.createPropertyAssignment('tag', decArg)]);
+		didNormalize = true;
+	}
+
+	if (!ts.isObjectLiteralExpression(decArg)) {
+		throw new Error('`customElement` expects either a string (the tag name) or an object');
+	}
+
+	// Figure out which props were explicitly set so we don't override
+	const passedArgKeys = new Set(
+		didNormalize
+			? ['tag'] // can't do getText on created nodes
+			: decArg.properties.map((n) => {
+					return n.name!.getText();
+			  })
+	);
+
+	// Get the public props from the widget's interface declaration
+	const checker = program.getTypeChecker();
+	if (
+		!(
+			node.heritageClauses &&
+			node.heritageClauses.length &&
+			node.heritageClauses[0].types.length &&
+			node.heritageClauses[0].types[0].typeArguments
+		)
+	) {
+		throw new Error(
+			"`customElement` expects to decore a class that extends WidgetBase<T> where T is the widget's public properties."
+		);
+	}
+	const widgetPropNode = node.heritageClauses[0].types[0].typeArguments![0];
+	const widgetPropType = checker.getTypeFromTypeNode(widgetPropNode);
+	const widgetProps = checker.getPropertiesOfType(widgetPropType).map((sym) => {
+		const propType = checker.typeToString(checker.getTypeOfSymbolAtLocation(sym, widgetPropNode));
+		return [sym.getName(), propType];
+	});
+
+	// Categorize the props
+	const attributes: string[] = [];
+	const events: string[] = [];
+	const properties: string[] = [];
+	for (let [n, t] of widgetProps) {
+		if (t === 'string') {
+			attributes.push(n);
+		} else if (n.startsWith('on') && (t.includes('=>') || t.includes('):'))) {
+			events.push(n);
+		} else {
+			properties.push(n);
+		}
+	}
+	const propsToAdd = [];
+
+	// Build output
+	if (!passedArgKeys.has('attributes') && attributes.length) {
+		propsToAdd.push(
+			ts.createPropertyAssignment('attributes', ts.createArrayLiteral(attributes.map(ts.createLiteral)))
+		);
+	}
+
+	if (!passedArgKeys.has('events') && events.length) {
+		propsToAdd.push(ts.createPropertyAssignment('events', ts.createArrayLiteral(events.map(ts.createLiteral))));
+	}
+
+	if (!passedArgKeys.has('properties') && properties.length) {
+		propsToAdd.push(
+			ts.createPropertyAssignment('properties', ts.createArrayLiteral(properties.map(ts.createLiteral)))
+		);
+	}
+
+	// update nodes
+	const newDecorator = ts.updateDecorator(
+		decorator,
+		ts.updateCall(
+			decorator.expression,
+			decorator.expression.expression,
+			[widgetPropNode],
+			[ts.updateObjectLiteral(decArg, [...decArg.properties, ...propsToAdd])]
+		)
+	);
+
+	// not sure why ts.NodeArray<T> doesn't have splice...
+	const decoratorIdx = node.decorators.indexOf(decorator);
+	const updatedDecoratorList = node.decorators
+		.slice(0, decoratorIdx)
+		.concat([newDecorator, ...node.decorators.slice(decoratorIdx + 1)]);
+
+	return ts.updateClassDeclaration(
+		node,
+		updatedDecoratorList,
+		node.modifiers,
+		node.name,
+		node.typeParameters,
+		node.heritageClauses,
+		node.members
+	);
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -10,6 +10,7 @@ import './i18n-plugin/templates/setLocaleData';
 import './promise-loader/all';
 import './build-time-render/all';
 import './registry-transformer/RegistryTransformer';
+import './element-transformer/ElementTransformer';
 import './service-worker-plugin/service-worker-entry';
 import './service-worker-plugin/ServiceWorkerPlugin';
 import './istanbul-loader/all';

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -1,0 +1,292 @@
+import elementTransformer from '../../../src/element-transformer/index';
+import * as ts from 'typescript';
+
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+describe('element-transformer', () => {
+	it('normalizes string arg to object', () => {
+		const source = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {}
+		@customElement("dojo-input")
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+		}`;
+		const expected = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {}
+		@customElement({ tag: "dojo-input" })
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+		}`;
+		assertCompile(source, expected, (program) => ({
+			before: [elementTransformer(program)]
+		}));
+	});
+
+	it('extracts attributes', () => {
+		const source = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {
+			a: string;
+			b: string;
+		}
+		@customElement({ tag: "dojo-input" })
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+			public a = "1";
+			public b = "true";
+			public c = "string";
+		}`;
+		const expected = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {
+			a: string;
+			b: string;
+		}
+		@customElement({tag: "dojo-input", attributes: ["a", "b"]})
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+			public a = "1";
+			public b = "true";
+			public c = "string";
+		}`;
+		assertCompile(source, expected, (program) => ({
+			before: [elementTransformer(program)]
+		}));
+	});
+
+	it('extracts events', () => {
+		const source = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {
+			onA: (x: number) => boolean;
+			onB(): void;
+		}
+		@customElement({ tag: "dojo-input" })
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+			onA(x: number) {
+				return true
+			}
+			onB() {}
+		}`;
+		const expected = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {
+			onA: (x: number) => boolean;
+			onB(): void;
+		}
+		@customElement({ tag: "dojo-input": events: ["onA", "onB"] })
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+			onA(x: number) {
+				return true
+			}
+			onB() {}
+		}`;
+		assertCompile(source, expected, (program) => ({
+			before: [elementTransformer(program)]
+		}));
+	});
+
+	it('extracts properties', () => {
+		const source = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {
+			a: number;
+			b: boolean;
+			aFn(): void;
+		}
+		@customElement({ tag: "dojo-input" })
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+			public a = 1;
+			public b = true;
+			public c = "string";
+			aFn(){}
+		}`;
+		const expected = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {
+			a: number;
+			b: boolean;
+			aFn(): void;
+		}
+		@customElement({tag: "dojo-input", properties: ["a", "b", "aFn"]})
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+			public a = 1;
+			public b = true;
+			public c = "string";
+			aFn(){}
+		}`;
+		assertCompile(source, expected, (program) => ({
+			before: [elementTransformer(program)]
+		}));
+	});
+
+	it("doesn't override explicitly set properties", () => {
+		const source = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {
+			a: number;
+			b: boolean;
+			onA(): void;
+		}
+		@customElement({ tag: "dojo-input", properties: ["a"], childType: 'DOJO' })
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+			public a = 1;
+			public b = true;
+			public c = "string";
+			onA() {}
+		}`;
+		const expected = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {
+			a: number;
+			b: boolean;
+			onA(): void;
+		}
+		@customElement({tag: "dojo-input", properties: ["a"], childType: 'DOJO', events: ["onA"]})
+			export class DojoInput extends WidgetBase<DojoInputProperties> {
+			public a = 1;
+			public b = true;
+			public c = "string";
+			onA() {}
+		}`;
+		assertCompile(source, expected, (program) => ({
+			before: [elementTransformer(program)]
+		}));
+	});
+
+	it('validates assumptions', () => {
+		const noCall = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {}
+		@blah
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+		}`;
+		assert.doesNotThrow(() => {
+			assertCompile(noCall, noCall, (program) => ({
+				before: [elementTransformer(program)]
+			}));
+		});
+
+		const missingArg = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {}
+		@customElement()
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+		}`;
+		assert.throw(() => {
+			assertCompile(missingArg, '', (program) => ({
+				before: [elementTransformer(program)]
+			}));
+		}, /single argument:/);
+
+		const extraArg = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {}
+		@customElement(true, true)
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+		}`;
+		assert.throw(() => {
+			assertCompile(extraArg, '', (program) => ({
+				before: [elementTransformer(program)]
+			}));
+		}, /single argument:/);
+
+		const wrongArg = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {}
+		@customElement(true)
+		export class DojoInput extends WidgetBase<DojoInputProperties> {
+		}`;
+		assert.throw(() => {
+			assertCompile(wrongArg, '', (program) => ({
+				before: [elementTransformer(program)]
+			}));
+		}, /either a string/);
+
+		const noExtends = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {}
+		@customElement("dojo-input")
+		export class DojoInput {
+		}`;
+		assert.throw(() => {
+			assertCompile(noExtends, '', (program) => ({
+				before: [elementTransformer(program)]
+			}));
+		}, /extends WidgetBase/);
+
+		const badExtends = `
+		class WidgetBase<T> {}
+		interface DojoInputProperties {}
+		@customElement("dojo-input")
+		export class DojoInput extends WidgetBase {
+		}`;
+		assert.throw(() => {
+			assertCompile(badExtends, '', (program) => ({
+				before: [elementTransformer(program)]
+			}));
+		}, /extends WidgetBase/);
+	});
+});
+
+function assertCompile(
+	actual: string,
+	expected: string,
+	getTransformers: (program: ts.Program) => ts.CustomTransformers,
+	otherOptions?: ts.CompilerOptions,
+	errorMessage?: string
+) {
+	const compilerOptions = {
+		module: ts.ModuleKind.ESNext,
+		target: ts.ScriptTarget.ESNext,
+		...otherOptions
+	};
+	let filePaths = { 'actual.ts': actual, 'expected.ts': expected };
+	const outputs: Record<string, string> = {};
+	const host = testCompilerHost(filePaths, outputs);
+	const program = ts.createProgram(Object.keys(filePaths), compilerOptions, host);
+	const resultActual = program.emit(
+		program.getSourceFile('actual.ts'),
+		undefined,
+		undefined,
+		undefined,
+		getTransformers(program)
+	);
+	if (resultActual.diagnostics.length) {
+		console.error(resultActual.diagnostics.map((n) => 'actual: ' + n.messageText).join('\n'));
+	}
+
+	const resultExpected = program.emit(program.getSourceFile('expected.ts'));
+	if (resultExpected.diagnostics.length) {
+		console.error(resultActual.diagnostics.map((n) => 'expected: ' + n.messageText).join('\n'));
+	}
+	assert.equal(outputs['actual.js'], outputs['expected.js'], errorMessage);
+}
+
+function testCompilerHost(inputs: Record<string, string>, outputs: Record<string, string>): ts.CompilerHost {
+	return {
+		getSourceFile,
+		getDefaultLibFileName: () => 'lib.d.ts',
+		writeFile: (fileName: string, content: string) => {
+			outputs[fileName] = content;
+		},
+		getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
+		getDirectories: (path) => ts.sys.getDirectories(path),
+		getCanonicalFileName: (fileName) => (ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase()),
+		getNewLine: () => ts.sys.newLine,
+		useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+		fileExists,
+		readFile
+	};
+
+	function fileExists(fileName: string): boolean {
+		return !!inputs[fileName] || !!outputs[fileName];
+	}
+
+	function readFile(fileName: string): string | undefined {
+		return inputs[fileName];
+	}
+
+	function getSourceFile(fileName: string, languageVersion: ts.ScriptTarget, onError?: (message: string) => void) {
+		return inputs[fileName] ? ts.createSourceFile(fileName, inputs[fileName], languageVersion) : undefined;
+	}
+}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [X] Unit or Functional tests are included in the PR

**Description:**

Transformer and unit tests for extracting customElement setttings from a widget's props interface. Additional PR comments inline.

Resolves #43 