### PR TITLE
Support defining specific routes as static

### DIFF
--- a/tests/support/fixtures/build-time-render/state-static-per-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/main.css
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/main.css
@@ -1,0 +1,27 @@
+#root {
+	margin: 10px;
+}
+
+/* example comment */
+
+.hello {
+	background: red;
+}
+
+.other.another {
+	color: pink;
+	background: url("relative.png");
+	background: url("/root.png");
+	background: url("./relative.png");
+	background: url("../relative.png");
+	background: url("https://example.com");
+	background: url("http://example.com");
+	background: url(https://example.com);
+	background: url(http://example.com);
+}
+
+span {
+	width: 100%;
+}
+
+/*# sourceMappingURL=main.16469ae7e579bf3f6af50cbfcb734efa.bundle.css.map*/

--- a/tests/support/fixtures/build-time-render/state-static-per-path/main.js
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/main.js
@@ -1,0 +1,47 @@
+(function main() {
+	const app = document.getElementById('app');
+	let div = document.createElement('div');
+	const route = window.location.pathname;
+
+	function renderDefault() {
+		const imgOne = document.createElement('img');
+		const imgTwo = document.createElement('img');
+		const imgThree = document.createElement('img');
+		const imgFour = document.createElement('img');
+		const imgFive = document.createElement('img');
+		div.classList.add('hello', 'another');
+		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
+		app.appendChild(div);
+
+		imgOne.setAttribute('src', 'https://example.com');
+		div.appendChild(imgOne);
+
+		imgTwo.setAttribute('src', 'http://example.com');
+		div.appendChild(imgTwo);
+
+		imgThree.setAttribute('src', '/image.svg');
+		div.appendChild(imgThree);
+
+		imgFour.setAttribute('src', './relative-image.svg');
+		div.appendChild(imgFour);
+
+		imgFive.setAttribute('src', '../other-relative-image.svg');
+		div.appendChild(imgFive);
+	}
+
+	if (route === '/') {
+		renderDefault();
+	} else if (route === '/my-path') {
+		div = document.createElement('div');
+		div.classList.add('hello', 'another');
+		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
+		app.appendChild(div);
+	} else if (route === '/my-path/other') {
+		div = document.createElement('div');
+		div.classList.add('other');
+		div.innerHTML = 'Other';
+		app.appendChild(div);
+	} else {
+		renderDefault();
+	}
+})();

--- a/tests/support/fixtures/build-time-render/state-static-per-path/manifest.json
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/manifest.json
@@ -1,0 +1,8 @@
+{
+	"main.js": "main.js",
+	"other.js": "other.js",
+	"main.css": "main.css",
+	"other.css": "other.css",
+	"runtime.js": "runtime.js",
+	"index.html": "index.html"
+}

--- a/tests/support/fixtures/build-time-render/state-static-per-path/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/my-path/index.html
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<link rel="manifest" href="../manifest.json" />
+	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
+	<body>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}</div></div>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/my-path/other/index.html
@@ -1,0 +1,11 @@
+<html>
+	<head>
+		<link rel="manifest" href="../../manifest.json" />
+	<style>.other.another{color:pink;background:url("../../relative.png");background:url("/root.png");background:url("../.././relative.png");background:url("../../../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
+	<body>
+		<div id="app"><div class="other">Other</div></div>
+		<script>
+window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/, '');
+</script><link rel="stylesheet" href="../../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/other.css
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/other.css
@@ -1,0 +1,3 @@
+.another {
+	background: red;
+}

--- a/tests/support/fixtures/build-time-render/state-static-per-path/other.js
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/other.js
@@ -1,0 +1,1 @@
+(function other() {})();

--- a/tests/support/fixtures/build-time-render/state-static-per-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/other/index.html
@@ -1,0 +1,11 @@
+<html>
+	<head>
+		<link rel="manifest" href="../manifest.json" />
+	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
+	<body>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src=".././relative-image.svg"><img src="../../other-relative-image.svg"></div></div>
+		<script>
+window.__public_path__ = window.location.pathname.replace(/other(\/)?/, '');
+</script><link rel="stylesheet" href="../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/runtime.js
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/runtime.js
@@ -1,0 +1,1 @@
+(function runtime() {})();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Extends the new "static" feature to enable users to configure individual paths as static via the `.dojorc`.

```json
{
    "build-time-render": {
        "root": "app",
        "paths": [
             {
                "path": "my-path",
                "static": true
             }
        ]
    }
}
```

Related to https://github.com/dojo/cli-build-app/issues/280
