### PR TITLE
Use the public origin instead of the global origin

### DIFF
--- a/src/bootstrap-plugin/common.js
+++ b/src/bootstrap-plugin/common.js
@@ -12,7 +12,7 @@ if (!has.exists('build-serve')) {
 if (global.default.__public_path__ || global.default.__public_origin__) {
 	var publicPath = global.default.__public_origin__ || window.location.origin;
 	if (global.default.__public_path__) {
-		publicPath = origin + global.default.__public_path__;
+		publicPath = publicPath + global.default.__public_path__;
 		has.add('public-path', global.default.__public_path__, true);
 	}
 	__webpack_public_path__ = publicPath;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Was incorrectly using the global `origin` which caused issues on IE11 but also should have been using the already calculated `publicPath` variable that conditionally uses `global.default.__public_origin__` or `window.location.origin`.

Resolves #156 
