### PR TITLE
Custom client for hot reloading

### DIFF
--- a/src/bootstrap-plugin/async.js
+++ b/src/bootstrap-plugin/async.js
@@ -5,7 +5,7 @@ require('./common');
 var modules = [];
 
 if (has.default('build-serve')) {
-	modules.push(import(/* webpackChunkName: "platform/client" */ 'webpack-hot-middleware/client?reload=true'));
+	modules.push(import(/* webpackChunkName: "platform/client" */ '../webpack-hot-client/client'));
 }
 
 // @ts-ignore

--- a/src/bootstrap-plugin/sync.js
+++ b/src/bootstrap-plugin/sync.js
@@ -2,5 +2,5 @@ var has = require('@dojo/framework/has/has');
 require('./common');
 
 if (has.default('build-serve')) {
-	require('webpack-hot-middleware/client?reload=true');
+	require('../webpack-hot-client/client');
 }

--- a/src/webpack-hot-client/client.js
+++ b/src/webpack-hot-client/client.js
@@ -7,7 +7,6 @@ var overlay = require('webpack-hot-middleware/client-overlay')({
 });
 
 var TIMEOUT = 20 * 1000;
-var PATH = '/__webpack_hmr';
 
 connect();
 
@@ -24,7 +23,7 @@ function EventSourceWrapper() {
 	}, TIMEOUT / 2);
 
 	function init() {
-		source = new global.EventSource(PATH);
+		source = new global.EventSource('/__webpack_hmr');
 		source.onopen = handleOnline;
 		source.onerror = handleDisconnect;
 		source.onmessage = handleMessage;
@@ -62,10 +61,10 @@ function EventSourceWrapper() {
 function getEventSourceWrapper() {
 	if (!global.__whmEventSourceWrapper) {
 		global.__whmEventSourceWrapper = {
-			[PATH]: EventSourceWrapper()
+			'/__webpack_hmr': EventSourceWrapper()
 		};
 	}
-	return global.__whmEventSourceWrapper[PATH];
+	return global.__whmEventSourceWrapper['/__webpack_hmr'];
 }
 
 function connect() {
@@ -147,7 +146,7 @@ function processMessage(obj) {
 			reporter.cleanProblemsCache();
 		}
 		if (applyUpdate) {
-			if (!buildHash || buildHash !== obj.hash) {
+			if (buildHash && buildHash !== obj.hash) {
 				global.location.reload();
 			}
 		}

--- a/src/webpack-hot-client/client.js
+++ b/src/webpack-hot-client/client.js
@@ -1,0 +1,156 @@
+var global = require('@dojo/framework/shim/global').default;
+var strip = require('strip-ansi');
+
+var overlay = require('webpack-hot-middleware/client-overlay')({
+	ansiColors: {},
+	overlayStyles: {}
+});
+
+var TIMEOUT = 20 * 1000;
+var PATH = '/__webpack_hmr';
+
+connect();
+
+function EventSourceWrapper() {
+	var source;
+	var lastActivity = Date.now();
+	var listeners = [];
+
+	init();
+	var timer = setInterval(function () {
+		if ((Date.now() - lastActivity) > TIMEOUT) {
+			handleDisconnect();
+		}
+	}, TIMEOUT / 2);
+
+	function init() {
+		source = new global.EventSource(PATH);
+		source.onopen = handleOnline;
+		source.onerror = handleDisconnect;
+		source.onmessage = handleMessage;
+	}
+
+	function handleOnline() {
+		console.log('[HMR] connected');
+		lastActivity = Date.now();
+	}
+
+	function handleMessage(event) {
+		lastActivity = Date.now();
+		for (var i = 0; i < listeners.length; i++) {
+			listeners[i](event);
+		}
+	}
+
+	function handleDisconnect() {
+		clearInterval(timer);
+		source.close();
+		setTimeout(init, TIMEOUT);
+	}
+
+	return {
+		addMessageListener: function(fn) {
+			listeners.push(fn);
+		},
+		disconnect: function() {
+			clearInterval(timer);
+			source.close();
+		}
+	};
+}
+
+function getEventSourceWrapper() {
+	if (!global.__whmEventSourceWrapper) {
+		global.__whmEventSourceWrapper = {
+			[PATH]: EventSourceWrapper()
+		};
+	}
+	return global.__whmEventSourceWrapper[PATH];
+}
+
+function connect() {
+	getEventSourceWrapper().addMessageListener(handleMessage);
+
+	function handleMessage(event) {
+		if (event.data === '\uD83D\uDC93') {
+			return;
+		}
+		try {
+			processMessage(JSON.parse(event.data));
+		} catch (ex) {
+			console.warn('Invalid HMR message: ' + event.data + '\n' + ex);
+		}
+	}
+}
+
+var styles = {
+	errors: 'color: #ff0000;',
+	warnings: 'color: #999933;'
+};
+
+var previousProblems = null;
+
+function log(type, obj) {
+	var newProblems = obj[type].map(function (msg) { return strip(msg); }).join('\n');
+	if (previousProblems === newProblems) {
+		return;
+	}
+
+	previousProblems = newProblems;
+
+	var style = styles[type];
+	var name = obj.name ? obj.name + ' ' : '';
+	var title = '[HMR] bundle ' + name + 'has ' + obj[type].length + type;
+	if (console.group && console.groupEnd) {
+		console.group('%c' + title, style);
+		console.log('%c' + newProblems, style);
+		console.groupEnd();
+	} else {
+		console.log(
+			'%c' + title + '\n\t%c' + newProblems.replace(/\n/g, '\n\t'),
+			style + 'font-weight: bold;',
+			style + 'font-weight: normal;'
+		);
+	}
+}
+
+var reporter = {
+	cleanProblemsCache: function() {
+		previousProblems = null;
+	},
+	problems: function(type, obj) {
+		log(type, obj);
+		if (type === 'errors') {
+			overlay.showProblems(type, obj[type]);
+		}
+	},
+	success: function() {
+		if (overlay && previousProblems) {
+			overlay.clear();
+		}
+	}
+};
+
+var buildHash = null;
+
+function processMessage(obj) {
+	if (obj.action === 'built' || obj.action === 'sync') {
+		var applyUpdate = true;
+		if (obj.errors.length > 0) {
+			reporter.problems('errors', obj);
+			applyUpdate = false;
+		} else {
+			if (obj.warnings.length > 0) {
+				reporter.problems('warnings', obj);
+			}
+			reporter.success();
+			reporter.cleanProblemsCache();
+		}
+		if (applyUpdate) {
+			if (!buildHash || buildHash !== obj.hash) {
+				global.location.reload();
+			}
+		}
+		buildHash = obj.hash;
+	}
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -17,3 +17,4 @@ import './istanbul-loader/all';
 import './webpack-bundle-analyzer/parseUtils';
 import './webpack-bundle-analyzer/analyzer';
 import './webpack-bundle-analyzer/viewer';
+import './webpack-hot-client/client';

--- a/tests/unit/webpack-hot-client/client.ts
+++ b/tests/unit/webpack-hot-client/client.ts
@@ -1,0 +1,176 @@
+const { afterEach, before, describe, it, after } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import MockModule from '../../support/MockModule';
+import global from '@dojo/framework/shim/global';
+import * as sinon from 'sinon';
+
+let mockModule: MockModule;
+let source: EventSource;
+let consoleStub: sinon.SinonStub;
+let consoleWarnStub: sinon.SinonStub;
+
+class EventSource {
+	public onopen: any;
+	public onerror: any;
+	public onmessage: any;
+	public close: any = sinon.stub();
+
+	constructor() {
+		source = this;
+	}
+}
+
+global.EventSource = EventSource;
+global.location = {
+	reload: sinon.stub()
+};
+
+describe('client', () => {
+	const overlayMock = {
+		showProblems: sinon.stub(),
+		clear: sinon.stub()
+	};
+
+	before(() => {
+		consoleStub = sinon.stub(console, 'log');
+		consoleWarnStub = sinon.stub(console, 'warn');
+		mockModule = new MockModule('../../../src/webpack-hot-client/client', require);
+		mockModule.proxy('webpack-hot-middleware/client-overlay', () => {
+			return overlayMock;
+		});
+		mockModule.getModuleUnderTest();
+	});
+
+	afterEach(() => {
+		consoleStub.reset();
+		consoleWarnStub.reset();
+		overlayMock.clear.reset();
+		overlayMock.showProblems.reset();
+	});
+
+	after(() => {
+		global.__whmEventSourceWrapper['/__webpack_hmr'].disconnect();
+		consoleStub.restore();
+		consoleWarnStub.restore();
+	});
+
+	it('Warns for an invalid message', () => {
+		source.onmessage({ data: '{ kjnaskjnakjdn": ' });
+		assert.isTrue(
+			consoleWarnStub.calledWith(
+				'Invalid HMR message: { kjnaskjnakjdn": \nSyntaxError: Unexpected token k in JSON at position 2'
+			)
+		);
+	});
+
+	it('Reloads window when built with no errors', () => {
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'built',
+				errors: [],
+				warnings: [],
+				hash: 'hash'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledOnce);
+
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'built',
+				errors: [],
+				warnings: [],
+				hash: 'hash'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledOnce);
+
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'sync',
+				errors: [],
+				warnings: [],
+				hash: 'hash-1'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledTwice);
+
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'sync',
+				errors: [],
+				warnings: [],
+				hash: 'hash-1'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledTwice);
+
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'sync',
+				errors: ['error'],
+				warnings: [],
+				hash: 'hash-1'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledTwice);
+		assert.isTrue(overlayMock.showProblems.calledOnce);
+		assert.isTrue(overlayMock.clear.notCalled);
+
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'sync',
+				errors: ['error'],
+				warnings: [],
+				hash: 'hash-1'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledTwice);
+		assert.isTrue(overlayMock.showProblems.calledTwice);
+		assert.isTrue(overlayMock.clear.notCalled);
+
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'sync',
+				errors: [],
+				warnings: [],
+				hash: 'hash-2'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledThrice);
+		assert.isTrue(overlayMock.showProblems.calledTwice);
+		assert.isTrue(overlayMock.clear.calledOnce);
+
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'other',
+				errors: [],
+				warnings: [],
+				hash: 'hash-3'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledThrice);
+		assert.isTrue(overlayMock.showProblems.calledTwice);
+		assert.isTrue(overlayMock.clear.calledOnce);
+
+		source.onmessage({
+			data: JSON.stringify({
+				action: 'sync',
+				errors: [],
+				warnings: ['warning'],
+				hash: 'hash-3'
+			})
+		});
+
+		assert.strictEqual(global.location.reload.callCount, 4);
+		assert.isTrue(overlayMock.showProblems.calledTwice);
+		assert.isTrue(overlayMock.clear.calledTwice);
+	});
+});

--- a/tests/unit/webpack-hot-client/client.ts
+++ b/tests/unit/webpack-hot-client/client.ts
@@ -66,6 +66,15 @@ describe('client', () => {
 	it('Reloads window when built with no errors', () => {
 		source.onmessage({
 			data: JSON.stringify({
+				action: 'sync',
+				errors: [],
+				warnings: [],
+				hash: 'first'
+			})
+		});
+
+		source.onmessage({
+			data: JSON.stringify({
 				action: 'built',
 				errors: [],
 				warnings: [],


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The `client` from `webpack-hot-client` requires using the `HotModuleReplacementPlugin` as it deals with more complex scenarios than we support in dojo, such as reloading a single module. For dojo we only support an automatic reload of the page.

The `HotModuleReplacementPlugin` also modifies the bundle to support this which is not needed in the dojo build.

Adding a custom `client` that only deals with processing messages and either reloading the page or displaying the error overlay (still using the overlay from `webpack-hot-client` for the moment) and removes the requirement to use the `HotModuleReplacementPlugin` meaning that the bundles are not affected and are the same regardless of whether built with `watch/serve` or a standard build.
