### PR TITLE
Make cache check and manifest check more robust

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -165,7 +165,7 @@ export default class BuildTimeRender {
 	private _writeBuildBridgeCache() {
 		Object.keys(this._manifestContent).forEach((chunkname) => {
 			let modified = false;
-			if (/\.js$/.test(chunkname)) {
+			if (/\.js$/.test(chunkname) && this._manifestContent[`${chunkname}.map`]) {
 				const content = this._manifestContent[chunkname];
 				const sourceMap = this._manifestContent[`${chunkname}.map`];
 				const node = SourceNode.fromStringWithSourceMap(content, new SourceMapConsumer(sourceMap));

--- a/src/build-time-render/bridge.js
+++ b/src/build-time-render/bridge.js
@@ -8,6 +8,13 @@ export default function () {
 		return global.__dojoBuildBridge(modulePath, args);
 	}
 	else {
-		return global.__dojoBuildBridgeCache[modulePath][JSON.stringify(args)];
+		var stringifiedArgs = JSON.stringify(args);
+		if (global__dojoBuildBridgeCache &&
+			global.__dojoBuildBridgeCache[modulePath] &&
+			global.__dojoBuildBridgeCache[modulePath][stringifiedArgs]
+		) {
+			return global.__dojoBuildBridgeCache[modulePath][stringifiedArgs];
+		}
+		return undefined;
 	}
 }


### PR DESCRIPTION

**Type:** bug

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)

**Description:**
Some js files don't have sourcemaps from our build (unprocessed assets), in which case ignore them. Also add some guards to the runtime check of the cache.
