### PR TITLE
Add custom transformer for emit all plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,49 @@ The plugin constructor accepts a single argument:
 
 ## emit-all-plugin
 
-Webpack is a bundler, which does not work well when build libraries. Rather than create separate toolchains for building libraries and applications/custom elements, the existing build tooling can be used to emit library files by way of the `EmitAllPlugin`. At the very least CSS and transpiled TS files will be emitted, but additional assets can be included with a filter.
+Webpack is a bundler, which does not work well when build libraries. Rather than create separate toolchains for building libraries and applications/custom elements, the existing build tooling can be used to emit library files by way of the `emitAllFactory` that produces both a plugin instance and a custom TypeScript transformer. The transformer is needed to ensure that any `.d.ts` dependencies are correctly emitted, while the plugin ensures assets are emitted as individual files instead of as a generated bundle:
 
-The plugin takes an options object with the following properties:
+```ts
+import { emitAllFactory } from '@dojo/webpack-contrib/emit-all-plugin/EmitAllPlugin';
+
+// See list of available options below
+const emitAll = emitAllFactory(options);
+
+const config = {
+	// ...
+	plugins: [
+		...,
+		emitAll.plugin
+	],
+	module: {
+		rules: [
+			// ...
+			{
+				test: /.*\.ts(x)?$/,
+				use: [
+					{
+						loader: 'ts-loader',
+						options: {
+							// ...
+							getCustomTransformers(program) {
+								return {
+									before: [
+										emitAll.transformer()
+									]
+								};
+							}
+						}
+					}
+				]
+			}
+		]
+	}
+}
+```
+
+At the very least CSS and transpiled TS files will be emitted, but additional assets can be included with a filter.
+
+The factory takes an options object with the following properties:
 
 | Property | Type | Optional | Description |
 | -------- | ---- | -------- | ----------- |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3968,7 +3968,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3986,11 +3987,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4003,15 +4006,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4114,7 +4120,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4124,6 +4131,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4136,17 +4144,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4163,6 +4174,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4235,7 +4247,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4245,6 +4258,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4320,7 +4334,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4350,6 +4365,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4367,6 +4383,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4405,11 +4422,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/webpack-bundle-analyzer/client/package-lock.json
