### PR TITLE
Add `es6- iterator` to modern feature set

### DIFF
--- a/src/static-build-loader/features/modern.json
+++ b/src/static-build-loader/features/modern.json
@@ -7,6 +7,7 @@
 	"es2017-string": true,
 	"es6-array": true,
 	"es6-array-fill": true,
+	"es6-iterator": true,
 	"es6-map": true,
 	"es6-math": true,
 	"es6-math-imul": true,

--- a/src/webpack-bundle-analyzer/client/package-lock.json
+++ b/src/webpack-bundle-analyzer/client/package-lock.json
@@ -1739,9 +1739,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000886",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000886.tgz",
-			"integrity": "sha512-xpYuY7rqc5+4q1n/l1BfSgIndaNqvXWKZ0Vk0ZXzVncCAkn0+huvIIPwcSL5YRJoW4MSRsgyNbjnKuh45GmknA==",
+			"version": "1.0.30000973",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
+			"integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==",
 			"dev": true
 		},
 		"capture-stack-trace": {

--- a/src/webpack-bundle-analyzer/client/package.json
+++ b/src/webpack-bundle-analyzer/client/package.json
@@ -21,6 +21,7 @@
 		"@types/d3": "~3.5.17",
 		"@types/filesize": "^3.6.0",
 		"@types/node": "~9.6.5",
+		"caniuse-lite": "1.0.30000973",
 		"shx": "^0.3.2",
 		"typescript": "~2.6.1"
 	}

--- a/tests/unit/static-build-loader/getFeatures.ts
+++ b/tests/unit/static-build-loader/getFeatures.ts
@@ -19,6 +19,7 @@ registerSuite('getFeatures', {
 			'es2017-string': true,
 			'es6-array': true,
 			'es6-array-fill': true,
+			'es6-iterator': true,
 			'es6-map': true,
 			'es6-math': true,
 			'es6-math-imul': true,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add `es6-iterator` has flag to modern feature set.