### PR TITLE
Update acorn and acorn-dynamic-import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,9 @@
       }
     },
     "@dojo/scripts": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@dojo/scripts/-/scripts-4.0.1.tgz",
-      "integrity": "sha512-GCXLgTnxe7a9a8pkw1+IqP0SKCd7PUXrfWw4KJX1U3HSRIflyi+e4ONgFH+G0CUJi4vCOuZqboEuVCrQTTJg4A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dojo/scripts/-/scripts-4.0.0.tgz",
+      "integrity": "sha512-nbJgedsfSAKnapXNrO7QOtwlwQ+2c+SqWSqg+NWodmDfG0ZCiPON/Tw6Xj3VGkChh3RjrdN+kBoaVyiZL9Jx6w==",
       "dev": true,
       "requires": {
         "chalk": "~2.4.0",
@@ -758,17 +758,14 @@
       }
     },
     "acorn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
     },
     "acorn-dynamic-import": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-      "requires": {
-        "acorn": "^5.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -3961,7 +3958,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3979,11 +3977,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3996,15 +3996,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4107,7 +4110,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4117,6 +4121,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4129,17 +4134,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4156,6 +4164,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4228,7 +4237,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4238,6 +4248,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4313,7 +4324,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4343,6 +4355,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4360,6 +4373,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4398,11 +4412,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10124,6 +10140,15 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
           "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
           "dev": true
+        },
+        "acorn-dynamic-import": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+          "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.0.0"
+          }
         },
         "schema-utils": {
           "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "@dojo/framework": "6.0.0-alpha.3",
-    "acorn": "5.3.0",
-    "acorn-dynamic-import": "3.0.0",
+    "acorn": "6.1.1",
+    "acorn-dynamic-import": "4.0.0",
     "bfj": "6.1.1",
     "chalk": "2.3.0",
     "clear-module": "3.1.0",
@@ -80,7 +80,7 @@
     "wrapper-webpack-plugin": "2.0.0"
   },
   "devDependencies": {
-    "@dojo/scripts": "~4.0.0",
+    "@dojo/scripts": "4.0.0",
     "@types/acorn": "4.0.3",
     "@types/connect-history-api-fallback": "1.3.1",
     "@types/cssnano": "4.0.0",

--- a/src/static-build-loader/loader.ts
+++ b/src/static-build-loader/loader.ts
@@ -8,7 +8,8 @@ const types = recast.types;
 const namedTypes = types.namedTypes;
 const builders = types.builders;
 const compose = require('recast/lib/util').composeSourceMaps;
-const acorn = require('acorn-dynamic-import').default;
+const { Parser } = require('acorn');
+const dynamicImport = require('acorn-dynamic-import').default;
 
 /**
  * A map of features that should be statically replaced in the code
@@ -16,6 +17,8 @@ const acorn = require('acorn-dynamic-import').default;
 export interface StaticHasFeatures {
 	[feature: string]: boolean;
 }
+
+const acorn = Parser.extend(dynamicImport);
 
 const HAS_MID = /\/has$/;
 const HAS_PRAGMA = /^\s*(!?)\s*has\s*\(["']([^'"]+)['"]\)\s*$/;


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)

**Description:**
Bump acorn and acorn-dynamic-import, as older version didn't support some es2017 syntax.
