### PR TITLE
Split out common bootstrap and add conditional import for webpack hot middleware client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dojo/framework": {
-      "version": "5.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.0-alpha.3.tgz",
-      "integrity": "sha512-n6Cy3t7Zu65ceBM3UfqgBUmyM0F3JGUDIahMhXv4JKkXNaXSaUGuWDdBlRoH3LcEJDk6pj6ZV+J4JYiZ4IyPCQ==",
+      "version": "5.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.0-alpha.4.tgz",
+      "integrity": "sha512-nqF13sk3NtZNWrpRlhc51m+On50w9F0EEqVdSmO2TsFNSS4v40jhE+NYjgwp6V9pKg4GcA07H0mD78VkB1/sdg==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
@@ -850,6 +850,11 @@
       "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
+    },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -4481,6 +4486,11 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
     "html-webpack-include-assets-plugin": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/html-webpack-include-assets-plugin/-/html-webpack-include-assets-plugin-1.0.6.tgz",
@@ -4990,7 +5000,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -5049,7 +5059,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -7304,8 +7314,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -9122,6 +9131,17 @@
             "ajv-keywords": "^3.1.0"
           }
         }
+      }
+    },
+    "webpack-hot-middleware": {
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.24.3.tgz",
+      "integrity": "sha512-pPlmcdoR2Fn6UhYjAhp1g/IJy1Yc9hD+T6O9mjRcWV2pFbBjIFoJXhP0CoD0xPOhWJuWXuZXGBga9ybbOdzXpg==",
+      "requires": {
+        "ansi-html": "0.0.7",
+        "html-entities": "^1.2.0",
+        "querystring": "^0.2.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "source-map": "0.6.1",
     "ts-loader": "5.3.0",
     "typed-css-modules": "0.3.7",
+    "webpack-hot-middleware": "2.24.3",
     "workbox-webpack-plugin": "3.6.3",
     "wrapper-webpack-plugin": "2.0.0"
   },

--- a/src/bootstrap-plugin/async.js
+++ b/src/bootstrap-plugin/async.js
@@ -1,8 +1,12 @@
 var has = require('@dojo/framework/has/has');
 require('@dojo/framework/shim/Promise');
-require('./sync');
+require('./common');
 
 var modules = [];
+
+if (has.default('build-serve')) {
+	modules.push(import(/* webpackChunkName: "platform/client" */ 'webpack-hot-middleware/client?reload=true'));
+}
 
 // @ts-ignore
 if (has.default(__dojoframeworkshimIntersectionObserver) && !has.default('dom-intersection-observer')) {

--- a/src/bootstrap-plugin/common.js
+++ b/src/bootstrap-plugin/common.js
@@ -1,0 +1,16 @@
+var has = require('@dojo/framework/has/has');
+var global = require('@dojo/framework/shim/global');
+
+if (!has.exists('build-time-render')) {
+	has.add('build-time-render', false, false);
+}
+
+if (!has.exists('build-serve')) {
+	has.add('build-serve', false, false);
+}
+
+if (global.default.__public_path__) {
+	// @ts-ignore
+	__webpack_public_path__ = window.location.origin + global.default.__public_path__;
+	has.add('public-path', global.default.__public_path__, true);
+}

--- a/src/bootstrap-plugin/sync.js
+++ b/src/bootstrap-plugin/sync.js
@@ -1,12 +1,6 @@
 var has = require('@dojo/framework/has/has');
-var global = require('@dojo/framework/shim/global');
+require('./common');
 
-if (!has.exists('build-time-render')) {
-	has.add('build-time-render', false, false);
-}
-
-if (global.default.__public_path__) {
-	// @ts-ignore
-	__webpack_public_path__ = window.location.origin + global.default.__public_path__;
-	has.add('public-path', global.default.__public_path__, true);
+if (has.default('build-serve')) {
+	require('webpack-hot-middleware/client?reload=true');
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Split common bootstrap code into separate module, `common.js` and include the webpack-hot-middleware conditionally based on a has flag `build-serve` that will get injected when using the serve option in `@dojo/cli-build-app`.