+++ b/src/webpack-bundle-analyzer/client/package-lock.json
@@ -4269,7 +4269,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4290,12 +4291,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4310,17 +4313,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4437,7 +4443,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4449,6 +4456,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4463,6 +4471,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4470,12 +4479,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -4494,6 +4505,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4574,7 +4586,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4586,6 +4599,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4671,7 +4685,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4707,6 +4722,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4726,6 +4742,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4769,12 +4786,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/tests/unit/emit-all-plugin/EmitAllPlugin.ts
+++ b/tests/unit/emit-all-plugin/EmitAllPlugin.ts
@@ -14,8 +14,12 @@ describe('EmitAllPlugin', () => {
 
 	beforeEach(() => {
 		mockModule = new MockModule('../../../src/emit-all-plugin/EmitAllPlugin', require);
-		mockModule.dependencies(['cssnano']);
+		mockModule.dependencies(['cssnano', 'fs', 'typescript']);
 		mockModule.getMock('cssnano').ctor.process = stub().callsFake((css: string) => Promise.resolve({ css }));
+		mockModule.getMock('typescript').visitNode = stub().callsFake((node, visit) => visit(node));
+		const mockFs = mockModule.getMock('fs');
+		mockFs.existsSync = stub().returns(true);
+		mockFs.readFileSync = stub().returns('');
 		compiler = createCompiler();
 	});
 
@@ -23,342 +27,169 @@ describe('EmitAllPlugin', () => {
 		mockModule.destroy();
 	});
 
-	it('prevents webpack from emitting a bundle', () => {
-		const EmitAll = mockModule.getModuleUnderTest().default;
-		const emitAll = new EmitAll();
-		const compilation = createCompilation(compiler);
-
-		emitAll.apply(compiler);
-		compilation.chunks = [{}];
-		compiler.hooks.emit.callAsync(compilation, () => {});
-
-		assert.deepEqual(compilation.chunks, []);
-	});
-
-	it('prevents webpack from emitting assets based on a filter', () => {
-		const EmitAll = mockModule.getModuleUnderTest().default;
-		const emitAll = new EmitAll({
-			assetFilter: (key: string) => key !== 'foo'
-		});
-		const compilation = createCompilation(compiler);
-
-		compilation.assets = {
-			foo: {},
-			bar: {},
-			baz: {}
-		};
-		emitAll.apply(compiler);
-		compiler.hooks.emit.callAsync(compilation, () => {});
-
-		assert.deepEqual(compilation.assets, {
-			bar: {},
-			baz: {}
-		});
-	});
-
-	it('emits all assets by default', () => {
-		const EmitAll = mockModule.getModuleUnderTest().default;
-		const emitAll = new EmitAll();
-		const compilation = createCompilation(compiler);
-		const assets = {
-			foo: {},
-			bar: {},
-			baz: {}
-		};
-
-		compilation.assets = assets;
-		emitAll.apply(compiler);
-		compiler.hooks.emit.callAsync(compilation, () => {});
-
-		assert.deepEqual(compilation.assets, assets);
-	});
-
-	describe('JavaScript assets', () => {
-		it('outputs individual mjs files', () => {
-			const EmitAll = mockModule.getModuleUnderTest().default;
-			const emitAll = new EmitAll({
-				basePath: 'src/'
-			});
+	describe('plugin', () => {
+		it('prevents webpack from emitting a bundle', () => {
+			const factory = mockModule.getModuleUnderTest().emitAllFactory;
+			const emitAll = factory().plugin;
 			const compilation = createCompilation(compiler);
-			const source = 'module.exports = {}';
-			const jsModule = {
-				resource: 'src/dir/asset.ts',
-				originalSource: () => ({
-					source: () => source
-				})
-			};
 
-			compilation.modules = [jsModule];
+			emitAll.apply(compiler);
+			compilation.chunks = [{}];
+			compiler.hooks.emit.callAsync(compilation, () => {});
+
+			assert.deepEqual(compilation.chunks, []);
+		});
+
+		it('prevents webpack from emitting assets based on a filter', () => {
+			const factory = mockModule.getModuleUnderTest().emitAllFactory;
+			const emitAll = factory({
+				assetFilter: (key: string) => key !== 'foo'
+			}).plugin;
+			const compilation = createCompilation(compiler);
+
+			compilation.assets = {
+				foo: {},
+				bar: {},
+				baz: {}
+			};
 			emitAll.apply(compiler);
 			compiler.hooks.emit.callAsync(compilation, () => {});
 
-			const asset = compilation.assets['dir/asset.mjs'];
-			assert.isObject(asset);
-			assert.strictEqual(asset.source(), source);
-			assert.strictEqual(asset.size(), Buffer.byteLength(source));
+			assert.deepEqual(compilation.assets, {
+				bar: {},
+				baz: {}
+			});
 		});
 
-		it('outputs JS files with the `.js` extension in legacy mode', () => {
-			const EmitAll = mockModule.getModuleUnderTest().default;
-			const emitAll = new EmitAll({
-				basePath: 'src/',
-				legacy: true
-			});
+		it('emits all assets by default', () => {
+			const factory = mockModule.getModuleUnderTest().emitAllFactory;
+			const emitAll = factory().plugin;
 			const compilation = createCompilation(compiler);
-			const source = 'module.exports = {}';
-			const jsModule = {
-				resource: 'src/dir/asset.ts',
-				originalSource: () => ({
-					source: () => source
-				})
+			const assets = {
+				foo: {},
+				bar: {},
+				baz: {}
 			};
 
-			compilation.modules = [jsModule];
+			compilation.assets = assets;
 			emitAll.apply(compiler);
 			compiler.hooks.emit.callAsync(compilation, () => {});
 
-			const asset = compilation.assets['dir/asset.js'];
-			assert.isObject(asset);
-			assert.strictEqual(asset.source(), source);
-			assert.strictEqual(asset.size(), Buffer.byteLength(source));
+			assert.deepEqual(compilation.assets, assets);
 		});
 
-		it('excludes files outside the base path', () => {
-			const EmitAll = mockModule.getModuleUnderTest().default;
-			const emitAll = new EmitAll({
-				basePath: 'src/'
-			});
-			const compilation = createCompilation(compiler);
-			const source = 'module.exports = {}';
-			const jsModule = {
-				resource: 'other/dir/asset.ts',
-				originalSource: () => ({
-					source: () => source
-				})
-			};
+		describe('JavaScript assets', () => {
+			it('outputs individual mjs files', () => {
+				const factory = mockModule.getModuleUnderTest().emitAllFactory;
+				const emitAll = factory({
+					basePath: 'src/'
+				}).plugin;
+				const compilation = createCompilation(compiler);
+				const source = 'module.exports = {}';
+				const jsModule = {
+					resource: 'src/dir/asset.ts',
+					originalSource: () => ({
+						source: () => source
+					})
+				};
 
-			compilation.modules = [jsModule];
-			emitAll.apply(compiler);
-			compiler.hooks.emit.callAsync(compilation, () => {});
+				compilation.modules = [jsModule];
+				emitAll.apply(compiler);
+				compiler.hooks.emit.callAsync(compilation, () => {});
 
-			assert.deepEqual(Object.keys(compilation.assets), []);
-		});
-
-		it('ignores modules without a resource', () => {
-			const EmitAll = mockModule.getModuleUnderTest().default;
-			const emitAll = new EmitAll({
-				basePath: 'src/'
-			});
-			const compilation = createCompilation(compiler);
-			const source = 'module.exports = {}';
-			const jsModule = {
-				originalSource: () => ({
-					source: () => source
-				})
-			};
-
-			compilation.modules = [jsModule];
-			emitAll.apply(compiler);
-			compiler.hooks.emit.callAsync(compilation, () => {});
-
-			assert.deepEqual(Object.keys(compilation.assets), []);
-		});
-
-		it('outputs JS sourcemaps', () => {
-			const EmitAll = mockModule.getModuleUnderTest().default;
-			const emitAll = new EmitAll({
-				basePath: 'src/'
-			});
-			const compilation = createCompilation(compiler);
-			const source = 'module.exports = {}';
-			const jsModule = {
-				resource: 'src/dir/asset.ts',
-				originalSource: () => ({
-					_sourceMap: { mappings: 'abcd' },
-					source: () => source
-				})
-			};
-
-			compilation.modules = [jsModule];
-			emitAll.apply(compiler);
-			compiler.hooks.emit.callAsync(compilation, () => {});
-
-			const asset = compilation.assets['dir/asset.mjs'];
-			const assetMap = compilation.assets['dir/asset.mjs.map'];
-			const assetMapSource = {
-				mappings: 'abcd',
-				sources: []
-			};
-			const assetMapSourceString = JSON.stringify(assetMapSource);
-			assert.isObject(assetMap);
-			assert.strictEqual(assetMap.source(), assetMapSourceString);
-			assert.strictEqual(assetMap.size(), Buffer.byteLength(assetMapSourceString));
-			assert.isTrue(asset.source().endsWith('\n/*# sourceMappingURL=asset.mjs.map*/'));
-		});
-
-		it('inlines JS sourcemaps with a flag', () => {
-			const EmitAll = mockModule.getModuleUnderTest().default;
-			const emitAll = new EmitAll({
-				basePath: 'src/',
-				inlineSourceMaps: true
-			});
-			const compilation = createCompilation(compiler);
-			const source = 'module.exports = {}';
-			const sourceMap = { mappings: 'abcd', sources: [] };
-			const jsModule = {
-				resource: 'src/dir/asset.ts',
-				originalSource: () => ({
-					_sourceMap: sourceMap,
-					source: () => source
-				})
-			};
-
-			compilation.modules = [jsModule];
-			emitAll.apply(compiler);
-			compiler.hooks.emit.callAsync(compilation, () => {});
-
-			const asset = compilation.assets['dir/asset.mjs'];
-			const sourceMapUrl = `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
-				JSON.stringify(sourceMap)
-			).toString('base64')}*/`;
-			assert.isTrue(asset.source().endsWith(sourceMapUrl));
-			assert.isUndefined(compilation.assets['dir/asset.mjs.map']);
-		});
-
-		it('removes the base path from the source map sources', () => {
-			const EmitAll = mockModule.getModuleUnderTest().default;
-			const emitAll = new EmitAll({
-				basePath: 'src/'
-			});
-			const compilation = createCompilation(compiler);
-			const source = 'module.exports = {}';
-			const sourceMap = {
-				mappings: 'abcd',
-				sources: ['src/dir/asset.ts']
-			};
-			const jsModule = {
-				resource: 'src/dir/asset.ts',
-				originalSource: () => ({
-					_sourceMap: sourceMap,
-					source: () => source
-				})
-			};
-
-			compilation.modules = [jsModule];
-			emitAll.apply(compiler);
-			compiler.hooks.emit.callAsync(compilation, () => {});
-
-			const assetMap = compilation.assets['dir/asset.mjs.map'];
-			const assetMapSource = {
-				mappings: 'abcd',
-				sources: [path.relative('src/', 'src/dir/asset.ts')]
-			};
-			const assetMapSourceString = JSON.stringify(assetMapSource);
-			assert.strictEqual(assetMap.source(), assetMapSourceString);
-		});
-	});
-
-	describe('CSS assets', () => {
-		function applyCssModule(cssModule: any, pluginOptions?: EmitAllPluginOptions): Promise<any> {
-			const EmitAll = mockModule.getModuleUnderTest().default;
-			const emitAll = new EmitAll({
-				basePath: 'src/',
-				...pluginOptions
-			});
-
-			const compilation = createCompilation(compiler);
-			compilation.modules = [cssModule];
-			emitAll.apply(compiler);
-
-			return new Promise((resolve) => {
-				compiler.hooks.emit.callAsync(compilation, () => {
-					resolve(compilation);
-				});
-			});
-		}
-
-		it('outputs individual CSS files', () => {
-			const source = '.root {}';
-			const cssModule = {
-				resource: 'src/dir/styles.css',
-				originalSource: () => ({
-					source: () => source
-				}),
-				dependencies: [
-					{
-						content: source,
-						identifier: 'src/dir/styles.css'
-					}
-				]
-			};
-
-			return applyCssModule(cssModule).then((compilation) => {
-				const asset = compilation.assets['dir/styles.css'];
+				const asset = compilation.assets['dir/asset.mjs'];
 				assert.isObject(asset);
 				assert.strictEqual(asset.source(), source);
 				assert.strictEqual(asset.size(), Buffer.byteLength(source));
 			});
-		});
 
-		it('excludes files outside the base path', () => {
-			const source = '.root {}';
-			const cssModule = {
-				resource: 'other/dir/styles.css',
-				originalSource: () => ({
-					source: () => source
-				}),
-				dependencies: [
-					{
-						content: source,
-						identifier: 'other/dir/styles.css'
-					}
-				]
-			};
+			it('outputs JS files with the `.js` extension in legacy mode', () => {
+				const factory = mockModule.getModuleUnderTest().emitAllFactory;
+				const emitAll = factory({
+					basePath: 'src/',
+					legacy: true
+				}).plugin;
+				const compilation = createCompilation(compiler);
+				const source = 'module.exports = {}';
+				const jsModule = {
+					resource: 'src/dir/asset.ts',
+					originalSource: () => ({
+						source: () => source
+					})
+				};
 
-			return applyCssModule(cssModule).then((compilation) => {
+				compilation.modules = [jsModule];
+				emitAll.apply(compiler);
+				compiler.hooks.emit.callAsync(compilation, () => {});
+
+				const asset = compilation.assets['dir/asset.js'];
+				assert.isObject(asset);
+				assert.strictEqual(asset.source(), source);
+				assert.strictEqual(asset.size(), Buffer.byteLength(source));
+			});
+
+			it('excludes files outside the base path', () => {
+				const factory = mockModule.getModuleUnderTest().emitAllFactory;
+				const emitAll = factory({
+					basePath: 'src/'
+				}).plugin;
+				const compilation = createCompilation(compiler);
+				const source = 'module.exports = {}';
+				const jsModule = {
+					resource: 'other/dir/asset.ts',
+					originalSource: () => ({
+						source: () => source
+					})
+				};
+
+				compilation.modules = [jsModule];
+				emitAll.apply(compiler);
+				compiler.hooks.emit.callAsync(compilation, () => {});
+
 				assert.deepEqual(Object.keys(compilation.assets), []);
 			});
-		});
 
-		it('ignores dependencies with a mismatched identifier', () => {
-			const source = '.root {}';
-			const cssModule = {
-				resource: 'src/dir/styles.css',
-				originalSource: () => ({
-					source: () => source
-				}),
-				dependencies: [
-					{
-						content: source,
-						identifier: 'src/other/asset.css'
-					}
-				]
-			};
+			it('ignores modules without a resource', () => {
+				const factory = mockModule.getModuleUnderTest().emitAllFactory;
+				const emitAll = factory({
+					basePath: 'src/'
+				}).plugin;
+				const compilation = createCompilation(compiler);
+				const source = 'module.exports = {}';
+				const jsModule = {
+					originalSource: () => ({
+						source: () => source
+					})
+				};
 
-			return applyCssModule(cssModule).then((compilation) => {
+				compilation.modules = [jsModule];
+				emitAll.apply(compiler);
+				compiler.hooks.emit.callAsync(compilation, () => {});
+
 				assert.deepEqual(Object.keys(compilation.assets), []);
 			});
-		});
 
-		it('outputs CSS sourcemaps', () => {
-			const source = '.root {}';
-			const cssModule = {
-				resource: 'src/dir/styles.css',
-				originalSource: () => ({
-					source: () => source
-				}),
-				dependencies: [
-					{
-						content: source,
-						identifier: 'src/dir/styles.css',
-						sourceMap: { mappings: 'abcd' }
-					}
-				]
-			};
+			it('outputs JS sourcemaps', () => {
+				const factory = mockModule.getModuleUnderTest().emitAllFactory;
+				const emitAll = factory({
+					basePath: 'src/'
+				}).plugin;
+				const compilation = createCompilation(compiler);
+				const source = 'module.exports = {}';
+				const jsModule = {
+					resource: 'src/dir/asset.ts',
+					originalSource: () => ({
+						_sourceMap: { mappings: 'abcd' },
+						source: () => source
+					})
+				};
 
-			return applyCssModule(cssModule).then((compilation) => {
-				const asset = compilation.assets['dir/styles.css'];
-				const assetMap = compilation.assets['dir/styles.css.map'];
+				compilation.modules = [jsModule];
+				emitAll.apply(compiler);
+				compiler.hooks.emit.callAsync(compilation, () => {});
+
+				const asset = compilation.assets['dir/asset.mjs'];
+				const assetMap = compilation.assets['dir/asset.mjs.map'];
 				const assetMapSource = {
 					mappings: 'abcd',
 					sources: []
@@ -367,66 +198,305 @@ describe('EmitAllPlugin', () => {
 				assert.isObject(assetMap);
 				assert.strictEqual(assetMap.source(), assetMapSourceString);
 				assert.strictEqual(assetMap.size(), Buffer.byteLength(assetMapSourceString));
-				assert.isTrue(asset.source().endsWith('\n/*# sourceMappingURL=styles.css.map*/'));
+				assert.isTrue(asset.source().endsWith('\n/*# sourceMappingURL=asset.mjs.map*/'));
 			});
-		});
 
-		it('inlines CSS sourcemaps with a flag', () => {
-			const source = `module.exports = {}`;
-			const sourceMap = { mappings: 'abcd', sources: [] };
-			const cssModule = {
-				resource: 'src/dir/styles.css',
-				originalSource: () => ({
-					source: () => source
-				}),
-				dependencies: [
-					{
-						content: source,
-						identifier: 'src/dir/styles.css',
-						sourceMap
-					}
-				]
-			};
+			it('inlines JS sourcemaps with a flag', () => {
+				const factory = mockModule.getModuleUnderTest().emitAllFactory;
+				const emitAll = factory({
+					basePath: 'src/',
+					inlineSourceMaps: true
+				}).plugin;
+				const compilation = createCompilation(compiler);
+				const source = 'module.exports = {}';
+				const sourceMap = { mappings: 'abcd', sources: [] };
+				const jsModule = {
+					resource: 'src/dir/asset.ts',
+					originalSource: () => ({
+						_sourceMap: sourceMap,
+						source: () => source
+					})
+				};
 
-			return applyCssModule(cssModule, { inlineSourceMaps: true }).then((compilation) => {
-				const asset = compilation.assets['dir/styles.css'];
+				compilation.modules = [jsModule];
+				emitAll.apply(compiler);
+				compiler.hooks.emit.callAsync(compilation, () => {});
+
+				const asset = compilation.assets['dir/asset.mjs'];
 				const sourceMapUrl = `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
 					JSON.stringify(sourceMap)
 				).toString('base64')}*/`;
 				assert.isTrue(asset.source().endsWith(sourceMapUrl));
-				assert.isUndefined(compilation.assets['dir/styles.css.map']);
+				assert.isUndefined(compilation.assets['dir/asset.mjs.map']);
 			});
-		});
 
-		it('removes the base path from the source map sources', () => {
-			const source = `module.exports = {}`;
-			const sourceMap = {
-				mappings: 'abcd',
-				sources: ['src/dir/styles.css']
-			};
-			const cssModule = {
-				resource: 'src/dir/styles.css',
-				originalSource: () => ({
-					source: () => source
-				}),
-				dependencies: [
-					{
-						content: source,
-						identifier: 'src/dir/styles.css',
-						sourceMap
-					}
-				]
-			};
+			it('removes the base path from the source map sources', () => {
+				const factory = mockModule.getModuleUnderTest().emitAllFactory;
+				const emitAll = factory({
+					basePath: 'src/'
+				}).plugin;
+				const compilation = createCompilation(compiler);
+				const source = 'module.exports = {}';
+				const sourceMap = {
+					mappings: 'abcd',
+					sources: ['src/dir/asset.ts']
+				};
+				const jsModule = {
+					resource: 'src/dir/asset.ts',
+					originalSource: () => ({
+						_sourceMap: sourceMap,
+						source: () => source
+					})
+				};
 
-			return applyCssModule(cssModule).then((compilation) => {
-				const assetMap = compilation.assets['dir/styles.css.map'];
+				compilation.modules = [jsModule];
+				emitAll.apply(compiler);
+				compiler.hooks.emit.callAsync(compilation, () => {});
+
+				const assetMap = compilation.assets['dir/asset.mjs.map'];
 				const assetMapSource = {
 					mappings: 'abcd',
-					sources: [path.relative('src/', 'src/dir/styles.css')]
+					sources: [path.relative('src/', 'src/dir/asset.ts')]
 				};
 				const assetMapSourceString = JSON.stringify(assetMapSource);
 				assert.strictEqual(assetMap.source(), assetMapSourceString);
 			});
+		});
+
+		describe('CSS assets', () => {
+			function applyCssModule(cssModule: any, pluginOptions?: EmitAllPluginOptions): Promise<any> {
+				const factory = mockModule.getModuleUnderTest().emitAllFactory;
+				const emitAll = factory({
+					basePath: 'src/',
+					...pluginOptions
+				}).plugin;
+
+				const compilation = createCompilation(compiler);
+				compilation.modules = [cssModule];
+				emitAll.apply(compiler);
+
+				return new Promise((resolve) => {
+					compiler.hooks.emit.callAsync(compilation, () => {
+						resolve(compilation);
+					});
+				});
+			}
+
+			it('outputs individual CSS files', () => {
+				const source = '.root {}';
+				const cssModule = {
+					resource: 'src/dir/styles.css',
+					originalSource: () => ({
+						source: () => source
+					}),
+					dependencies: [
+						{
+							content: source,
+							identifier: 'src/dir/styles.css'
+						}
+					]
+				};
+
+				return applyCssModule(cssModule).then((compilation) => {
+					const asset = compilation.assets['dir/styles.css'];
+					assert.isObject(asset);
+					assert.strictEqual(asset.source(), source);
+					assert.strictEqual(asset.size(), Buffer.byteLength(source));
+				});
+			});
+
+			it('excludes files outside the base path', () => {
+				const source = '.root {}';
+				const cssModule = {
+					resource: 'other/dir/styles.css',
+					originalSource: () => ({
+						source: () => source
+					}),
+					dependencies: [
+						{
+							content: source,
+							identifier: 'other/dir/styles.css'
+						}
+					]
+				};
+
+				return applyCssModule(cssModule).then((compilation) => {
+					assert.deepEqual(Object.keys(compilation.assets), []);
+				});
+			});
+
+			it('ignores dependencies with a mismatched identifier', () => {
+				const source = '.root {}';
+				const cssModule = {
+					resource: 'src/dir/styles.css',
+					originalSource: () => ({
+						source: () => source
+					}),
+					dependencies: [
+						{
+							content: source,
+							identifier: 'src/other/asset.css'
+						}
+					]
+				};
+
+				return applyCssModule(cssModule).then((compilation) => {
+					assert.deepEqual(Object.keys(compilation.assets), []);
+				});
+			});
+
+			it('outputs CSS sourcemaps', () => {
+				const source = '.root {}';
+				const cssModule = {
+					resource: 'src/dir/styles.css',
+					originalSource: () => ({
+						source: () => source
+					}),
+					dependencies: [
+						{
+							content: source,
+							identifier: 'src/dir/styles.css',
+							sourceMap: { mappings: 'abcd' }
+						}
+					]
+				};
+
+				return applyCssModule(cssModule).then((compilation) => {
+					const asset = compilation.assets['dir/styles.css'];
+					const assetMap = compilation.assets['dir/styles.css.map'];
+					const assetMapSource = {
+						mappings: 'abcd',
+						sources: []
+					};
+					const assetMapSourceString = JSON.stringify(assetMapSource);
+					assert.isObject(assetMap);
+					assert.strictEqual(assetMap.source(), assetMapSourceString);
+					assert.strictEqual(assetMap.size(), Buffer.byteLength(assetMapSourceString));
+					assert.isTrue(asset.source().endsWith('\n/*# sourceMappingURL=styles.css.map*/'));
+				});
+			});
+
+			it('inlines CSS sourcemaps with a flag', () => {
+				const source = `module.exports = {}`;
+				const sourceMap = { mappings: 'abcd', sources: [] };
+				const cssModule = {
+					resource: 'src/dir/styles.css',
+					originalSource: () => ({
+						source: () => source
+					}),
+					dependencies: [
+						{
+							content: source,
+							identifier: 'src/dir/styles.css',
+							sourceMap
+						}
+					]
+				};
+
+				return applyCssModule(cssModule, { inlineSourceMaps: true }).then((compilation) => {
+					const asset = compilation.assets['dir/styles.css'];
+					const sourceMapUrl = `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
+						JSON.stringify(sourceMap)
+					).toString('base64')}*/`;
+					assert.isTrue(asset.source().endsWith(sourceMapUrl));
+					assert.isUndefined(compilation.assets['dir/styles.css.map']);
+				});
+			});
+
+			it('removes the base path from the source map sources', () => {
+				const source = `module.exports = {}`;
+				const sourceMap = {
+					mappings: 'abcd',
+					sources: ['src/dir/styles.css']
+				};
+				const cssModule = {
+					resource: 'src/dir/styles.css',
+					originalSource: () => ({
+						source: () => source
+					}),
+					dependencies: [
+						{
+							content: source,
+							identifier: 'src/dir/styles.css',
+							sourceMap
+						}
+					]
+				};
+
+				return applyCssModule(cssModule).then((compilation) => {
+					const assetMap = compilation.assets['dir/styles.css.map'];
+					const assetMapSource = {
+						mappings: 'abcd',
+						sources: [path.relative('src/', 'src/dir/styles.css')]
+					};
+					const assetMapSourceString = JSON.stringify(assetMapSource);
+					assert.strictEqual(assetMap.source(), assetMapSourceString);
+				});
+			});
+		});
+	});
+
+	describe('transformer', () => {
+		it('registers .d.ts files to be emitted', () => {
+			const factory = mockModule.getModuleUnderTest().emitAllFactory;
+			const { plugin, transformer } = factory({
+				basePath: '/src'
+			});
+			const context = {};
+			const node = {
+				resolvedModules: new Map([
+					['name.d.ts', { extension: '.d.ts', resolvedFileName: '/src/name.d.ts' }],
+					['name.ts', { extension: '.ts', resolvedFileName: '/src/name.ts' }]
+				])
+			};
+			transformer(context)(node);
+			const compilation = createCompilation(compiler);
+			plugin.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+			assert.isDefined(compilation.assets['name.d.ts']);
+		});
+
+		it('ignores .d.ts files outside the src path or those that do not exist', () => {
+			const factory = mockModule.getModuleUnderTest().emitAllFactory;
+			const { plugin, transformer } = factory({
+				basePath: '/src'
+			});
+			const context = {};
+			const node = {
+				resolvedModules: new Map([
+					['foo.d.ts', { extension: '.d.ts', resolvedFileName: '/node_modules/foo.d.ts' }],
+					['bar.d.ts', { extension: '.d.ts', resolvedFileName: '/src/bar.d.ts' }]
+				])
+			};
+			mockModule.getMock('fs').existsSync = stub().callsFake((file: string) => {
+				return !file.includes('bar.d.ts');
+			});
+			transformer(context)(node);
+			const compilation = createCompilation(compiler);
+			plugin.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+			assert.isUndefined(compilation.assets['foo.d.ts']);
+			assert.isUndefined(compilation.assets['bar.d.ts']);
+		});
+
+		it('guards against malformed nodes', () => {
+			const factory = mockModule.getModuleUnderTest().emitAllFactory;
+			const { plugin, transformer } = factory({
+				basePath: '/src'
+			});
+			const context = {};
+			const node = {
+				resolvedModules: new Map([['foo.d.ts', null]])
+			};
+			mockModule.getMock('fs').existsSync = stub().callsFake((file: string) => {
+				return !file.includes('bar.d.ts');
+			});
+			transformer(context)(node);
+			transformer(context)({});
+			const compilation = createCompilation(compiler);
+			plugin.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+			assert.deepEqual(compilation.assets, {});
 		});
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Since the usual Webpack pipeline does not provide a convenient way to emit TypeScript declaration files that are an import target (e.g., when importing an interface from a declaration file), create a transformer that manually adds declaration files in the base path encountered in the build pipeline to the compilation assets.

As a result, given the following example file, `./foo.d.ts` will be emitted, but `@dojo/framework/core/interfaces.d.ts` will not:

```
import { EventHandler } from '@dojo/frameworks/core/interfaces';
import { SomeInterface } from './foo'; // foo.d.ts
```
