### PR TITLE
Guard against no named imports

### DIFF
--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -174,14 +174,16 @@ class Visitor {
 	private setWPragma(node: ts.ImportDeclaration) {
 		if (node.importClause) {
 			const namedBindings = node.importClause.namedBindings as ts.NamedImports;
-			namedBindings.elements.some((element: ts.ImportSpecifier) => {
-				const text = element.name.getText();
-				if (text === wPragma || (element.propertyName && element.propertyName.escapedText === wPragma)) {
-					this.wPragma = text;
-					return true;
-				}
-				return false;
-			});
+			if (namedBindings) {
+				namedBindings.elements.some((element: ts.ImportSpecifier) => {
+					const text = element.name.getText();
+					if (text === wPragma || (element.propertyName && element.propertyName.escapedText === wPragma)) {
+						this.wPragma = text;
+						return true;
+					}
+					return false;
+				});
+			}
 		}
 	}
 

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -7,6 +7,7 @@ const { assert } = intern.getPlugin('chai');
 
 const source = `
 import { v, w } from '@dojo/framework/core/vdom';
+import renderer from '@dojo/framework/core/vdom';
 import WidgetBase from '@dojo/framework/core/WidgetBase';
 import Bar from './widgets/Bar';
 import Baz from './Baz';


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Now that `w` is exported from `vdom` there can be imports from `vdom` with no named exports as `renderer` is a default export.

This guards against imports from only import the default from `vdom`.
