### PR TITLE
Emit All Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository contains all of the custom Webpack [plugins](https://webpack.js.
 - [Plugins](#plugins)
 	- [build-time-render](#build-time-render)
 	- [css-module-plugin](#css-module-plugin)
+	- [emit-all-plugin](#emit-all-plugin)
 	- [external-loader-plugin](#external-loader-plugin)
 	- [i18n-plugin](#i18n-plugin)
 	- [service-worker-plugin](#service-worker-plugin)
@@ -308,6 +309,19 @@ The plugin constructor accepts a single argument:
 | Property | Type | Optional | Description |
 | -------- | ---- | -------- | ----------- |
 | basePath | `string` | No | The root path from which to resolve CSS modules |
+
+## emit-all-plugin
+
+Webpack is a bundler, which does not work well when build libraries. Rather than create separate toolchains for building libraries and applications/custom elements, the existing build tooling can be used to emit library files by way of the `EmitAllPlugin`. At the very least CSS and transpiled TS files will be emitted, but additional assets can be included with a filter.
+
+The plugin takes an options object with the following properties:
+
+| Property | Type | Optional | Description |
+| -------- | ---- | -------- | ----------- |
+| basePath | `string` | Yes | The base path for the project's source files. Only files within this directory are emitted. Defaults to the project's `src/` directory. |
+| inlineSourceMaps | `boolean` | Yes | Specifies whether sources maps should be inlined with the output source files or emitted separately. Defaults to `false`. |
+| legacy | `boolean` | Yes | Specifies whether TypeScript files should be transpiled to ES modules or to legacy JavaScript. Defaults to `false`. |
+| assetFilter | `Function` | Yes | Used to filter assets to only those that should be included in the output. Accepts the asset file path and the asset object. If the function returns `true`, the asset will be emitted; otherwise it will be excluded. |
 
 ## external-loader-plugin
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3996,7 +3996,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4014,11 +4015,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4031,15 +4034,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4142,7 +4148,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4152,6 +4159,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4164,17 +4172,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4191,6 +4202,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4263,7 +4275,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4273,6 +4286,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4348,7 +4362,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4378,6 +4393,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4395,6 +4411,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4433,11 +4450,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/emit-all-plugin/EmitAllPlugin.ts
+++ b/src/emit-all-plugin/EmitAllPlugin.ts
@@ -1,0 +1,111 @@
+import * as path from 'path';
+import * as webpack from 'webpack';
+import NormalModule = require('webpack/lib/NormalModule');
+
+export interface EmitAllPluginOptions {
+	assetFilter?: (key: string, asset: any) => boolean;
+	basePath?: string;
+	inlineSourceMaps?: boolean;
+	legacy?: boolean;
+}
+
+const createSource = (content: string) => ({
+	source: () => content,
+	size: () => Buffer.byteLength(content)
+});
+
+export default class EmitAllPlugin {
+	private assetFilter: (key: string, asset: any) => boolean;
+	private basePath: string;
+	private inlineSourceMaps: boolean;
+	private legacy: boolean;
+
+	constructor(options: EmitAllPluginOptions = {}) {
+		this.basePath = options.basePath || path.join(process.cwd(), 'src');
+		this.inlineSourceMaps = Boolean(options.inlineSourceMaps);
+		this.legacy = Boolean(options.legacy);
+		this.assetFilter = options.assetFilter || (() => true);
+	}
+
+	apply(compiler: webpack.Compiler) {
+		const { basePath, inlineSourceMaps, legacy } = this;
+		compiler.hooks.emit.tap(this.constructor.name, (compilation) => {
+			compilation.chunks = [];
+			Object.keys(compilation.assets).forEach((key) => {
+				if (!this.assetFilter(key, compilation.assets[key])) {
+					delete compilation.assets[key];
+				}
+			});
+			compilation.modules.forEach((module: NormalModule) => {
+				const { resource } = module;
+				if ((resource || '').includes(basePath)) {
+					const extension = legacy ? '.js' : '.mjs';
+					const source = module.originalSource().source();
+					const assetName = resource.replace(basePath, '').replace(/\.ts$/, extension);
+
+					if (assetName.includes('.css')) {
+						let imports: string[];
+
+						module.dependencies.forEach(({ identifier, content, sourceMap }: any) => {
+							if (identifier.includes(resource)) {
+								let css = content;
+								if (sourceMap) {
+									const { map, url } = this.normalizeSourceMap(
+										assetName,
+										sourceMap,
+										inlineSourceMaps
+									);
+									css += url;
+									if (!inlineSourceMaps) {
+										compilation.assets[assetName + '.map'] = createSource(JSON.stringify(map));
+									}
+								}
+
+								if (imports && imports.length) {
+									css = imports.join('') + '\n' + css;
+								}
+
+								compilation.assets[assetName] = createSource(css);
+
+								const cssjs = source.replace(/\s*\/\/[^\n]*\n/, '');
+								compilation.assets[assetName + '.js'] = createSource(cssjs);
+							}
+						});
+					} else {
+						const sourceMap = (module.originalSource() as any)._sourceMap;
+						let js = source;
+
+						if (sourceMap) {
+							const { map, url } = this.normalizeSourceMap(assetName, sourceMap, inlineSourceMaps);
+							js += url;
+
+							if (!inlineSourceMaps) {
+								compilation.assets[assetName + '.map'] = createSource(JSON.stringify(map));
+							}
+						}
+
+						compilation.assets[assetName] = createSource(js);
+					}
+				}
+			});
+		});
+	}
+
+	private normalizeSourceMap(assetName: string, sourceMap: any, inline = false) {
+		// The source map's `sources` will be absolute paths, leaking details about the system that
+		// generated it. Force the `sources` array to contain paths relative to the base path.
+		const fixedSourceMap = {
+			...sourceMap,
+			sources: Array.isArray(sourceMap.sources)
+				? sourceMap.sources.map((file: string) => path.relative(this.basePath, file))
+				: []
+		};
+		const url = inline
+			? `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
+					JSON.stringify(fixedSourceMap)
+			  ).toString('base64')}*/`
+			: `\n/*# sourceMappingURL=${assetName.split('/').pop()}.map*/`;
+
+		return { map: fixedSourceMap, url };
+	}
+}

--- a/src/emit-all-plugin/EmitAllPlugin.ts
+++ b/src/emit-all-plugin/EmitAllPlugin.ts
@@ -44,8 +44,6 @@ export default class EmitAllPlugin {
 					const assetName = resource.replace(basePath, '').replace(/\.ts$/, extension);
 
 					if (assetName.includes('.css')) {
-						let imports: string[];
-
 						module.dependencies.forEach(({ identifier, content, sourceMap }: any) => {
 							if (identifier.includes(resource)) {
 								let css = content;
@@ -59,10 +57,6 @@ export default class EmitAllPlugin {
 									if (!inlineSourceMaps) {
 										compilation.assets[assetName + '.map'] = createSource(JSON.stringify(map));
 									}
-								}
-
-								if (imports && imports.length) {
-									css = imports.join('') + '\n' + css;
 								}
 
 								compilation.assets[assetName] = createSource(css);
@@ -91,7 +85,7 @@ export default class EmitAllPlugin {
 		});
 	}
 
-	private normalizeSourceMap(assetName: string, sourceMap: any, inline = false) {
+	private normalizeSourceMap(assetName: string, sourceMap: any, inline: boolean) {
 		// The source map's `sources` will be absolute paths, leaking details about the system that
 		// generated it. Force the `sources` array to contain paths relative to the base path.
 		const fixedSourceMap = {

--- a/src/emit-all-plugin/EmitAllPlugin.ts
+++ b/src/emit-all-plugin/EmitAllPlugin.ts
@@ -1,3 +1,4 @@
+import * as cssnano from 'cssnano';
 import * as path from 'path';
 import * as webpack from 'webpack';
 import NormalModule = require('webpack/lib/NormalModule');
@@ -29,59 +30,58 @@ export default class EmitAllPlugin {
 
 	apply(compiler: webpack.Compiler) {
 		const { basePath, inlineSourceMaps, legacy } = this;
-		compiler.hooks.emit.tap(this.constructor.name, (compilation) => {
+		compiler.hooks.emit.tapAsync(this.constructor.name, async (compilation, callback) => {
 			compilation.chunks = [];
 			Object.keys(compilation.assets).forEach((key) => {
 				if (!this.assetFilter(key, compilation.assets[key])) {
 					delete compilation.assets[key];
 				}
 			});
-			compilation.modules.forEach((module: NormalModule) => {
-				const { resource } = module;
-				if ((resource || '').includes(basePath)) {
-					const extension = legacy ? '.js' : '.mjs';
-					const source = module.originalSource().source();
-					const assetName = resource.replace(basePath, '').replace(/\.ts$/, extension);
+			await Promise.all(
+				compilation.modules.map(async (module: NormalModule) => {
+					const { resource } = module;
+					if ((resource || '').includes(basePath)) {
+						const extension = legacy ? '.js' : '.mjs';
+						const source = module.originalSource().source();
+						const assetName = resource.replace(basePath, '').replace(/\.ts$/, extension);
 
-					if (assetName.includes('.css')) {
-						module.dependencies.forEach(({ identifier, content, sourceMap }: any) => {
-							if (identifier.includes(resource)) {
-								let css = content;
-								if (sourceMap) {
-									const { map, url } = this.normalizeSourceMap(
-										assetName,
-										sourceMap,
-										inlineSourceMaps
-									);
-									css += url;
-									if (!inlineSourceMaps) {
-										compilation.assets[assetName + '.map'] = createSource(JSON.stringify(map));
+						if (assetName.includes('.css')) {
+							await Promise.all(
+								module.dependencies.map(async ({ identifier, content, sourceMap }: any) => {
+									if (identifier.includes(resource)) {
+										const { css, map } = await this.processCssAsset(assetName, content, sourceMap);
+
+										if (sourceMap && !inlineSourceMaps) {
+											compilation.assets[assetName + '.map'] = createSource(JSON.stringify(map));
+										}
+
+										compilation.assets[assetName] = createSource(css);
+
+										const cssjs = source.replace(/\s*\/\/[^\n]*\n/, '');
+										compilation.assets[assetName + '.js'] = createSource(cssjs);
 									}
+								})
+							);
+						} else {
+							const sourceMap = (module.originalSource() as any)._sourceMap;
+							let js = source;
+
+							if (sourceMap) {
+								const { map, url } = this.normalizeSourceMap(assetName, sourceMap, inlineSourceMaps);
+								js += url;
+
+								if (!inlineSourceMaps) {
+									compilation.assets[assetName + '.map'] = createSource(JSON.stringify(map));
 								}
-
-								compilation.assets[assetName] = createSource(css);
-
-								const cssjs = source.replace(/\s*\/\/[^\n]*\n/, '');
-								compilation.assets[assetName + '.js'] = createSource(cssjs);
 							}
-						});
-					} else {
-						const sourceMap = (module.originalSource() as any)._sourceMap;
-						let js = source;
 
-						if (sourceMap) {
-							const { map, url } = this.normalizeSourceMap(assetName, sourceMap, inlineSourceMaps);
-							js += url;
-
-							if (!inlineSourceMaps) {
-								compilation.assets[assetName + '.map'] = createSource(JSON.stringify(map));
-							}
+							compilation.assets[assetName] = createSource(js);
 						}
-
-						compilation.assets[assetName] = createSource(js);
 					}
-				}
-			});
+				})
+			);
+
+			callback();
 		});
 	}
 
@@ -101,5 +101,32 @@ export default class EmitAllPlugin {
 			: `\n/*# sourceMappingURL=${assetName.split('/').pop()}.map*/`;
 
 		return { map: fixedSourceMap, url };
+	}
+
+	private async processCssAsset(
+		assetName: string,
+		content: string,
+		sourceMap: any
+	): Promise<{ css: string; map?: any }> {
+		let { css } = await (cssnano as any).process(
+			content,
+			{
+				from: assetName,
+				to: assetName
+			},
+			{
+				preset: ['default', { calc: false }]
+			}
+		);
+
+		if (sourceMap) {
+			const { inlineSourceMaps } = this;
+			const { map, url } = this.normalizeSourceMap(assetName, sourceMap, inlineSourceMaps);
+			css += url;
+
+			return { css, map };
+		}
+
+		return { css };
 	}
 }

--- a/src/typings/webpack-lib.d.ts
+++ b/src/typings/webpack-lib.d.ts
@@ -100,6 +100,7 @@ declare module 'webpack/lib/Module' {
 
 declare module 'webpack/lib/NormalModule' {
 	import Module = require('webpack/lib/Module');
+	import Source = require('webpack-sources/lib/Source');
 
 	interface NormalModuleParams {
 		type: string;
@@ -125,6 +126,8 @@ declare module 'webpack/lib/NormalModule' {
 		generator?: Function;
 
 		constructor(params: NormalModuleParams);
+
+		originalSource(): Source;
 	}
 
 	export = NormalModule;

--- a/src/webpack-bundle-analyzer/client/package-lock.json
+++ b/src/webpack-bundle-analyzer/client/package-lock.json
@@ -4269,7 +4269,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4290,12 +4291,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4310,17 +4313,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4437,7 +4443,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4449,6 +4456,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4463,6 +4471,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4470,12 +4479,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -4494,6 +4505,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4574,7 +4586,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4586,6 +4599,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4671,7 +4685,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4707,6 +4722,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4726,6 +4742,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4769,12 +4786,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,4 +1,5 @@
 import './main';
+import './emit-all-plugin/EmitAllPlugin';
 import './external-loader-plugin/ExternalLoaderPlugin';
 import './static-build-loader/all';
 import './css-module-decorator-loader/all';

--- a/tests/unit/emit-all-plugin/EmitAllPlugin.ts
+++ b/tests/unit/emit-all-plugin/EmitAllPlugin.ts
@@ -1,0 +1,452 @@
+import { Compiler } from 'webpack';
+import MockModule from '../../support/MockModule';
+import { createCompilation, createCompiler } from '../../support/util';
+
+const { assert } = intern.getPlugin('chai');
+const { afterEach, beforeEach, describe, it } = intern.getInterface('bdd');
+
+describe('EmitAllPlugin', () => {
+	let compiler: Compiler;
+	let mockModule: MockModule;
+
+	beforeEach(() => {
+		mockModule = new MockModule('../../../src/emit-all-plugin/EmitAllPlugin', require);
+		compiler = createCompiler();
+	});
+
+	afterEach(() => {
+		mockModule.destroy();
+	});
+
+	it('prevents webpack from emitting a bundle', () => {
+		const EmitAll = mockModule.getModuleUnderTest().default;
+		const emitAll = new EmitAll();
+		const compilation = createCompilation(compiler);
+
+		emitAll.apply(compiler);
+		compilation.chunks = [{}];
+		compiler.hooks.emit.callAsync(compilation, () => {});
+
+		assert.deepEqual(compilation.chunks, []);
+	});
+
+	it('prevents webpack from emitting assets based on a filter', () => {
+		const EmitAll = mockModule.getModuleUnderTest().default;
+		const emitAll = new EmitAll({
+			assetFilter: (key: string) => key !== 'foo'
+		});
+		const compilation = createCompilation(compiler);
+
+		compilation.assets = {
+			foo: {},
+			bar: {},
+			baz: {}
+		};
+		emitAll.apply(compiler);
+		compiler.hooks.emit.callAsync(compilation, () => {});
+
+		assert.deepEqual(compilation.assets, {
+			bar: {},
+			baz: {}
+		});
+	});
+
+	it('emits all assets by default', () => {
+		const EmitAll = mockModule.getModuleUnderTest().default;
+		const emitAll = new EmitAll();
+		const compilation = createCompilation(compiler);
+		const assets = {
+			foo: {},
+			bar: {},
+			baz: {}
+		};
+
+		compilation.assets = assets;
+		emitAll.apply(compiler);
+		compiler.hooks.emit.callAsync(compilation, () => {});
+
+		assert.deepEqual(compilation.assets, assets);
+	});
+
+	describe('JavaScript assets', () => {
+		it('outputs individual mjs files', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = 'module.exports = {}';
+			const jsModule = {
+				resource: 'src/dir/asset.ts',
+				originalSource: () => ({
+					source: () => source
+				})
+			};
+
+			compilation.modules = [jsModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const asset = compilation.assets['dir/asset.mjs'];
+			assert.isObject(asset);
+			assert.strictEqual(asset.source(), source);
+			assert.strictEqual(asset.size(), Buffer.byteLength(source));
+		});
+
+		it('outputs JS files with the `.js` extension in legacy mode', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/',
+				legacy: true
+			});
+			const compilation = createCompilation(compiler);
+			const source = 'module.exports = {}';
+			const jsModule = {
+				resource: 'src/dir/asset.ts',
+				originalSource: () => ({
+					source: () => source
+				})
+			};
+
+			compilation.modules = [jsModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const asset = compilation.assets['dir/asset.js'];
+			assert.isObject(asset);
+			assert.strictEqual(asset.source(), source);
+			assert.strictEqual(asset.size(), Buffer.byteLength(source));
+		});
+
+		it('excludes files outside the base path', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = 'module.exports = {}';
+			const jsModule = {
+				resource: 'other/dir/asset.ts',
+				originalSource: () => ({
+					source: () => source
+				})
+			};
+
+			compilation.modules = [jsModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			assert.deepEqual(Object.keys(compilation.assets), []);
+		});
+
+		it('ignores modules without a resource', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = 'module.exports = {}';
+			const jsModule = {
+				originalSource: () => ({
+					source: () => source
+				})
+			};
+
+			compilation.modules = [jsModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			assert.deepEqual(Object.keys(compilation.assets), []);
+		});
+
+		it('outputs JS sourcemaps', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = 'module.exports = {}';
+			const jsModule = {
+				resource: 'src/dir/asset.ts',
+				originalSource: () => ({
+					_sourceMap: { mappings: 'abcd' },
+					source: () => source
+				})
+			};
+
+			compilation.modules = [jsModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const asset = compilation.assets['dir/asset.mjs'];
+			const assetMap = compilation.assets['dir/asset.mjs.map'];
+			const assetMapSource = {
+				mappings: 'abcd',
+				sources: []
+			};
+			const assetMapSourceString = JSON.stringify(assetMapSource);
+			assert.isObject(assetMap);
+			assert.strictEqual(assetMap.source(), assetMapSourceString);
+			assert.strictEqual(assetMap.size(), Buffer.byteLength(assetMapSourceString));
+			assert.isTrue(asset.source().endsWith('\n/*# sourceMappingURL=asset.mjs.map*/'));
+		});
+
+		it('inlines JS sourcemaps with a flag', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/',
+				inlineSourceMaps: true
+			});
+			const compilation = createCompilation(compiler);
+			const source = 'module.exports = {}';
+			const sourceMap = { mappings: 'abcd', sources: [] };
+			const jsModule = {
+				resource: 'src/dir/asset.ts',
+				originalSource: () => ({
+					_sourceMap: sourceMap,
+					source: () => source
+				})
+			};
+
+			compilation.modules = [jsModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const asset = compilation.assets['dir/asset.mjs'];
+			const sourceMapUrl = `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
+				JSON.stringify(sourceMap)
+			).toString('base64')}*/`;
+			assert.isTrue(asset.source().endsWith(sourceMapUrl));
+			assert.isUndefined(compilation.assets['dir/asset.mjs.map']);
+		});
+
+		it('removes the base path from the source map sources', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = 'module.exports = {}';
+			const sourceMap = {
+				mappings: 'abcd',
+				sources: ['src/dir/asset.ts']
+			};
+			const jsModule = {
+				resource: 'src/dir/asset.ts',
+				originalSource: () => ({
+					_sourceMap: sourceMap,
+					source: () => source
+				})
+			};
+
+			compilation.modules = [jsModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const assetMap = compilation.assets['dir/asset.mjs.map'];
+			const assetMapSource = {
+				mappings: 'abcd',
+				sources: ['dir/asset.ts']
+			};
+			const assetMapSourceString = JSON.stringify(assetMapSource);
+			assert.strictEqual(assetMap.source(), assetMapSourceString);
+		});
+	});
+
+	describe('CSS assets', () => {
+		it('outputs individual CSS files', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = '.root {}';
+			const cssModule = {
+				resource: 'src/dir/styles.css',
+				originalSource: () => ({
+					source: () => source
+				}),
+				dependencies: [
+					{
+						content: source,
+						identifier: 'src/dir/styles.css'
+					}
+				]
+			};
+
+			compilation.modules = [cssModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const asset = compilation.assets['dir/styles.css'];
+			assert.isObject(asset);
+			assert.strictEqual(asset.source(), source);
+			assert.strictEqual(asset.size(), Buffer.byteLength(source));
+		});
+
+		it('excludes files outside the base path', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = '.root {}';
+			const cssModule = {
+				resource: 'other/dir/styles.css',
+				originalSource: () => ({
+					source: () => source
+				}),
+				dependencies: [
+					{
+						content: source,
+						identifier: 'other/dir/styles.css'
+					}
+				]
+			};
+
+			compilation.modules = [cssModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			assert.deepEqual(Object.keys(compilation.assets), []);
+		});
+
+		it('ignores dependencies with a mismatched identifier', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = '.root {}';
+			const cssModule = {
+				resource: 'src/dir/styles.css',
+				originalSource: () => ({
+					source: () => source
+				}),
+				dependencies: [
+					{
+						content: source,
+						identifier: 'src/other/asset.css'
+					}
+				]
+			};
+
+			compilation.modules = [cssModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			assert.deepEqual(Object.keys(compilation.assets), []);
+		});
+
+		it('outputs CSS sourcemaps', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = '.root {}';
+			const cssModule = {
+				resource: 'src/dir/styles.css',
+				originalSource: () => ({
+					source: () => source
+				}),
+				dependencies: [
+					{
+						content: source,
+						identifier: 'src/dir/styles.css',
+						sourceMap: { mappings: 'abcd' }
+					}
+				]
+			};
+
+			compilation.modules = [cssModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const asset = compilation.assets['dir/styles.css'];
+			const assetMap = compilation.assets['dir/styles.css.map'];
+			const assetMapSource = {
+				mappings: 'abcd',
+				sources: []
+			};
+			const assetMapSourceString = JSON.stringify(assetMapSource);
+			assert.isObject(assetMap);
+			assert.strictEqual(assetMap.source(), assetMapSourceString);
+			assert.strictEqual(assetMap.size(), Buffer.byteLength(assetMapSourceString));
+			assert.isTrue(asset.source().endsWith('\n/*# sourceMappingURL=styles.css.map*/'));
+		});
+
+		it('inlines CSS sourcemaps with a flag', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/',
+				inlineSourceMaps: true
+			});
+			const compilation = createCompilation(compiler);
+			const source = `module.exports = {}`;
+			const sourceMap = { mappings: 'abcd', sources: [] };
+			const cssModule = {
+				resource: 'src/dir/styles.css',
+				originalSource: () => ({
+					source: () => source
+				}),
+				dependencies: [
+					{
+						content: source,
+						identifier: 'src/dir/styles.css',
+						sourceMap
+					}
+				]
+			};
+
+			compilation.modules = [cssModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const asset = compilation.assets['dir/styles.css'];
+			const sourceMapUrl = `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
+				JSON.stringify(sourceMap)
+			).toString('base64')}*/`;
+			assert.isTrue(asset.source().endsWith(sourceMapUrl));
+			assert.isUndefined(compilation.assets['dir/styles.css.map']);
+		});
+
+		it('removes the base path from the source map sources', () => {
+			const EmitAll = mockModule.getModuleUnderTest().default;
+			const emitAll = new EmitAll({
+				basePath: 'src/'
+			});
+			const compilation = createCompilation(compiler);
+			const source = `module.exports = {}`;
+			const sourceMap = {
+				mappings: 'abcd',
+				sources: ['src/dir/styles.css']
+			};
+			const cssModule = {
+				resource: 'src/dir/styles.css',
+				originalSource: () => ({
+					source: () => source
+				}),
+				dependencies: [
+					{
+						content: source,
+						identifier: 'src/dir/styles.css',
+						sourceMap
+					}
+				]
+			};
+
+			compilation.modules = [cssModule];
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			const assetMap = compilation.assets['dir/styles.css.map'];
+			const assetMapSource = {
+				mappings: 'abcd',
+				sources: ['dir/styles.css']
+			};
+			const assetMapSourceString = JSON.stringify(assetMapSource);
+			assert.strictEqual(assetMap.source(), assetMapSourceString);
+		});
+	});
+});

--- a/tests/unit/emit-all-plugin/EmitAllPlugin.ts
+++ b/tests/unit/emit-all-plugin/EmitAllPlugin.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { Compiler } from 'webpack';
 import MockModule from '../../support/MockModule';
 import { createCompilation, createCompiler } from '../../support/util';
@@ -246,7 +247,7 @@ describe('EmitAllPlugin', () => {
 			const assetMap = compilation.assets['dir/asset.mjs.map'];
 			const assetMapSource = {
 				mappings: 'abcd',
-				sources: ['dir/asset.ts']
+				sources: [path.relative('src/', 'src/dir/asset.ts')]
 			};
 			const assetMapSourceString = JSON.stringify(assetMapSource);
 			assert.strictEqual(assetMap.source(), assetMapSourceString);
@@ -443,7 +444,7 @@ describe('EmitAllPlugin', () => {
 			const assetMap = compilation.assets['dir/styles.css.map'];
 			const assetMapSource = {
 				mappings: 'abcd',
-				sources: ['dir/styles.css']
+				sources: [path.relative('src/', 'src/dir/styles.css')]
 			};
 			const assetMapSourceString = JSON.stringify(assetMapSource);
 			assert.strictEqual(assetMap.source(), assetMapSourceString);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Introduces an "emit as library" plugin that allows processed assets to be emitted as standalone files instead of as part of a compiled bundle.

Related to https://github.com/dojo/cli-build-widget/issues/35