### PR TITLE
Ensure css is extracted from all css files

### DIFF
--- a/tests/support/fixtures/build-time-render/build-bridge/expected/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge/expected/index.html
@@ -1,8 +1,8 @@
 <html><head>
-		<style>span {
+	<style>span {
   width: 100%;
-}</style>
-	</head>
+}
+</style></head>
 	<body>
 		<div id="app"><div>hello world a</div></div>
 		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>

--- a/tests/support/fixtures/build-time-render/hash/expected/index.html
+++ b/tests/support/fixtures/build-time-render/hash/expected/index.html
@@ -1,11 +1,11 @@
 <html><head>
-		<style>.hello {
+	<style>.hello {
   background: red;
 }
 span {
   width: 100%;
-}</style>
-	</head>
+}
+</style></head>
 	<body>
 		<div id="app"><div class="hello">Hello</div></div>
 		<link rel="stylesheet" href="main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>

--- a/tests/support/fixtures/build-time-render/hash/expected/indexWithPaths.html
+++ b/tests/support/fixtures/build-time-render/hash/expected/indexWithPaths.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<style>
+	<style>
 .hello {
   background: red;
 }
@@ -9,8 +9,8 @@ span {
 }
 .other {
   color: pink;
-}</style>
-	</head>
+}
+</style></head>
 	<body>
 		<div id="app"></div>
 		<script>

--- a/tests/support/fixtures/build-time-render/state/main.js
+++ b/tests/support/fixtures/build-time-render/state/main.js
@@ -8,7 +8,7 @@
 		const imgThree = document.createElement('img');
 		const imgFour = document.createElement('img');
 		const imgFive = document.createElement('img');
-		div.classList.add('hello');
+		div.classList.add('hello', 'another');
 		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
 		app.appendChild(div);
 
@@ -34,7 +34,7 @@
 		app.removeChild(div);
 		if (window.location.pathname === '/my-path') {
 			div = document.createElement('div');
-			div.classList.add('hello');
+			div.classList.add('hello', 'another');
 			div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
 			app.appendChild(div);
 		} else if (window.location.pathname === '/my-path/other') {

--- a/tests/support/fixtures/build-time-render/state/manifest.json
+++ b/tests/support/fixtures/build-time-render/state/manifest.json
@@ -2,5 +2,6 @@
 	"main.js": "main.js",
 	"other.js": "other.js",
 	"main.css": "main.css",
+	"other.css": "other.css",
 	"runtime.js": "runtime.js"
 }

--- a/tests/support/fixtures/build-time-render/state/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state/my-path/index.html
@@ -1,14 +1,17 @@
 <html><head>
 		<link rel="manifest" href="../manifest.json" />
-		<style>.hello {
+	<style>.hello {
   background: red;
 }
 span {
   width: 100%;
-}</style>
-	</head>
+}
+.another {
+  background: red;
+}
+</style></head>
 	<body>
-		<div id="app"><div class="hello">{"staticFeatures":{"build-time-render":true}}</div></div>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}</div></div>
 		<script>
 window.__public_path__ = window.location.pathname.replace(/my-path(\/)?/, '');
 </script><link rel="stylesheet" href="../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>

--- a/tests/support/fixtures/build-time-render/state/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/my-path/other/index.html
@@ -1,6 +1,6 @@
 <html><head>
 		<link rel="manifest" href="../../manifest.json" />
-		<style>.other.another {
+	<style>.other.another {
   color: pink;
   background: url("../../relative.png");
   background: url("/root.png");
@@ -13,8 +13,8 @@
 }
 span {
   width: 100%;
-}</style>
-	</head>
+}
+</style></head>
 	<body>
 		<div id="app"><div class="other">Other</div></div>
 		<script>

--- a/tests/support/fixtures/build-time-render/state/other.css
+++ b/tests/support/fixtures/build-time-render/state/other.css
@@ -1,0 +1,3 @@
+.another {
+	background: red;
+}

--- a/tests/support/fixtures/build-time-render/state/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/other/index.html
@@ -1,14 +1,17 @@
 <html><head>
 		<link rel="manifest" href="../manifest.json" />
-		<style>.hello {
+	<style>.hello {
   background: red;
 }
 span {
   width: 100%;
-}</style>
-	</head>
+}
+.another {
+  background: red;
+}
+</style></head>
 	<body>
-		<div id="app"><div class="hello">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src=".././relative-image.svg"><img src="../../other-relative-image.svg"></div></div>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src=".././relative-image.svg"><img src="../../other-relative-image.svg"></div></div>
 		<script>
 window.__public_path__ = window.location.pathname.replace(/other(\/)?/, '');
 </script><link rel="stylesheet" href="../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Since the upgrade to webpack 4, css assets are generated for each chunk. Build time rendering should use all the available CSS assets when inlining the critical CSS.