### PR TITLE
Fixing file paths on windows

### DIFF
--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -40,7 +40,7 @@ export default function elementTransformer<T extends ts.Node>(
 			const classNode = node as ts.ClassDeclaration;
 
 			if (
-				customElementFilesIncludingDefaults.indexOf(node.getSourceFile().fileName) !== -1 &&
+				customElementFilesIncludingDefaults.indexOf(path.resolve(node.getSourceFile().fileName)) !== -1 &&
 				defaultExport &&
 				classSymbol &&
 				checker.getTypeOfSymbolAtLocation(defaultExport, node.getSourceFile()) ===

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -1,8 +1,12 @@
 import * as ts from 'typescript';
 import elementTransformer from '../../../src/element-transformer/ElementTransformer';
+import * as path from 'path';
 
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
+
+const actualPath = path.resolve('actual.ts');
+const expectedPath = path.resolve('expected.ts');
 
 describe('element-transformer', () => {
 	it('does not touch classes that are not the default export', () => {
@@ -13,11 +17,11 @@ describe('element-transformer', () => {
 		}`;
 		assertCompile(
 			{
-				'actual.ts': source,
-				'expected.ts': source
+				[actualPath]: source,
+				[expectedPath]: source
 			},
 			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: ['actual.ts'] })]
+				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
 			})
 		);
 	});
@@ -37,11 +41,11 @@ describe('element-transformer', () => {
 `;
 		assertCompile(
 			{
-				'actual.ts': source,
-				'expected.ts': expected
+				[actualPath]: source,
+				[expectedPath]: expected
 			},
 			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: ['actual.ts'] })]
+				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
 			})
 		);
 	});
@@ -64,11 +68,11 @@ describe('element-transformer', () => {
 	`;
 		assertCompile(
 			{
-				'actual.ts': source,
-				'expected.ts': expected
+				[actualPath]: source,
+				[expectedPath]: expected
 			},
 			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: ['actual.ts'] })]
+				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
 			})
 		);
 	});
@@ -90,8 +94,8 @@ describe('element-transformer', () => {
 	`;
 		assertCompile(
 			{
-				'actual.ts': source,
-				'expected.ts': expected
+				[actualPath]: source,
+				[expectedPath]: expected
 			},
 			(program) => ({
 				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [] })]
@@ -136,11 +140,11 @@ describe('element-transformer', () => {
 	`;
 		assertCompile(
 			{
-				'actual.ts': source,
-				'expected.ts': expected
+				[actualPath]: source,
+				[expectedPath]: expected
 			},
 			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: ['actual.ts'] })]
+				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
 			})
 		);
 	});
@@ -154,11 +158,11 @@ describe('element-transformer', () => {
 	`;
 		assertCompile(
 			{
-				'actual.ts': source,
-				'expected.ts': source
+				[actualPath]: source,
+				[expectedPath]: source
 			},
 			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: ['actual.ts'] })]
+				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
 			})
 		);
 	});
@@ -179,14 +183,14 @@ describe('element-transformer', () => {
 	`;
 		assertCompile(
 			{
-				'actual.ts': source,
-				'expected.ts': expected
+				[actualPath]: source,
+				[expectedPath]: expected
 			},
 			(program) => ({
 				before: [
 					elementTransformer(program, {
 						elementPrefix: 'widget',
-						customElementFiles: ['actual.ts']
+						customElementFiles: [actualPath]
 					})
 				]
 			})


### PR DESCRIPTION
**Type:** bug
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Fixes a bug in which the new element transformer doesn't recognize paths from Windows. This was occurring because we run the users' supplied files through `path.resolve` (because TS provides an absolute path), but TS is supplying paths with `/`, while `path.resolve` is supplying paths with `\`.

The easiest thing to do was run TS's files through `path.resolve` as well and normalize all the paths.
