### PR TITLE
Should not normalise the html output

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -88,7 +88,6 @@ export default class BuildTimeRender {
 
 		styles = await this._processCss(styles);
 		html = html.replace(`</head>`, `<style>${styles}</style></head>`);
-		html = html.replace(/^(\s*)(\r\n?|\n)/gm, '').trim();
 		html = html.replace(this._createScripts(path), `${script}${css}${this._createScripts(path)}`);
 		outputFileSync(join(this._output!, ...path.split('/'), 'index.html'), html);
 	}

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -80,7 +80,7 @@ describe('build-time-render', () => {
 				assert.isTrue(callbackStub.calledOnce);
 				const expected = readFileSync(path.join(outputPath, 'expected', 'index.html'), 'utf-8');
 				const actual = outputFileSync.firstCall.args[1];
-				assert.strictEqual(actual, expected.replace(/^(\s*)(\r\n?|\n)/gm, '').trim());
+				assert.strictEqual(normalise(actual), normalise(expected));
 			});
 		});
 
@@ -103,7 +103,7 @@ describe('build-time-render', () => {
 				assert.isTrue(callbackStub.calledOnce);
 				const expected = readFileSync(path.join(outputPath, 'expected', 'index.html'), 'utf-8');
 				const actual = outputFileSync.firstCall.args[1];
-				assert.strictEqual(actual, expected.replace(/^(\s*)(\r\n?|\n)/gm, '').trim());
+				assert.strictEqual(normalise(actual), normalise(expected));
 			});
 		});
 
@@ -130,7 +130,7 @@ describe('build-time-render', () => {
 				assert.isTrue(callbackStub.calledOnce);
 				const expected = readFileSync(path.join(outputPath, 'expected', 'indexWithPaths.html'), 'utf-8');
 				const actual = outputFileSync.firstCall.args[1];
-				assert.strictEqual(actual, expected.replace(/^(\s*)(\r\n?|\n)/gm, '').trim());
+				assert.strictEqual(normalise(actual), normalise(expected));
 			});
 		});
 
@@ -242,15 +242,15 @@ describe('build-time-render', () => {
 						) > -1
 				);
 				assert.strictEqual(
-					outputFileSync.secondCall.args[1],
+					normalise(outputFileSync.secondCall.args[1]),
 					normalise(readFileSync(outputFileSync.getCall(1).args[0], 'utf8'))
 				);
 				assert.strictEqual(
-					outputFileSync.thirdCall.args[1],
+					normalise(outputFileSync.thirdCall.args[1]),
 					normalise(readFileSync(outputFileSync.getCall(2).args[0], 'utf8'))
 				);
 				assert.strictEqual(
-					outputFileSync.getCall(3).args[1],
+					normalise(outputFileSync.getCall(3).args[1]),
 					normalise(readFileSync(outputFileSync.getCall(3).args[0], 'utf8'))
 				);
 			});
@@ -307,15 +307,15 @@ describe('build-time-render', () => {
 						) > -1
 				);
 				assert.strictEqual(
-					outputFileSync.secondCall.args[1],
+					normalise(outputFileSync.secondCall.args[1]),
 					normalise(readFileSync(outputFileSync.getCall(1).args[0], 'utf8'))
 				);
 				assert.strictEqual(
-					outputFileSync.thirdCall.args[1],
+					normalise(outputFileSync.thirdCall.args[1]),
 					normalise(readFileSync(outputFileSync.getCall(2).args[0], 'utf8'))
 				);
 				assert.strictEqual(
-					outputFileSync.getCall(3).args[1],
+					normalise(outputFileSync.getCall(3).args[1]),
 					normalise(readFileSync(outputFileSync.getCall(3).args[0], 'utf8'))
 				);
 			});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Do not strip newlines from the html output as it can affect the rendered view.

Resolves #108 
