### PR TITLE
Adds support for `fetch` in BootstrapPlugin

### DIFF
--- a/src/bootstrap-plugin/BootstrapPlugin.ts
+++ b/src/bootstrap-plugin/BootstrapPlugin.ts
@@ -22,7 +22,8 @@ export class BootstrapPlugin {
 	private _defineConfiguration: { [index: string]: string } = {
 		__dojoframeworkshimIntersectionObserver: JSON.stringify('no-bootstrap'),
 		__dojoframeworkshimWebAnimations: JSON.stringify('no-bootstrap'),
-		__dojoframeworkshimResizeObserver: JSON.stringify('no-bootstrap')
+		__dojoframeworkshimResizeObserver: JSON.stringify('no-bootstrap'),
+		__dojoframeworkshimFetch: JSON.stringify('no-bootstrap')
 	};
 
 	constructor(options: BootstrapPluginOptions) {

--- a/src/bootstrap-plugin/async.js
+++ b/src/bootstrap-plugin/async.js
@@ -8,19 +8,20 @@ if (has.default('build-serve')) {
 	modules.push(import(/* webpackChunkName: "platform/client" */ '../webpack-hot-client/client'));
 }
 
-// @ts-ignore
 if (has.default(__dojoframeworkshimIntersectionObserver) && !has.default('dom-intersection-observer')) {
 	modules.push(
 		import(/* webpackChunkName: "platform/IntersectionObserver" */ '@dojo/framework/shim/IntersectionObserver')
 	);
 }
 
-// @ts-ignore
+if (has.default(__dojoframeworkshimFetch) && !has.default('fetch')) {
+	modules.push(import(/* webpackChunkName: "platform/fetch" */ '@dojo/framework/shim/fetch'));
+}
+
 if (has.default(__dojoframeworkshimWebAnimations) && !has.default('dom-webanimation')) {
 	modules.push(import(/* webpackChunkName: "platform/WebAnimations" */ '@dojo/framework/shim/WebAnimations'));
 }
 
-// @ts-ignore
 if (has.default(__dojoframeworkshimResizeObserver) && !has.default('dom-resize-observer')) {
 	modules.push(import(/* webpackChunkName: "platform/ResizeObserver" */ '@dojo/framework/shim/ResizeObserver'));
 }
@@ -30,6 +31,5 @@ if (!has.default('dom-pointer-events')) {
 }
 
 Promise.all(modules).then(function() {
-	// @ts-ignore
 	import(/* webpackChunkName: "main" */ __MAIN_ENTRY);
 });

--- a/tests/unit/bootstrap-plugin/BootstrapPlugin.ts
+++ b/tests/unit/bootstrap-plugin/BootstrapPlugin.ts
@@ -120,6 +120,7 @@ window.DojoHasEnvironment = { staticFeatures: shimFeatures };`
 			__dojoframeworkshimIntersectionObserver: '"no-bootstrap"',
 			__dojoframeworkshimWebAnimations: '"no-bootstrap"',
 			__dojoframeworkshimResizeObserver: '"no-bootstrap"',
+			__dojoframeworkshimFetch: '"no-bootstrap"',
 			__dojoframeworkshimFoo: '"foo"',
 			__dojoframeworkshimBar: '"bar"',
 			__dojoframeworkshimBaz: '"baz"'


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add support to include `fetch` as a platform bundle and conditionally load based on usage and browser capabilities.