### PR TITLE
Create a new browser page for each route

### DIFF
--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -148,7 +148,6 @@ describe('build-time-render', () => {
 			const compilation = createCompilation('build-bridge-error');
 			return runBtr(compilation, callbackStub).then(() => {
 				assert.isTrue(callbackStub.calledOnce);
-				console.log(compilation.errors);
 				assert.lengthOf(compilation.errors, 2);
 				assert.strictEqual(compilation.errors[0].message, 'Block error');
 				assert.include(
@@ -191,7 +190,6 @@ describe('build-time-render', () => {
 			const compilation = createCompilation('build-bridge-error');
 			return runBtr(compilation, callbackStub).then(() => {
 				assert.isTrue(callbackStub.calledOnce);
-				console.log(compilation.errors);
 				assert.lengthOf(compilation.errors, 3);
 				assert.strictEqual(compilation.errors[0].message, 'Block error');
 				assert.include(

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -148,12 +148,13 @@ describe('build-time-render', () => {
 			const compilation = createCompilation('build-bridge-error');
 			return runBtr(compilation, callbackStub).then(() => {
 				assert.isTrue(callbackStub.calledOnce);
+				console.log(compilation.errors);
 				assert.lengthOf(compilation.errors, 2);
+				assert.strictEqual(compilation.errors[0].message, 'Block error');
 				assert.include(
-					compilation.errors[0].message,
+					compilation.errors[1].message,
 					'BTR runtime Error: runtime error\n    at main (http://localhost'
 				);
-				assert.strictEqual(compilation.errors[1].message, 'Block error');
 			});
 		});
 
@@ -190,12 +191,14 @@ describe('build-time-render', () => {
 			const compilation = createCompilation('build-bridge-error');
 			return runBtr(compilation, callbackStub).then(() => {
 				assert.isTrue(callbackStub.calledOnce);
-				assert.lengthOf(compilation.errors, 2);
+				console.log(compilation.errors);
+				assert.lengthOf(compilation.errors, 3);
+				assert.strictEqual(compilation.errors[0].message, 'Block error');
 				assert.include(
-					compilation.errors[0].message,
+					compilation.errors[1].message,
 					'BTR runtime Error: runtime error\n    at main (http://localhost'
 				);
-				assert.strictEqual(compilation.errors[1].message, 'Test Error');
+				assert.strictEqual(compilation.errors[2].message, 'Test Error');
 			});
 		});
 	});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Prevent BTR loading routes twice by creating a new page per route.

Resolves #151 
