### PR TITLE
Organise the info directory

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -362,7 +362,7 @@ export default class BuildTimeRender {
 				await Promise.all(renderResults.map((result) => this._writeIndexHtml(result)));
 				if (Object.keys(this._buildBridgeResult).length) {
 					outputFileSync(
-						join(this._output, '..', 'info', 'originalManifest.json'),
+						join(this._output, '..', 'info', 'manifest.original.json'),
 						compilation.assets['manifest.json'].source(),
 						'utf8'
 					);

--- a/src/webpack-bundle-analyzer/BundleAnalyzerPlugin.ts
+++ b/src/webpack-bundle-analyzer/BundleAnalyzerPlugin.ts
@@ -53,7 +53,7 @@ export default class BundleAnalyzerPlugin {
 		try {
 			const manifest = JSON.parse(fs.readFileSync(path.join(this.compiler.outputPath, 'manifest.json'), 'utf8'));
 			const originalManifest = JSON.parse(
-				fs.readFileSync(path.join(this._outputDirectory, 'originalManifest.json'), 'utf8')
+				fs.readFileSync(path.join(this._outputDirectory, 'manifest.original.json'), 'utf8')
 			);
 			let updatedStats = JSON.stringify(stats);
 			Object.keys(manifest).forEach((key) => {

--- a/src/webpack-bundle-analyzer/viewer.ts
+++ b/src/webpack-bundle-analyzer/viewer.ts
@@ -38,14 +38,17 @@ export function generateReportData(bundleStats: any, opts: Partial<ReportDataOpt
 
 	const reporterFiles = glob.sync(path.join(__dirname, 'reporter', '**', '*.*'));
 	reporterFiles.forEach((file) => {
-		fs.copySync(file, path.join(path.dirname(reportFilePath), `${path.parse(file).name}${path.parse(file).ext}`));
+		fs.copySync(
+			file,
+			path.join(path.dirname(reportFilePath), 'analyzer', `${path.parse(file).name}${path.parse(file).ext}`)
+		);
 	});
 	fs.writeFileSync(
-		path.join(path.dirname(reportFilePath), `bundleContent.js`),
+		path.join(path.dirname(reportFilePath), 'analyzer', 'bundleContent.js'),
 		`window.__bundleContent = ${JSON.stringify(bundleContent)}`
 	);
 	fs.writeFileSync(
-		path.join(path.dirname(reportFilePath), `bundleList.js`),
+		path.join(path.dirname(reportFilePath), 'analyzer', 'bundleList.js'),
 		`window.__bundleList = ${JSON.stringify(bundlesList)}`
 	);
 }

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -480,7 +480,7 @@ describe('build-time-render', () => {
 					if (filename.match(/main\..*\.bundle\.js\.map$/)) {
 						map = content;
 					}
-					if (filename.match(/originalManifest\.json$/)) {
+					if (filename.match(/manifest\.original\.json$/)) {
 						originalManifest = content;
 					}
 				});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Organise the `info` output directory. Always put the webpack-analzyer output into an `analyzer` directory based on the directory passed to the configuration.

Rename the `originalManifest.json` to `manifest.original.json`