### PR TITLE
Add "static" option for BTR

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ The plugin takes an options object with the following properties:
 | paths | `string[]` or `{ path: string; match: string[] }` | Yes | An array of paths that will be matched against the URL hash, rendering the HTML associated with any matched path. If the path is a string, then it will be compared directly to `window.location.hash`. If the path is an object, then it should include a `path` string that will be used to resolve the HTML, and `match` string array that represents multiple paths that should trigger the `path` to be rendered. Defaults to an empty array ('[]'). |
 | root | `string` | Yes | The ID for the root HTML element. If falsy, then no HTML will be generated. Defaults to an emtpy string (`''`). |
 | useManifest | `boolean` | Yes | Determines whether a manifest file should be used to resolve the entries. Defaults to `false`. |
+| static | `boolean` | Yes | Removes js and css scripts tags from generated `index.html` files for truly static sites. Not compatible with hash routing. Defaults to `false`. |
 
 ### Usage
 

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -39,7 +39,7 @@ export interface BuildTimeRenderArguments {
 	useManifest?: boolean;
 	paths?: (BuildTimePath | string)[];
 	useHistory?: boolean;
-	static: boolean;
+	static?: boolean;
 	puppeteerOptions?: any;
 	basePath: string;
 }

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -39,6 +39,7 @@ export interface BuildTimeRenderArguments {
 	useManifest?: boolean;
 	paths?: (BuildTimePath | string)[];
 	useHistory?: boolean;
+	static: boolean;
 	puppeteerOptions?: any;
 	basePath: string;
 }
@@ -59,6 +60,7 @@ export default class BuildTimeRender {
 	private _output?: string;
 	private _jsonpName?: string;
 	private _paths: any[];
+	private _static = false;
 	private _puppeteerOptions: any;
 	private _root: string;
 	private _useHistory = false;
@@ -81,6 +83,9 @@ export default class BuildTimeRender {
 		this._root = root;
 		this._entries = entries.map((entry) => `${entry.replace('.js', '')}.js`);
 		this._useHistory = useHistory !== undefined ? useHistory : paths.length > 0 && !/^#.*/.test(initialPath);
+		if (this._useHistory) {
+			this._static = args.static || false;
+		}
 	}
 
 	private async _writeIndexHtml({ content, script, path = '', styles }: RenderResult) {
@@ -101,7 +106,11 @@ export default class BuildTimeRender {
 
 		styles = await this._processCss(styles);
 		html = html.replace(`</head>`, `<style>${styles}</style></head>`);
-		html = html.replace(this._createScripts(), `${script}${css}${this._createScripts(path)}`);
+		if (this._static) {
+			html = html.replace(this._createScripts(), '');
+		} else {
+			html = html.replace(this._createScripts(), `${script}${css}${this._createScripts(path)}`);
+		}
 		outputFileSync(join(this._output!, ...path.split('/'), 'index.html'), html);
 	}
 

--- a/tests/support/fixtures/build-time-render/state-static/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static/main.css
+++ b/tests/support/fixtures/build-time-render/state-static/main.css
@@ -1,0 +1,27 @@
+#root {
+	margin: 10px;
+}
+
+/* example comment */
+
+.hello {
+	background: red;
+}
+
+.other.another {
+	color: pink;
+	background: url("relative.png");
+	background: url("/root.png");
+	background: url("./relative.png");
+	background: url("../relative.png");
+	background: url("https://example.com");
+	background: url("http://example.com");
+	background: url(https://example.com);
+	background: url(http://example.com);
+}
+
+span {
+	width: 100%;
+}
+
+/*# sourceMappingURL=main.16469ae7e579bf3f6af50cbfcb734efa.bundle.css.map*/

--- a/tests/support/fixtures/build-time-render/state-static/main.js
+++ b/tests/support/fixtures/build-time-render/state-static/main.js
@@ -1,0 +1,47 @@
+(function main() {
+	const app = document.getElementById('app');
+	let div = document.createElement('div');
+	const route = window.location.pathname;
+
+	function renderDefault() {
+		const imgOne = document.createElement('img');
+		const imgTwo = document.createElement('img');
+		const imgThree = document.createElement('img');
+		const imgFour = document.createElement('img');
+		const imgFive = document.createElement('img');
+		div.classList.add('hello', 'another');
+		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
+		app.appendChild(div);
+
+		imgOne.setAttribute('src', 'https://example.com');
+		div.appendChild(imgOne);
+
+		imgTwo.setAttribute('src', 'http://example.com');
+		div.appendChild(imgTwo);
+
+		imgThree.setAttribute('src', '/image.svg');
+		div.appendChild(imgThree);
+
+		imgFour.setAttribute('src', './relative-image.svg');
+		div.appendChild(imgFour);
+
+		imgFive.setAttribute('src', '../other-relative-image.svg');
+		div.appendChild(imgFive);
+	}
+
+	if (route === '/') {
+		renderDefault();
+	} else if (route === '/my-path') {
+		div = document.createElement('div');
+		div.classList.add('hello', 'another');
+		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
+		app.appendChild(div);
+	} else if (route === '/my-path/other') {
+		div = document.createElement('div');
+		div.classList.add('other');
+		div.innerHTML = 'Other';
+		app.appendChild(div);
+	} else {
+		renderDefault();
+	}
+})();

--- a/tests/support/fixtures/build-time-render/state-static/manifest.json
+++ b/tests/support/fixtures/build-time-render/state-static/manifest.json
@@ -1,0 +1,8 @@
+{
+	"main.js": "main.js",
+	"other.js": "other.js",
+	"main.css": "main.css",
+	"other.css": "other.css",
+	"runtime.js": "runtime.js",
+	"index.html": "index.html"
+}

--- a/tests/support/fixtures/build-time-render/state-static/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/my-path/index.html
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<link rel="manifest" href="../manifest.json" />
+	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
+	<body>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}</div></div>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/my-path/other/index.html
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<link rel="manifest" href="../../manifest.json" />
+	<style>.other.another{color:pink;background:url("../../relative.png");background:url("/root.png");background:url("../.././relative.png");background:url("../../../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
+	<body>
+		<div id="app"><div class="other">Other</div></div>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static/other.css
+++ b/tests/support/fixtures/build-time-render/state-static/other.css
@@ -1,0 +1,3 @@
+.another {
+	background: red;
+}

--- a/tests/support/fixtures/build-time-render/state-static/other.js
+++ b/tests/support/fixtures/build-time-render/state-static/other.js
@@ -1,0 +1,1 @@
+(function other() {})();

--- a/tests/support/fixtures/build-time-render/state-static/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/other/index.html
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<link rel="manifest" href="../manifest.json" />
+	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
+	<body>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src=".././relative-image.svg"><img src="../../other-relative-image.svg"></div></div>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static/runtime.js
+++ b/tests/support/fixtures/build-time-render/state-static/runtime.js
@@ -1,0 +1,1 @@
+(function runtime() {})();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds a `static` option for BTR that completely removes the javascript and css from the generated `index.html` files. 

When using routing only works with `StateHistory` (i.e. not hash routing).

Resolves #https://github.com/dojo/cli-build-app/issues/280
