### PR TITLE
Differentiate between default and namespace imports

### DIFF
--- a/src/webpack-bundle-analyzer/client/package-lock.json
+++ b/src/webpack-bundle-analyzer/client/package-lock.json
@@ -4269,7 +4269,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4290,12 +4291,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4310,17 +4313,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4437,7 +4443,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4449,6 +4456,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4463,6 +4471,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4470,12 +4479,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -4494,6 +4505,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4574,7 +4586,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4586,6 +4599,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4671,7 +4685,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4707,6 +4722,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4726,6 +4742,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4769,12 +4786,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/tests/support/fixtures/static-build-loader/has-es6-foo-true.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-foo-true.js
@@ -27,3 +27,8 @@ if (exists('bar')) {
 if (true) {
 	doY();
 }
+
+// Should not parse
+if (checkHas.exists('foo')) {
+	doY();
+}

--- a/tests/support/fixtures/static-build-loader/has-es6-import-namespace-foo-true.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-import-namespace-foo-true.js
@@ -1,0 +1,28 @@
+import * as has from '/has';
+
+function doX() {
+
+}
+
+function doY() {
+
+}
+if (true) {
+	doX();
+}
+
+if (!true) {
+	doY();
+}
+
+if (has.default('bar')) {
+	doX();
+}
+
+if (has.exists('bar')) {
+	doX();
+}
+
+if (true) {
+	doY();
+}

--- a/tests/support/fixtures/static-build-loader/has-es6-import-namespace.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-import-namespace.js
@@ -1,0 +1,28 @@
+import * as has from '/has';
+
+function doX() {
+
+}
+
+function doY() {
+
+}
+if (has.default('foo')) {
+	doX();
+}
+
+if (!has.default('foo')) {
+	doY();
+}
+
+if (has.default('bar')) {
+	doX();
+}
+
+if (has.exists('bar')) {
+	doX();
+}
+
+if (has.exists('foo')) {
+	doY();
+}

--- a/tests/support/fixtures/static-build-loader/has-es6.js
+++ b/tests/support/fixtures/static-build-loader/has-es6.js
@@ -27,3 +27,8 @@ if (exists('bar')) {
 if (exists('foo')) {
 	doY();
 }
+
+// Should not parse
+if (checkHas.exists('foo')) {
+	doY();
+}

--- a/tests/unit/static-build-loader/loader.ts
+++ b/tests/unit/static-build-loader/loader.ts
@@ -113,6 +113,22 @@ registerSuite('static-build-loader', {
 			assert.strictEqual(logStub.secondCall.args[0], 'Dynamic features: bar', 'should have logged properly');
 		},
 
+		'static features with namespace import'() {
+			const code = loadCode('has-es6-import-namespace');
+			mockLoaderUtils.getOptions.returns({
+				features: { foo: true }
+			});
+
+			const context = {
+				callback: sandbox.stub()
+			};
+			const resultCode = loader.call(context, code).replace(/\r\n/g, '\n');
+			assert.equal(resultCode, loadCode('has-es6-import-namespace-foo-true'));
+			assert.isFalse(mockGetFeatures.default.called, 'Should not have called getFeatures');
+			assert.strictEqual(logStub.callCount, 3, 'should have logged to console three time');
+			assert.strictEqual(logStub.secondCall.args[0], 'Dynamic features: bar', 'should have logged properly');
+		},
+
 		'should pass to callback if a sourcemap was provided'() {
 			const map = 'map';
 			const returnedCode = 'code';


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:
Fixes the parsing in the static build loader to differentiate between a default and namespace
import.

* [x] There is a related issue
*  [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Resolves #171 
