### PR TITLE
Harcode args for calls to 'has.add' for static features

### DIFF
--- a/src/static-build-loader/loader.ts
+++ b/src/static-build-loader/loader.ts
@@ -306,7 +306,7 @@ export default function loader(
 	// Now we want to walk the AST and find an expressions where the default import or `exists` of `*/has` is
 	// called. This will be a CallExpression, where the callee is an object named the import from above
 	// accessing the `default` or `exists` properties, with one argument, which is a string literal.
-	if (hasIdentifier || hasNamespaceIdentifier) {
+	if (hasIdentifier || hasNamespaceIdentifier || existsIdentifier || addIdentifier) {
 		types.visit(ast, {
 			visitCallExpression(path) {
 				const {

--- a/src/static-build-loader/recast.d.ts
+++ b/src/static-build-loader/recast.d.ts
@@ -12,6 +12,7 @@ declare module 'recast/main' {
 		Literal,
 		Identifier,
 		CallExpression,
+		Expression,
 		ExpressionStatement,
 		VariableDeclaration,
 		MemberExpression,
@@ -19,7 +20,11 @@ declare module 'recast/main' {
 		AssignmentExpression,
 		TemplateLiteral,
 		TemplateElement,
-		VariableDeclarator
+		VariableDeclarator,
+		SourceLocation,
+		SimpleCallExpression,
+		Super,
+		SpreadElement
 	} from 'estree';
 
 	namespace recast {
@@ -67,6 +72,7 @@ declare module 'recast/main' {
 				literal(value: boolean | string | number | null | RegExp): Literal;
 				variableDeclarator(id: Identifier, value: Literal | Identifier): VariableDeclarator;
 				variableDeclaration(value: string, declarators: VariableDeclarator[]): VariableDeclaration;
+				callExpression(callee: Expression | Super, args: Array<Expression | SpreadElement>): CallExpression;
 			};
 			export function visit(
 				ast: AST,

--- a/tests/support/fixtures/static-build-loader/has-es6-foo-true.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-foo-true.js
@@ -1,4 +1,4 @@
-import checkHas, { exists, arbitrary } from 'dojo/has';
+import checkHas, { exists, add, arbitrary } from 'dojo/has';
 
 
 function doX() {
@@ -28,7 +28,19 @@ if (true) {
 	doY();
 }
 
+add('foo', true);
+add('foo', true);
+add('foo', true);
+add('foo', true);
+add('foo', true);
+add('bar', true);
+add('bar', false, true);
+add('bar', function () { return true }, true);
+
 // Should not parse
 if (checkHas.exists('foo')) {
 	doY();
 }
+
+// Should not parse
+checkHas.add('foo', true);

--- a/tests/support/fixtures/static-build-loader/has-es6-import-namespace-foo-true.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-import-namespace-foo-true.js
@@ -26,3 +26,8 @@ if (has.exists('bar')) {
 if (true) {
 	doY();
 }
+
+add('bar', false, true);
+add('bar', function addBar() { return true; });
+has.add('foo', true);
+has.add('foo', true);

--- a/tests/support/fixtures/static-build-loader/has-es6-import-namespace.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-import-namespace.js
@@ -26,3 +26,8 @@ if (has.exists('bar')) {
 if (has.exists('foo')) {
 	doY();
 }
+
+add('bar', false, true);
+add('bar', function addBar() { return true; });
+has.add('foo', false, true);
+has.add('foo', function addFoo() { return true; });

--- a/tests/support/fixtures/static-build-loader/has-es6-named-imports-foo-false.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-named-imports-foo-false.js
@@ -1,4 +1,4 @@
-import { default as checkHas, exists as doesItExist, arbitrary } from 'dojo/has';
+import { default as checkHas, exists as doesItExist, add as addIt, arbitrary } from 'dojo/has';
 
 function doX() {
 
@@ -26,3 +26,6 @@ if (doesItExist('bar')) {
 if (true) {
 	doY();
 }
+
+addIt('foo', false);
+addIt('bar', () => 'yes', true);

--- a/tests/support/fixtures/static-build-loader/has-es6-named-imports.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-named-imports.js
@@ -1,4 +1,4 @@
-import { default as checkHas, exists as doesItExist, arbitrary } from 'dojo/has';
+import { default as checkHas, exists as doesItExist, add as addIt, arbitrary } from 'dojo/has';
 
 function doX() {
 
@@ -26,3 +26,6 @@ if (doesItExist('bar')) {
 if (doesItExist('foo')) {
 	doY();
 }
+
+addIt('foo', () => 'no', false);
+addIt('bar', () => 'yes', true);

--- a/tests/support/fixtures/static-build-loader/has-es6.js
+++ b/tests/support/fixtures/static-build-loader/has-es6.js
@@ -1,4 +1,4 @@
-import checkHas, { exists, arbitrary } from 'dojo/has';
+import checkHas, { exists, add, arbitrary } from 'dojo/has';
 
 
 function doX() {
@@ -28,7 +28,19 @@ if (exists('foo')) {
 	doY();
 }
 
+add('foo', false, true);
+add('foo', false);
+add('foo', function () { return true; });
+add('foo', function addFoo() { return true; });
+add('foo', () => true, false);
+add('bar', true);
+add('bar', false, true);
+add('bar', function () { return true }, true);
+
 // Should not parse
 if (checkHas.exists('foo')) {
 	doY();
 }
+
+// Should not parse
+checkHas.add('foo', true);

--- a/tests/support/fixtures/static-build-loader/no-has-import-foo-true.js
+++ b/tests/support/fixtures/static-build-loader/no-has-import-foo-true.js
@@ -1,0 +1,17 @@
+import { exists, add } from '@dojo/has';
+
+function doX() {
+	return 'foo';
+}
+
+function doY() {
+	return 'bar';
+}
+
+if (!true) {
+	add('foo', true);
+}
+
+if(!exists('bar')) {
+	add('bar', () => doX() !== doY());
+}

--- a/tests/support/fixtures/static-build-loader/no-has-import.js
+++ b/tests/support/fixtures/static-build-loader/no-has-import.js
@@ -1,0 +1,17 @@
+import { exists, add } from '@dojo/has';
+
+function doX() {
+	return 'foo';
+}
+
+function doY() {
+	return 'bar';
+}
+
+if (!exists('foo')) {
+	add('foo', () => doX() === doY());
+}
+
+if(!exists('bar')) {
+	add('bar', () => doX() !== doY());
+}

--- a/tests/support/fixtures/static-build-loader/static-has-base.js
+++ b/tests/support/fixtures/static-build-loader/static-has-base.js
@@ -76,6 +76,18 @@ if (returnArg(!somename.default('foo')) && (somename.default('baz') || returnArg
 if (somename.default('foo'))
 	doX();
 
+somename.add('foo', function () {
+	return true;
+});
+
+somename.add('bar', true, true);
+
+somename.add('qat', function addqat() {
+	if (true) {
+		return false;
+	}
+}, true);
+
 var variable = somename.default('bar') || returnArg(somename.default('foo'));
 
 '!has("foo")';

--- a/tests/support/fixtures/static-build-loader/static-has-foo-true-bar-false.js
+++ b/tests/support/fixtures/static-build-loader/static-has-foo-true-bar-false.js
@@ -80,4 +80,14 @@ if (returnArg(!true) && (somename.default('baz') || returnArg(somename.default('
 if (true)
 	doX();
 
+somename.add('foo', true);
+
+somename.add('bar', false);
+
+somename.add('qat', function addqat() {
+	if (true) {
+		return false;
+	}
+}, true);
+
 var variable = false || returnArg(true);

--- a/tests/support/fixtures/static-build-loader/static-has-no-flags.js
+++ b/tests/support/fixtures/static-build-loader/static-has-no-flags.js
@@ -76,6 +76,18 @@ if (returnArg(!somename.default('foo')) && (somename.default('baz') || returnArg
 if (somename.default('foo'))
 	doX();
 
+somename.add('foo', function () {
+	return true;
+});
+
+somename.add('bar', true, true);
+
+somename.add('qat', function addqat() {
+	if (true) {
+		return false;
+	}
+}, true);
+
 var variable = somename.default('bar') || returnArg(somename.default('foo'));
 
 // !has('foo')

--- a/tests/support/fixtures/static-build-loader/static-has-qat-true.js
+++ b/tests/support/fixtures/static-build-loader/static-has-qat-true.js
@@ -76,6 +76,14 @@ if (returnArg(!somename.default('foo')) && (somename.default('baz') || returnArg
 if (somename.default('foo'))
 	doX();
 
+somename.add('foo', function () {
+	return true;
+});
+
+somename.add('bar', true, true);
+
+somename.add('qat', true);
+
 var variable = somename.default('bar') || returnArg(somename.default('foo'));
 
 // !has('foo')

--- a/tests/unit/static-build-loader/loader.ts
+++ b/tests/unit/static-build-loader/loader.ts
@@ -129,6 +129,22 @@ registerSuite('static-build-loader', {
 			assert.strictEqual(logStub.secondCall.args[0], 'Dynamic features: bar', 'should have logged properly');
 		},
 
+		'add and exists without has import'() {
+			const code = loadCode('no-has-import');
+			mockLoaderUtils.getOptions.returns({
+				features: { foo: true }
+			});
+
+			const context = {
+				callback: sandbox.stub()
+			};
+			const resultCode = loader.call(context, code).replace(/\r\n/g, '\n');
+			assert.equal(resultCode, loadCode('no-has-import-foo-true'));
+			assert.isFalse(mockGetFeatures.default.called, 'Should not have called getFeatures');
+			assert.strictEqual(logStub.callCount, 3, 'should have logged to console three time');
+			assert.strictEqual(logStub.secondCall.args[0], 'Dynamic features: bar', 'should have logged properly');
+		},
+
 		'should pass to callback if a sourcemap was provided'() {
 			const map = 'map';
 			const returnedCode = 'code';


### PR DESCRIPTION

**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**
This implements static resolution for calls to `has.add`, replacing the passed values with the statically set value, and eliminating the overwrite flag if it exists as it will be ignored anyways.

I don't know if we can say this fully resolves the issue, as the issue assumes that the has module itself will be subject to these changes. That is, at the moment, not the case, because the static parsing specifically looks for imports of the `has` module to determine whether to parse a file, and to determine the identifiers it looks for. Since the checks in this case are defined in `has.ts` itself this approach has no effect there.
Related to #169 
