### PR TITLE
Adding paths during BTR

### DIFF
--- a/tests/support/fixtures/build-time-render/build-bridge-path-async/bootstrap.js
+++ b/tests/support/fixtures/build-time-render/build-bridge-path-async/bootstrap.js
@@ -1,0 +1,1 @@
+(function runtime() {})();

--- a/tests/support/fixtures/build-time-render/build-bridge-path-async/expected/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-path-async/expected/index.html
@@ -1,0 +1,26 @@
+<html>
+	<head>
+	<style>span{width:100%}</style></head>
+	<body>
+		<div id="app"></div>
+		<script>
+(function () {
+	var paths = ["","foo"];
+	var html = ["<div id=\"app\"><div>hello world a</div></div>","<div id=\"app\"><div>hello world a</div></div>"];
+	var element = document.getElementById('app');
+	var target;
+	paths.some(function (path, i) {
+		var match = (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
+		if (match) {
+			target = html[i];
+		}
+		return match;
+	});
+	if (target && element) {
+		var frag = document.createRange().createContextualFragment(target);
+		element.parentNode.replaceChild(frag, element);
+	}
+}())
+</script><link rel="stylesheet" href="main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="bootstrap.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/build-bridge-path-async/foo.block.js
+++ b/tests/support/fixtures/build-time-render/build-bridge-path-async/foo.block.js
@@ -1,0 +1,12 @@
+let paths = [];
+module.exports = {
+	default(...args) {
+		return new Promise(resolve => {
+			paths.push('foo');
+			resolve(`hello world ${args[0]}`);
+		});
+	},
+	paths() {
+		return paths;
+	}
+}

--- a/tests/support/fixtures/build-time-render/build-bridge-path-async/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-path-async/index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="bootstrap.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/build-bridge-path-async/main.css
+++ b/tests/support/fixtures/build-time-render/build-bridge-path-async/main.css
@@ -1,0 +1,19 @@
+#root {
+	margin: 10px;
+}
+
+/* example comment */
+
+.hello {
+	background: red;
+}
+
+.other {
+	color: pink;
+}
+
+span {
+	width: 100%;
+}
+
+/*# sourceMappingURL=main.16469ae7e579bf3f6af50cbfcb734efa.bundle.css.map*/

--- a/tests/support/fixtures/build-time-render/build-bridge-path-async/main.js
+++ b/tests/support/fixtures/build-time-render/build-bridge-path-async/main.js
@@ -1,0 +1,11 @@
+"use strict";
+(function main() {
+    var app = document.getElementById('app');
+    var div = document.createElement('div');
+    /** @preserve dojoBuildBridgeCache 'foo.block' **/
+    window.__dojoBuildBridge('foo.block', ['a']).then(function (result) {
+        div.innerHTML = result;
+    });
+    app.appendChild(div);
+})();
+//# sourceMappingURL=main.js.map

--- a/tests/support/fixtures/build-time-render/build-bridge-path-async/manifest.json
+++ b/tests/support/fixtures/build-time-render/build-bridge-path-async/manifest.json
@@ -1,0 +1,6 @@
+{
+	"main.js": "main.js",
+	"main.css": "main.css",
+	"bootstrap.js": "bootstrap.js",
+	"index.html": "index.html"
+}

--- a/tests/support/fixtures/build-time-render/build-bridge-path/bootstrap.js
+++ b/tests/support/fixtures/build-time-render/build-bridge-path/bootstrap.js
@@ -1,0 +1,1 @@
+(function runtime() {})();

--- a/tests/support/fixtures/build-time-render/build-bridge-path/expected/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-path/expected/index.html
@@ -1,0 +1,26 @@
+<html>
+	<head>
+	<style>span{width:100%}</style></head>
+	<body>
+		<div id="app"></div>
+		<script>
+(function () {
+	var paths = ["","foo"];
+	var html = ["<div id=\"app\"><div>hello world a</div></div>","<div id=\"app\"><div>hello world a</div></div>"];
+	var element = document.getElementById('app');
+	var target;
+	paths.some(function (path, i) {
+		var match = (typeof path === 'string' && path === window.location.hash) || path && (typeof path === 'object' && path.match && new RegExp(path.match.join('|')).test(window.location.hash));
+		if (match) {
+			target = html[i];
+		}
+		return match;
+	});
+	if (target && element) {
+		var frag = document.createRange().createContextualFragment(target);
+		element.parentNode.replaceChild(frag, element);
+	}
+}())
+</script><link rel="stylesheet" href="main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="bootstrap.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/build-bridge-path/foo.block.js
+++ b/tests/support/fixtures/build-time-render/build-bridge-path/foo.block.js
@@ -1,0 +1,6 @@
+module.exports = {
+	default(...args) {
+		return `hello world ${args[0]}`;
+	},
+	paths: ['foo']
+}

--- a/tests/support/fixtures/build-time-render/build-bridge-path/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-path/index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="bootstrap.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/build-bridge-path/main.css
+++ b/tests/support/fixtures/build-time-render/build-bridge-path/main.css
@@ -1,0 +1,19 @@
+#root {
+	margin: 10px;
+}
+
+/* example comment */
+
+.hello {
+	background: red;
+}
+
+.other {
+	color: pink;
+}
+
+span {
+	width: 100%;
+}
+
+/*# sourceMappingURL=main.16469ae7e579bf3f6af50cbfcb734efa.bundle.css.map*/

--- a/tests/support/fixtures/build-time-render/build-bridge-path/main.js
+++ b/tests/support/fixtures/build-time-render/build-bridge-path/main.js
@@ -1,0 +1,11 @@
+"use strict";
+(function main() {
+    var app = document.getElementById('app');
+    var div = document.createElement('div');
+    /** @preserve dojoBuildBridgeCache 'foo.block' **/
+    window.__dojoBuildBridge('foo.block', ['a']).then(function (result) {
+        div.innerHTML = result;
+    });
+    app.appendChild(div);
+})();
+//# sourceMappingURL=main.js.map

--- a/tests/support/fixtures/build-time-render/build-bridge-path/manifest.json
+++ b/tests/support/fixtures/build-time-render/build-bridge-path/manifest.json
@@ -1,0 +1,6 @@
+{
+	"main.js": "main.js",
+	"main.css": "main.css",
+	"bootstrap.js": "bootstrap.js",
+	"index.html": "index.html"
+}


### PR DESCRIPTION
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
This adds a `paths` array or the results of a `paths` function from any blocks run during BTR, after the script is completed. It waits for a returned promise to be resolved. @matt-gadd  Is this along the lines of what you were thinking, or should these paths be discovered automatically somehow?
Resolves #134 