### PR TITLE
Do not conditionally load bundle for sync bootstrap

### DIFF
--- a/src/bootstrap-plugin/sync.js
+++ b/src/bootstrap-plugin/sync.js
@@ -5,6 +5,4 @@ if (has.default('build-serve')) {
 	require('../webpack-hot-client/client');
 }
 
-if (has.default(__dojoBuildBlocks)) {
-	require('../build-time-render/blocks');
-}
+require('../build-time-render/blocks');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The bootstrap plugin does not run when using the `sync` bootstrap module so cannot conditionally load modules.
