### PR TITLE
Load HMR client relative to the application base

### DIFF
--- a/src/webpack-hot-client/client.js
+++ b/src/webpack-hot-client/client.js
@@ -1,5 +1,5 @@
 var global = require('@dojo/framework/shim/global').default;
-var has = require('@dojo/framework/has/has').default;
+var has = require('@dojo/framework/core/has').default;
 
 var ANSI_REGEX = /(?:(?:\u001b\[)|\u009b)(?:(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?[A-M|f-m])|\u001b[A-M]/g;
 

--- a/src/webpack-hot-client/client.js
+++ b/src/webpack-hot-client/client.js
@@ -1,4 +1,5 @@
 var global = require('@dojo/framework/shim/global').default;
+var has = require('@dojo/framework/has/has').default;
 
 var ANSI_REGEX = /(?:(?:\u001b\[)|\u009b)(?:(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?[A-M|f-m])|\u001b[A-M]/g;
 
@@ -28,7 +29,11 @@ function EventSourceWrapper() {
 	}, TIMEOUT / 2);
 
 	function init() {
-		source = new global.EventSource('/__webpack_hmr');
+		if (has('public-path')) {
+			source = new global.EventSource('.' + has('public-path') + '__webpack_hmr');
+		} else {
+			source = new global.EventSource('./__webpack_hmr');
+		}
 		source.onopen = handleOnline;
 		source.onerror = handleDisconnect;
 		source.onmessage = handleMessage;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support loading the HMR client relative to the application's base url. This works with hash based routing and history based routing when using BTR.

For application's using history routing without BTR, will need to set the `base` for the routing history (This is true when proxying when using cli-build-app's serve functionality already)

Resolves https://github.com/dojo/cli-build-app/issues/277
