### PR TITLE
Check the manifest key exists in the original manifest

### DIFF
--- a/src/webpack-bundle-analyzer/BundleAnalyzerPlugin.ts
+++ b/src/webpack-bundle-analyzer/BundleAnalyzerPlugin.ts
@@ -57,7 +57,9 @@ export default class BundleAnalyzerPlugin {
 			);
 			let updatedStats = JSON.stringify(stats);
 			Object.keys(manifest).forEach((key) => {
-				updatedStats = updatedStats.replace(new RegExp(originalManifest[key], 'g'), manifest[key]);
+				if (originalManifest[key]) {
+					updatedStats = updatedStats.replace(new RegExp(originalManifest[key], 'g'), manifest[key]);
+				}
 			});
 			return JSON.parse(updatedStats);
 		} catch (e) {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Check that an entry exists in the original manifest for the keys before attempting to do the replace.
