### PR TITLE
Split public path option into public origin and public path

### DIFF
--- a/src/bootstrap-plugin/common.js
+++ b/src/bootstrap-plugin/common.js
@@ -10,7 +10,10 @@ if (!has.exists('build-serve')) {
 }
 
 if (global.default.__public_path__) {
-	// @ts-ignore
-	__webpack_public_path__ = window.location.origin + global.default.__public_path__;
+	if (/^http(s)?:\/\//.test(global.default.__public_path__)) {
+		__webpack_public_path__ = global.default.__public_path__;
+	} else {
+		__webpack_public_path__ = window.location.origin + global.default.__public_path__;
+	}
 	has.add('public-path', global.default.__public_path__, true);
 }

--- a/src/bootstrap-plugin/common.js
+++ b/src/bootstrap-plugin/common.js
@@ -9,11 +9,12 @@ if (!has.exists('build-serve')) {
 	has.add('build-serve', false, false);
 }
 
-if (global.default.__public_path__) {
-	if (/^http(s)?:\/\//.test(global.default.__public_path__)) {
-		__webpack_public_path__ = global.default.__public_path__;
-	} else {
-		__webpack_public_path__ = window.location.origin + global.default.__public_path__;
+if (global.default.__public_path__ || global.default.__public_origin__) {
+	var origin = global.default.__public_origin__ || window.location.origin;
+	var publicPath = origin;
+	if (global.default.__public_path__) {
+		publicPath = origin + global.default.__public_path__;
+		has.add('public-path', global.default.__public_path__, true);
 	}
-	has.add('public-path', global.default.__public_path__, true);
+	__webpack_public_path__ = publicPath;
 }

--- a/src/bootstrap-plugin/common.js
+++ b/src/bootstrap-plugin/common.js
@@ -10,8 +10,7 @@ if (!has.exists('build-serve')) {
 }
 
 if (global.default.__public_path__ || global.default.__public_origin__) {
-	var origin = global.default.__public_origin__ || window.location.origin;
-	var publicPath = origin;
+	var publicPath = global.default.__public_origin__ || window.location.origin;
 	if (global.default.__public_path__) {
 		publicPath = origin + global.default.__public_path__;
 		has.add('public-path', global.default.__public_path__, true);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Splits the functionality of setting `window.__public_path__` into two options `__public_origin__` and `__public_path__`. This enables flexibility that allows consumers to set origins that differ to the applications origin. If `__public_origin__` is not set it will use `window.location.origin` by default.

`__public_path__` is appended to the origin (either default or specified) and then set as the webpack public_path for loading assets, the `__public_path__`.