### PR TITLE
Only add cache to modules that are loaded for page

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:static:dev": "cpx \"{src,tests}/**/*.{js.map,d.ts,html,md,json,js,css,txt}\" dist/dev && rimraf dist/dev/src/webpack-bundle-analyzer/client",
     "build:static:release": "cpx \"src/**/*.{js,d.ts,json}\" dist/release && rimraf dist/release/webpack-bundle-analyzer/client",
     "build:cjs": "tsc",
-    "build": "npm-run-all -s clean -p build:** -s dojo-package -s && rimraf src/webpack-bundle-analyzer/client/node_modules",
+    "build": "npm-run-all -s clean -p build:** -s webpack-bundle-analyzer -s dojo-package -s && rimraf src/webpack-bundle-analyzer/client/node_modules",
     "clean": "rimraf dist coverage && rimraf src/webpack-bundle-analyzer/client/node_modules",
     "dojo-package": "dojo-package",
     "dojo-release": "dojo-release",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:static:dev": "cpx \"{src,tests}/**/*.{js.map,d.ts,html,md,json,js,css,txt}\" dist/dev && rimraf dist/dev/src/webpack-bundle-analyzer/client",
     "build:static:release": "cpx \"src/**/*.{js,d.ts,json}\" dist/release && rimraf dist/release/webpack-bundle-analyzer/client",
     "build:cjs": "tsc",
-    "build": "npm-run-all -s clean -p build:** -s webpack-bundle-analyzer -s dojo-package -s && rimraf src/webpack-bundle-analyzer/client/node_modules",
+    "build": "npm-run-all -s clean -p build:** -s dojo-package -s && rimraf src/webpack-bundle-analyzer/client/node_modules",
     "clean": "rimraf dist coverage && rimraf src/webpack-bundle-analyzer/client/node_modules",
     "dojo-package": "dojo-package",
     "dojo-release": "dojo-release",

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -76,6 +76,13 @@ export async function getForSelector(page: any, selector: string) {
 	return page.$eval(selector, (element: Element) => element.outerHTML);
 }
 
+export async function getScriptSources(page: any, port: number): Promise<string[]> {
+	const scripts: string[] = await page.$$eval('script', (elements: HTMLScriptElement[]) =>
+		elements.map((element) => element.src)
+	);
+	return scripts.map((script) => script.replace(`http://localhost:${port}/`, ''));
+}
+
 export function generateRouteInjectionScript(html: string[], paths: any[], root: string): string {
 	return `<script>
 (function () {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Use the scripts that are loaded for the BTR page to determine where to add the build cache when the application contains one or more blocks.

Resolves #127 
