### PR TITLE
Clear the require cache before BTR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1859,6 +1859,22 @@
       "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.0.tgz",
       "integrity": "sha1-N76S2NGo5myO4S8TA+0xbYXY6zc="
     },
+    "clear-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-3.1.0.tgz",
+      "integrity": "sha512-YEe9OX62MYUMjw16Vf2txyzZ3x2ICXNOrjuZ+06MMhnx3fy7V121h9VA3M3bMTtDg8oEfQ2f/fLuhxrSLXS8uw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
+      }
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -7306,6 +7322,21 @@
         "cyclist": "~0.2.2",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "requires": {
+        "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+          "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw=="
+        }
       }
     },
     "parse-asn1": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "acorn-dynamic-import": "3.0.0",
     "bfj": "6.1.1",
     "chalk": "2.3.0",
+    "clear-module": "3.1.0",
     "commander": "2.13.0",
     "connect-history-api-fallback": "1.6.0",
     "copy-webpack-plugin": "4.6.0",

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -19,6 +19,7 @@ const webpack = require('webpack');
 const SourceNode = require('source-map').SourceNode;
 const SourceMapConsumer = require('source-map').SourceMapConsumer;
 const postcss = require('postcss');
+const clearModule = require('clear-module');
 const createHash = require('webpack/lib/util/createHash');
 import { parse } from 'node-html-parser';
 
@@ -372,6 +373,7 @@ export default class BuildTimeRender {
 				})
 				.map((key) => this._manifest[key]);
 
+			clearModule.all();
 			const browser = await puppeteer.launch(this._puppeteerOptions);
 			const app = await serve(`${this._output}`);
 			try {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Clears the node require cache before each run of BTR to ensure that the latest version of a module is loaded.

Resolves #135 
