### PR TITLE
Collect runtime errors from BTR

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -356,9 +356,15 @@ export default class BuildTimeRender {
 			const browser = await puppeteer.launch(this._puppeteerOptions);
 			const app = await serve(`${this._output}`);
 			try {
+				const reportError = (err: Error) => {
+					err.message = `BTR runtime ${err.message}`;
+					compilation.errors.push(err);
+				};
 				const screenshotDirectory = join(this._output, '..', 'info', 'screenshots');
 				ensureDirSync(screenshotDirectory);
 				const page = await browser.newPage();
+				page.on('error', reportError);
+				page.on('pageerror', reportError);
 				await setHasFlags(page);
 				await page.exposeFunction('__dojoBuildBridge', this._buildBridge.bind(this));
 				const wait = page.waitForNavigation({ waitUntil: 'networkidle0' });

--- a/tests/support/fixtures/build-time-render/build-bridge-error/main.js
+++ b/tests/support/fixtures/build-time-render/build-bridge-error/main.js
@@ -7,5 +7,6 @@
         div.innerHTML = result;
     });
     app.appendChild(div);
+	throw new Error('runtime error');
 })();
 //# sourceMappingURL=main.js.map

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -109,9 +109,8 @@ describe('build-time-render', () => {
 			return runBtr(compilation, callbackStub).then(() => {
 				assert.isTrue(callbackStub.calledOnce);
 				assert.lengthOf(compilation.errors, 1);
-				const error = compilation.errors.pop()!;
 				assert.strictEqual(
-					error.message,
+					compilation.errors[0].message,
 					'Failed to run build time rendering. Could not find DOM node with id: "missing" in src/index.html'
 				);
 			});
@@ -146,9 +145,12 @@ describe('build-time-render', () => {
 			const compilation = createCompilation('build-bridge-error');
 			return runBtr(compilation, callbackStub).then(() => {
 				assert.isTrue(callbackStub.calledOnce);
-				assert.lengthOf(compilation.errors, 1);
-				const error = compilation.errors.pop()!;
-				assert.strictEqual(error.message, 'Block error');
+				assert.lengthOf(compilation.errors, 2);
+				assert.include(
+					compilation.errors[0].message,
+					'BTR runtime Error: runtime error\n    at main (http://localhost'
+				);
+				assert.strictEqual(compilation.errors[1].message, 'Block error');
 			});
 		});
 
@@ -182,9 +184,12 @@ describe('build-time-render', () => {
 			const compilation = createCompilation('build-bridge-error');
 			return runBtr(compilation, callbackStub).then(() => {
 				assert.isTrue(callbackStub.calledOnce);
-				assert.lengthOf(compilation.errors, 1);
-				const error = compilation.errors.pop()!;
-				assert.strictEqual(error.message, 'Test Error');
+				assert.lengthOf(compilation.errors, 2);
+				assert.include(
+					compilation.errors[0].message,
+					'BTR runtime Error: runtime error\n    at main (http://localhost'
+				);
+				assert.strictEqual(compilation.errors[1].message, 'Test Error');
 			});
 		});
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Collect and report errors from the page during BTR.