### PR TITLE
Replace bfj-node4 with bfj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1326,13 +1326,14 @@
         "platform": "^1.3.3"
       }
     },
-    "bfj-node4": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bfj-node4/-/bfj-node4-5.2.0.tgz",
-      "integrity": "sha512-shYA6rXr1mlAzJT8R96TscvicMyV9GJTMDFRii9HlgxLXT7HD3aDfsEHkQzIHYghh4jLI3+oouXDHqI+pnR3zA==",
+    "bfj": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.1.tgz",
+      "integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
       "requires": {
         "bluebird": "^3.5.1",
         "check-types": "^7.3.0",
+        "hoopy": "^0.1.2",
         "tryer": "^1.0.0"
       }
     },
@@ -4480,6 +4481,11 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
+    },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "hosted-git-info": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@dojo/framework": "next",
     "acorn": "5.3.0",
     "acorn-dynamic-import": "3.0.0",
-    "bfj-node4": "5.2.0",
+    "bfj": "6.1.1",
     "chalk": "2.3.0",
     "commander": "2.13.0",
     "copy-webpack-plugin": "4.6.0",

--- a/src/webpack-bundle-analyzer/BundleAnalyzerPlugin.ts
+++ b/src/webpack-bundle-analyzer/BundleAnalyzerPlugin.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as mkdir from 'mkdirp';
 import * as viewer from './viewer';
 import { Compiler } from 'webpack';
-const bfj = require('bfj-node4');
+const bfj = require('bfj');
 
 export interface BundleAnalyzerOptions {
 	reportFilename: string;

--- a/src/webpack-bundle-analyzer/client/package-lock.json
+++ b/src/webpack-bundle-analyzer/client/package-lock.json
@@ -4269,7 +4269,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4290,12 +4291,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4310,17 +4313,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4437,7 +4443,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4449,6 +4456,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4463,6 +4471,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4470,12 +4479,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -4494,6 +4505,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4574,7 +4586,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4586,6 +4599,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4671,7 +4685,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4707,6 +4722,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4726,6 +4742,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4769,12 +4786,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The `bfj-node4` module is now deprecated. This PR uses the newer, maintained `bfj` module instead. This also removes the deprecated warning on install.

