### PR TITLE
Update Element transformer to support function-based widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ export class Hello extends WidgetBase<HelloProperties> {
 		]);
 	}
 }
-Hello.prototype.__customElementDescriptor = { ...{ tagName: 'widget-hello', attributes: ['name'], properties: ['flag'], events: ['onClick', onChange'] }, ...Hello.prototype.__customElementDescriptor || {} };
+Hello.__customElementDescriptor = { ...{ tagName: 'widget-hello', attributes: ['name'], properties: ['flag'], events: ['onClick', onChange'] }, ...Hello.prototype.__customElementDescriptor || {} };
 
 export default Hello;
 ```

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "puppeteer": "1.11.0",
     "recast": "0.12.7",
     "source-map": "0.6.1",
-    "ts-loader": "5.3.0",
+    "ts-loader": "5.4.5",
     "ts-node": "^8.0.3",
     "typed-css-modules": "0.3.7",
     "webpack-hot-middleware": "2.24.3",

--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -37,75 +37,131 @@ export default function elementTransformer<T extends ts.Node>(
 				: [];
 			const classSymbol =
 				ts.isClassDeclaration(node) && node.name ? checker.getSymbolAtLocation(node.name) : undefined;
-			const classNode = node as ts.ClassDeclaration;
+			const variableSymbol =
+				ts.isVariableDeclaration(node) && node.name ? checker.getSymbolAtLocation(node.name) : undefined;
+
+			let widgetName: string = '';
+			const attributes: string[] = [];
+			const properties: string[] = [];
+			const events: string[] = [];
+			let propertyAccess: ts.PropertyAccessExpression | undefined = undefined;
+
+			function parsePropertyType(prop: ts.Symbol, locationNode: ts.Node) {
+				const type = checker.getTypeOfSymbolAtLocation(prop, locationNode);
+				const name = prop.getName();
+				let types = [type];
+
+				const intersectionType = type as ts.UnionOrIntersectionType;
+
+				if (intersectionType.types && intersectionType.types.length > 0) {
+					types = intersectionType.types;
+				}
+
+				types = types.filter((type) => checker.typeToString(type) !== 'undefined');
+
+				if (types.length === 1) {
+					if (
+						name.indexOf('on') === 0 &&
+						checker.getSignaturesOfType(types[0], ts.SignatureKind.Call).length > 0
+					) {
+						events.push(name);
+					} else if (checker.typeToString(types[0]) === 'string') {
+						attributes.push(name);
+					} else {
+						properties.push(name);
+					}
+				} else {
+					if (types.some((type) => Boolean(type.flags & ts.TypeFlags.StringLike))) {
+						attributes.push(name);
+					} else {
+						properties.push(name);
+					}
+				}
+			}
 
 			if (
 				customElementFilesIncludingDefaults.indexOf(path.resolve(node.getSourceFile().fileName)) !== -1 &&
 				defaultExport &&
+				variableSymbol &&
+				checker.getTypeOfSymbolAtLocation(defaultExport, node.getSourceFile()) ===
+					checker.getTypeOfSymbolAtLocation(variableSymbol, node)
+			) {
+				const variableNode = node as ts.VariableDeclaration;
+				const initializer = variableNode.initializer;
+				if (initializer && ts.isCallExpression(initializer)) {
+					const call = initializer as ts.CallExpression;
+					const renderOptionsCallback = call.arguments[0];
+					let optionsNode: ts.Node | undefined;
+					if (ts.isFunctionLike(renderOptionsCallback)) {
+						optionsNode = renderOptionsCallback.parameters[0];
+					} else if (ts.isIdentifier(renderOptionsCallback)) {
+						// TODO
+						// const type = checker.getTypeAtLocation(renderOptionsCallback);
+						// type.is
+						// ts.isFunctionTypeNode(type)
+						// (renderOptionsCallback as ts.Identifier).
+						optionsNode = undefined;
+					}
+
+					if (optionsNode) {
+						const typeOfOptions = checker.getTypeAtLocation(optionsNode);
+						const properties = typeOfOptions.getProperty('properties');
+						const typeOfProperties =
+							properties && checker.getTypeOfSymbolAtLocation(properties, optionsNode);
+						if (typeOfProperties) {
+							typeOfProperties.getProperties().forEach((prop) => {
+								parsePropertyType(prop, optionsNode!);
+							});
+							widgetName = variableNode.name!.getText();
+							propertyAccess = ts.createPropertyAccess(
+								ts.createIdentifier(widgetName),
+								'__customElementDescriptor'
+							);
+						}
+					}
+				}
+			} else if (
+				customElementFilesIncludingDefaults.indexOf(path.resolve(node.getSourceFile().fileName)) !== -1 &&
+				defaultExport &&
 				classSymbol &&
 				checker.getTypeOfSymbolAtLocation(defaultExport, node.getSourceFile()) ===
-					checker.getTypeOfSymbolAtLocation(classSymbol, node) &&
-				classNode.heritageClauses &&
-				classNode.heritageClauses.length > 0
+					checker.getTypeOfSymbolAtLocation(classSymbol, node)
 			) {
-				const widgetName = classNode.name!.getText();
+				const classNode = node as ts.ClassDeclaration;
+				if (classNode.heritageClauses && classNode.heritageClauses.length > 0) {
+					widgetName = classNode.name!.getText();
+
+					const [
+						{
+							types: [{ typeArguments = [] }]
+						}
+					] = classNode.heritageClauses;
+
+					if (typeArguments.length) {
+						const widgetPropNode = typeArguments[0];
+						const widgetPropNodeSymbol = checker.getSymbolAtLocation(widgetPropNode.getChildAt(0));
+
+						if (widgetPropNodeSymbol) {
+							const widgetPropType = checker.getDeclaredTypeOfSymbol(widgetPropNodeSymbol);
+							const widgetProps = widgetPropType.getProperties();
+
+							widgetProps.forEach((prop) => {
+								parsePropertyType(prop, widgetPropNode);
+							});
+						}
+					}
+
+					propertyAccess = ts.createPropertyAccess(
+						ts.createPropertyAccess(ts.createIdentifier(widgetName), ts.createIdentifier('prototype')),
+						'__customElementDescriptor'
+					);
+				}
+			}
+
+			if (widgetName && propertyAccess) {
 				const tagName = `${preparedElementPrefix}-${widgetName
 					.replace(/([a-z])([A-Z])/g, '$1-$2')
 					.toLowerCase()}`;
-
-				const [
-					{
-						types: [{ typeArguments = [] }]
-					}
-				] = classNode.heritageClauses;
-
-				const attributes: string[] = [];
-				const properties: string[] = [];
-				const events: string[] = [];
-
-				if (typeArguments.length) {
-					const widgetPropNode = typeArguments[0];
-					const widgetPropNodeSymbol = checker.getSymbolAtLocation(widgetPropNode.getChildAt(0));
-
-					if (widgetPropNodeSymbol) {
-						const widgetPropType = checker.getDeclaredTypeOfSymbol(widgetPropNodeSymbol);
-						const widgetProps = widgetPropType.getProperties();
-
-						widgetProps.forEach((prop) => {
-							const type = checker.getTypeOfSymbolAtLocation(prop, widgetPropNode);
-							const name = prop.getName();
-
-							let types = [type];
-
-							const intersectionType = type as ts.UnionOrIntersectionType;
-
-							if (intersectionType.types && intersectionType.types.length > 0) {
-								types = intersectionType.types;
-							}
-
-							types = types.filter((type) => checker.typeToString(type) !== 'undefined');
-
-							if (types.length === 1) {
-								if (
-									name.indexOf('on') === 0 &&
-									checker.getSignaturesOfType(types[0], ts.SignatureKind.Call).length > 0
-								) {
-									events.push(name);
-								} else if (checker.typeToString(types[0]) === 'string') {
-									attributes.push(name);
-								} else {
-									properties.push(name);
-								}
-							} else {
-								if (types.some((type) => Boolean(type.flags & ts.TypeFlags.StringLike))) {
-									attributes.push(name);
-								} else {
-									properties.push(name);
-								}
-							}
-						});
-					}
-				}
 
 				const customElementDeclaration = ts.createObjectLiteral([
 					ts.createPropertyAssignment('tagName', ts.createLiteral(tagName)),
@@ -123,13 +179,8 @@ export default function elementTransformer<T extends ts.Node>(
 					)
 				]);
 
-				const prototypeAccess = ts.createPropertyAccess(
-					ts.createPropertyAccess(ts.createIdentifier(widgetName), ts.createIdentifier('prototype')),
-					'__customElementDescriptor'
-				);
-
 				const existingDescriptor = ts.createBinary(
-					prototypeAccess,
+					propertyAccess,
 					ts.SyntaxKind.BarBarToken,
 					ts.createObjectLiteral()
 				);
@@ -138,7 +189,7 @@ export default function elementTransformer<T extends ts.Node>(
 					node,
 					ts.createStatement(
 						ts.createAssignment(
-							prototypeAccess,
+							propertyAccess,
 							ts.createObjectLiteral([
 								ts.createSpreadAssignment(customElementDeclaration),
 								ts.createSpreadAssignment(existingDescriptor)

--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -173,7 +173,7 @@ export default function elementTransformer<T extends ts.Node>(
 					}
 
 					propertyAccess = ts.createPropertyAccess(
-						ts.createPropertyAccess(ts.createIdentifier(widgetName), ts.createIdentifier('prototype')),
+						ts.createIdentifier(widgetName),
 						'__customElementDescriptor'
 					);
 				}

--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -30,13 +30,16 @@ export default function elementTransformer<T extends ts.Node>(
 		.trim();
 
 	function createCustomElementExpression(
-		identifier: string,
+		identifier: string | ts.Identifier,
 		widgetName: string,
 		attributes: string[],
 		properties: string[],
 		events: string[]
 	) {
-		const propertyAccess = ts.createPropertyAccess(ts.createIdentifier(identifier), '__customElementDescriptor');
+		const propertyAccess = ts.createPropertyAccess(
+			typeof identifier === 'string' ? ts.createIdentifier(identifier) : identifier,
+			'__customElementDescriptor'
+		);
 		const tagName = `${preparedElementPrefix}-${widgetName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`;
 
 		const customElementDeclaration = ts.createObjectLiteral([
@@ -175,6 +178,7 @@ export default function elementTransformer<T extends ts.Node>(
 								});
 								widgetName = variableNode.name!.getText();
 
+								const uniqueIdentifier = ts.createUniqueName('temp');
 								const updatedNode = ts.updateVariableDeclaration(
 									variableNode,
 									variableNode.name,
@@ -190,19 +194,19 @@ export default function elementTransformer<T extends ts.Node>(
 												[
 													ts.createVariableStatement(undefined, [
 														ts.createVariableDeclaration(
-															ts.createIdentifier('temp'),
+															uniqueIdentifier,
 															undefined,
 															variableNode.initializer
 														)
 													]),
 													createCustomElementExpression(
-														'temp',
+														uniqueIdentifier,
 														widgetName,
 														attributes,
 														properties,
 														events
 													),
-													ts.createReturn(ts.createIdentifier('temp'))
+													ts.createReturn(uniqueIdentifier)
 												],
 												true
 											)

--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -73,7 +73,7 @@ export default function elementTransformer<T extends ts.Node>(
 				: [];
 			const classSymbol =
 				ts.isClassDeclaration(node) && node.name ? checker.getSymbolAtLocation(node.name) : undefined;
-			// const isVariableStatement = ts.isVariableStatement(node);
+
 			const defaultExportType =
 				defaultExport && checker.getTypeOfSymbolAtLocation(defaultExport, node.getSourceFile());
 

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -435,6 +435,142 @@ describe('element-transformer', () => {
 			);
 		});
 
+		it('it handles a direct export type', () => {
+			const source = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: () => B & T }) => string) {
+                		return (properties: B & T) => '';
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+		export default render(function DojoInput({ properties }) {
+			return 'foo'
+		});
+		`;
+			const expected = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: () => B & T }) => string) {
+                		return (properties: B & T) => '';
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+		export default (() => {
+			var temp_1 = render(function DojoInput({ properties }) {
+				return 'foo'
+			});
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };	
+			return temp_1;
+		})();
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
+
+		it('it handles a direct export with no function name', () => {
+			const source = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: () => B & T }) => string) {
+                		return (properties: B & T) => '';
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+		export default render(({ properties }) => 'foo');
+		`;
+			const expected = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: () => B & T }) => string) {
+                		return (properties: B & T) => '';
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+		export default (() => {
+			var temp_1 = render(({ properties }) => 'foo');
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-actual", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };	
+			return temp_1;
+		})();
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
+
 		it('it handles an explicit type', () => {
 			const source = `
 		enum StringEnum { value1 = 'value1', value2 = 'value2' };

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -9,56 +9,57 @@ const actualPath = path.resolve('actual.ts');
 const expectedPath = path.resolve('expected.ts');
 
 describe('element-transformer', () => {
-	it('does not touch classes that are not the default export', () => {
-		const source = `
+	describe('classes', () => {
+		it('does not touch classes that are not the default export', () => {
+			const source = `
 		class WidgetBase<T> {}
 		interface DojoInputProperties {}
 		export class DojoInput extends WidgetBase<DojoInputProperties> {
 		}`;
-		assertCompile(
-			{
-				[actualPath]: source,
-				[expectedPath]: source
-			},
-			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
-			})
-		);
-	});
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: source
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
 
-	it('it modifies classes that are explicitly the default export', () => {
-		const source = `
+		it('it modifies classes that are explicitly the default export', () => {
+			const source = `
 		class WidgetBase<T> {}
 		interface DojoInputProperties {}
 		export default class DojoInput extends WidgetBase<DojoInputProperties> {
 		}`;
-		const expected = `
+			const expected = `
 		class WidgetBase<T> {}
 		interface DojoInputProperties {}
 		export default class DojoInput extends WidgetBase<DojoInputProperties> {
 		}
 		DojoInput.prototype.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
 `;
-		assertCompile(
-			{
-				[actualPath]: source,
-				[expectedPath]: expected
-			},
-			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
-			})
-		);
-	});
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
 
-	it('it modifies classes that are the default export, but aliased', () => {
-		const source = `
+		it('it modifies classes that are the default export, but aliased', () => {
+			const source = `
 			class WidgetBase<T> {}
 			interface DojoInputProperties {}
 			export class DojoInput extends WidgetBase<DojoInputProperties> {
 			}
 			export default DojoInput;
 	`;
-		const expected = `
+			const expected = `
 			class WidgetBase<T> {}
 			interface DojoInputProperties {}
 			export class DojoInput extends WidgetBase<DojoInputProperties> {
@@ -66,45 +67,45 @@ describe('element-transformer', () => {
 			DojoInput.prototype.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
 			export default DojoInput;
 	`;
-		assertCompile(
-			{
-				[actualPath]: source,
-				[expectedPath]: expected
-			},
-			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
-			})
-		);
-	});
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
 
-	it('it does not modify classes that are not listed in files', () => {
-		const source = `
+		it('it does not modify classes that are not listed in files', () => {
+			const source = `
 			class WidgetBase<T> {}
 			interface DojoInputProperties {}
 			export class DojoInput extends WidgetBase<DojoInputProperties> {
 			}
 			export default DojoInput;
 	`;
-		const expected = `
+			const expected = `
 			class WidgetBase<T> {}
 			interface DojoInputProperties {}
 			export class DojoInput extends WidgetBase<DojoInputProperties> {
 			}
 			export default DojoInput;
 	`;
-		assertCompile(
-			{
-				[actualPath]: source,
-				[expectedPath]: expected
-			},
-			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [] })]
-			})
-		);
-	});
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [] })]
+				})
+			);
+		});
 
-	it('it adds attributes, properties, and events', () => {
-		const source = `
+		it('it adds attributes, properties, and events', () => {
+			const source = `
 			enum StringEnum { value1 = 'value1', value2 = 'value2' };
 			enum IntEnum { value1 = 0, value 2 = 1 };
 			type stringOrNumber = string | number;
@@ -122,7 +123,7 @@ describe('element-transformer', () => {
 			export default class DojoInput extends WidgetBase<DojoInputProperties> {
 			}
 	`;
-		const expected = `
+			const expected = `
 			enum StringEnum { value1 = 'value1', value2 = 'value2' };
 			enum IntEnum { value1 = 0, value 2 = 1 };
 			type stringOrNumber = string | number;
@@ -138,63 +139,357 @@ describe('element-transformer', () => {
 			}
 			DojoInput.prototype.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.prototype.__customElementDescriptor || {} };
 	`;
-		assertCompile(
-			{
-				[actualPath]: source,
-				[expectedPath]: expected
-			},
-			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
-			})
-		);
-	});
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
 
-	it('it leaves classes that do not extend', () => {
-		const source = `
+		it('it leaves classes that do not extend', () => {
+			const source = `
 			interface DojoInputProperties {
 			}
 			export default class DojoInput {
 			}
 	`;
-		assertCompile(
-			{
-				[actualPath]: source,
-				[expectedPath]: source
-			},
-			(program) => ({
-				before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
-			})
-		);
-	});
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: source
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
 
-	it('it modifies classes that do not take generics', () => {
-		const source = `
+		it('it modifies classes that do not take generics', () => {
+			const source = `
 			export class WidgetBase {
 			}
 			export default class DojoInput extends WidgetBase {
 			}
 	`;
-		const expected = `
+			const expected = `
 			export class WidgetBase {
 			}
 			export default class DojoInput extends WidgetBase {
 			}
 			DojoInput.prototype.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
 	`;
-		assertCompile(
-			{
-				[actualPath]: source,
-				[expectedPath]: expected
-			},
-			(program) => ({
-				before: [
-					elementTransformer(program, {
-						elementPrefix: 'widget',
-						customElementFiles: [actualPath]
-					})
-				]
-			})
-		);
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [actualPath]
+						})
+					]
+				})
+			);
+		});
+	});
+
+	describe('function-based widgets', () => {
+		it('does not touch function-based widgets that are not the default export', () => {
+			const source = `
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {}
+		const render = create().properties<DojoInputProperties>();
+		export const DojoInput = render(({ properties }) => 'foo');
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: source
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
+
+		it('it modifies function-based widgets that are explicitly the default export', () => {
+			const source = `
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {}
+		const render = create().properties<DojoInputProperties>();
+		const DojoInput = render(({ properties }) => 'foo');
+		export default DojoInput;
+		`;
+			const expected = `
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {}
+		const render = create().properties<DojoInputProperties>();
+		const DojoInput = render(({ properties }) => 'foo');
+		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
+		export default DojoInput;
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
+
+		it('it does not modify function-based widgets that are not listed in files', () => {
+			const source = `
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {}
+		const render = create().properties<DojoInputProperties>();
+		const DojoInput = render(({ properties }) => 'foo');
+		export default DojoInput;
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: source
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [] })]
+				})
+			);
+		});
+
+		it('it adds attributes, properties, and events', () => {
+			const source = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create().properties<DojoInputProperties>();
+		const DojoInput = render(({ properties }) => 'foo');
+		export default DojoInput;
+		`;
+			const expected = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create().properties<DojoInputProperties>();
+		const DojoInput = render(({ properties }) => 'foo');
+		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.__customElementDescriptor || {} };
+		export default DojoInput;
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
+
+		it('it handles a combined type', () => {
+			const source = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+		const DojoInput = render(({ properties }) => 'foo');
+		export default DojoInput;
+		`;
+			const expected = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+		const DojoInput = render(({ properties }) => 'foo');
+		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.__customElementDescriptor || {} };
+		export default DojoInput;
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
+
+		it('it handles an explicit type', () => {
+			const source = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create().properties();
+		const DojoInput = render(({ properties }: { properties: { bar: string; } }) => 'foo');
+		export default DojoInput;
+		`;
+			const expected = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: B & T }) => string) {
+                		return (properties: B & T) => '';    
+            	}
+    		};
+		}
+
+		interface DojoInputProperties {
+			attribute: string;
+			property: boolean;
+			onClick: () => void;
+			onChange(value: string): void;
+			stringEnum: StringEnum;
+			intEnum?: IntEnum;
+			stringOrNumber: stringOrNumber;
+		}
+		const render = create().properties();
+		const DojoInput = render(({ properties }: { properties: { bar: string; } }) => 'foo');
+		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
+		export default DojoInput;
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
 	});
 });
 
@@ -228,6 +523,7 @@ function assertCompile(
 	if (resultExpected.diagnostics.length) {
 		console.error(resultActual.diagnostics.map((n) => 'expected: ' + n.messageText).join('\n'));
 	}
+
 	assert.equal(outputs['actual.js'], outputs['expected.js'], errorMessage);
 }
 
@@ -236,7 +532,8 @@ function testCompilerHost(inputs: Record<string, string>, outputs: Record<string
 		getSourceFile,
 		getDefaultLibFileName: () => 'lib.d.ts',
 		writeFile: (fileName: string, content: string) => {
-			outputs[fileName] = content;
+			const split = fileName.split(/[/\\]/);
+			outputs[split[split.length - 1]] = content;
 		},
 		getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
 		getDirectories: (path) => ts.sys.getDirectories(path),

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -38,7 +38,7 @@ describe('element-transformer', () => {
 		interface DojoInputProperties {}
 		export default class DojoInput extends WidgetBase<DojoInputProperties> {
 		}
-		DojoInput.prototype.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
+		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
 `;
 			assertCompile(
 				{
@@ -64,7 +64,7 @@ describe('element-transformer', () => {
 			interface DojoInputProperties {}
 			export class DojoInput extends WidgetBase<DojoInputProperties> {
 			}
-			DojoInput.prototype.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
+			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
 			export default DojoInput;
 	`;
 			assertCompile(
@@ -109,7 +109,7 @@ describe('element-transformer', () => {
 			enum StringEnum { value1 = 'value1', value2 = 'value2' };
 			enum IntEnum { value1 = 0, value 2 = 1 };
 			type stringOrNumber = string | number;
-			
+
 			class WidgetBase<T> {}
 			interface DojoInputProperties {
 				attribute: string;
@@ -137,7 +137,7 @@ describe('element-transformer', () => {
 			}
 			export default class DojoInput extends WidgetBase<DojoInputProperties> {
 			}
-			DojoInput.prototype.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.prototype.__customElementDescriptor || {} };
+			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.prototype.__customElementDescriptor || {} };
 	`;
 			assertCompile(
 				{
@@ -180,7 +180,7 @@ describe('element-transformer', () => {
 			}
 			export default class DojoInput extends WidgetBase {
 			}
-			DojoInput.prototype.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
+			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
 	`;
 			assertCompile(
 				{
@@ -206,7 +206,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -232,7 +232,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -247,7 +247,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -275,7 +275,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -305,7 +305,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -331,7 +331,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -370,7 +370,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -396,7 +396,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -435,7 +435,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}
@@ -461,7 +461,7 @@ describe('element-transformer', () => {
     		return {
         		properties: <T>() =>
             		function render(callback: (options: { properties: B & T }) => string) {
-                		return (properties: B & T) => '';    
+                		return (properties: B & T) => '';
             	}
     		};
 		}

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -254,8 +254,11 @@ describe('element-transformer', () => {
 
 		interface DojoInputProperties {}
 		const render = create().properties<DojoInputProperties>();
-		const DojoInput = render(({ properties }) => 'foo');
-		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
+		const DojoInput = (() => {
+			var temp = render(({ properties }) => 'foo');
+			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...temp.__customElementDescriptor || {} };	
+			return temp;
+		})()
 		export default DojoInput;
 		`;
 			assertCompile(
@@ -346,8 +349,11 @@ describe('element-transformer', () => {
 			stringOrNumber: stringOrNumber;
 		}
 		const render = create().properties<DojoInputProperties>();
-		const DojoInput = render(({ properties }) => 'foo');
-		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.__customElementDescriptor || {} };
+		const DojoInput = (() => {
+			var temp = render(({ properties }) => 'foo')
+			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp.__customElementDescriptor || {} };
+			return temp;
+		})();
 		export default DojoInput;
 		`;
 			assertCompile(
@@ -411,8 +417,11 @@ describe('element-transformer', () => {
 			stringOrNumber: stringOrNumber;
 		}
 		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
-		const DojoInput = render(({ properties }) => 'foo');
-		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.__customElementDescriptor || {} };
+		const DojoInput = (() => {
+			var temp = render(({ properties }) => 'foo');
+			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp.__customElementDescriptor || {} };	
+			return temp;
+		})();
 		export default DojoInput;
 		`;
 			assertCompile(
@@ -458,8 +467,11 @@ describe('element-transformer', () => {
 		}
 
 		const render = create().properties();
-		const DojoInput = render(({ properties }: { properties: () => { bar: string; } }) => 'foo');
-		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
+		const DojoInput = (() => {
+			var temp = render(({ properties }: { properties: () => { bar: string; } }) => 'foo');	
+			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...temp.__customElementDescriptor || {} };	
+			return temp;
+		})();
 		export default DojoInput;
 		`;
 			assertCompile(
@@ -513,8 +525,11 @@ describe('element-transformer', () => {
 		type Options = { properties: Props };
 		type Callback = (options: Options) => any;
 		const callback: Callback = () => 'foo';
-		const DojoInput = render(callback);
-		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
+		const DojoInput = (() => {
+			var temp = render(callback);
+			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...temp.__customElementDescriptor || {} };	
+			return temp;
+		})();
 		export default DojoInput;
 		`;
 			assertCompile(

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -255,9 +255,9 @@ describe('element-transformer', () => {
 		interface DojoInputProperties {}
 		const render = create().properties<DojoInputProperties>();
 		const DojoInput = (() => {
-			var temp = render(({ properties }) => 'foo');
-			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...temp.__customElementDescriptor || {} };	
-			return temp;
+			var temp_1 = render(({ properties }) => 'foo');
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...temp_1.__customElementDescriptor || {} };	
+			return temp_1;
 		})()
 		export default DojoInput;
 		`;
@@ -350,9 +350,9 @@ describe('element-transformer', () => {
 		}
 		const render = create().properties<DojoInputProperties>();
 		const DojoInput = (() => {
-			var temp = render(({ properties }) => 'foo')
-			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp.__customElementDescriptor || {} };
-			return temp;
+			var temp_1 = render(({ properties }) => 'foo')
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };
+			return temp_1;
 		})();
 		export default DojoInput;
 		`;
@@ -418,9 +418,9 @@ describe('element-transformer', () => {
 		}
 		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
 		const DojoInput = (() => {
-			var temp = render(({ properties }) => 'foo');
-			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp.__customElementDescriptor || {} };	
-			return temp;
+			var temp_1 = render(({ properties }) => 'foo');
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };	
+			return temp_1;
 		})();
 		export default DojoInput;
 		`;
@@ -468,9 +468,9 @@ describe('element-transformer', () => {
 
 		const render = create().properties();
 		const DojoInput = (() => {
-			var temp = render(({ properties }: { properties: () => { bar: string; } }) => 'foo');	
-			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...temp.__customElementDescriptor || {} };	
-			return temp;
+			var temp_1 = render(({ properties }: { properties: () => { bar: string; } }) => 'foo');	
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...temp_1.__customElementDescriptor || {} };	
+			return temp_1;
 		})();
 		export default DojoInput;
 		`;
@@ -526,9 +526,9 @@ describe('element-transformer', () => {
 		type Callback = (options: Options) => any;
 		const callback: Callback = () => 'foo';
 		const DojoInput = (() => {
-			var temp = render(callback);
-			temp.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...temp.__customElementDescriptor || {} };	
-			return temp;
+			var temp_1 = render(callback);
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...temp_1.__customElementDescriptor || {} };	
+			return temp_1;
 		})();
 		export default DojoInput;
 		`;

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -38,7 +38,7 @@ describe('element-transformer', () => {
 		interface DojoInputProperties {}
 		export default class DojoInput extends WidgetBase<DojoInputProperties> {
 		}
-		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
+		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
 `;
 			assertCompile(
 				{
@@ -64,7 +64,7 @@ describe('element-transformer', () => {
 			interface DojoInputProperties {}
 			export class DojoInput extends WidgetBase<DojoInputProperties> {
 			}
-			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
+			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
 			export default DojoInput;
 	`;
 			assertCompile(
@@ -137,7 +137,7 @@ describe('element-transformer', () => {
 			}
 			export default class DojoInput extends WidgetBase<DojoInputProperties> {
 			}
-			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.prototype.__customElementDescriptor || {} };
+			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...DojoInput.__customElementDescriptor || {} };
 	`;
 			assertCompile(
 				{
@@ -180,7 +180,7 @@ describe('element-transformer', () => {
 			}
 			export default class DojoInput extends WidgetBase {
 			}
-			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.prototype.__customElementDescriptor || {} };
+			DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
 	`;
 			assertCompile(
 				{
@@ -205,7 +205,7 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
@@ -231,7 +231,7 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
@@ -246,7 +246,7 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
@@ -274,7 +274,7 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
@@ -304,7 +304,7 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
@@ -330,7 +330,7 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
@@ -369,7 +369,7 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
@@ -395,7 +395,7 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
@@ -434,23 +434,14 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
 		}
 
-		interface DojoInputProperties {
-			attribute: string;
-			property: boolean;
-			onClick: () => void;
-			onChange(value: string): void;
-			stringEnum: StringEnum;
-			intEnum?: IntEnum;
-			stringOrNumber: stringOrNumber;
-		}
 		const render = create().properties();
-		const DojoInput = render(({ properties }: { properties: { bar: string; } }) => 'foo');
+		const DojoInput = render(({ properties }: { properties: () => { bar: string; } }) => 'foo');
 		export default DojoInput;
 		`;
 			const expected = `
@@ -460,24 +451,124 @@ describe('element-transformer', () => {
 		function create<A = any, B = {}>() {
     		return {
         		properties: <T>() =>
-            		function render(callback: (options: { properties: B & T }) => string) {
+            		function render(callback: (options: { properties: () => B & T }) => string) {
                 		return (properties: B & T) => '';
             	}
     		};
 		}
 
-		interface DojoInputProperties {
-			attribute: string;
-			property: boolean;
-			onClick: () => void;
-			onChange(value: string): void;
-			stringEnum: StringEnum;
-			intEnum?: IntEnum;
-			stringOrNumber: stringOrNumber;
-		}
 		const render = create().properties();
-		const DojoInput = render(({ properties }: { properties: { bar: string; } }) => 'foo');
+		const DojoInput = render(({ properties }: { properties: () => { bar: string; } }) => 'foo');
 		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
+		export default DojoInput;
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
+
+		it('handles using variables and types in widget creation', () => {
+			const source = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: () => B & T }) => string) {
+                		return (properties: B & T) => '';
+            	}
+    		};
+		}
+
+		const render = create().properties();
+		type Props = () => { bar: string; };
+		type Options = { properties: Props };
+		type Callback = (options: Options) => any;
+		const callback: Callback = () => 'foo';
+		const DojoInput = render(callback);
+		export default DojoInput;
+		`;
+			const expected = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: { properties: () => B & T }) => string) {
+                		return (properties: B & T) => '';
+            	}
+    		};
+		}
+
+		const render = create().properties();
+		type Props = () => { bar: string; };
+		type Options = { properties: Props };
+		type Callback = (options: Options) => any;
+		const callback: Callback = () => 'foo';
+		const DojoInput = render(callback);
+		DojoInput.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
+		export default DojoInput;
+		`;
+			assertCompile(
+				{
+					[actualPath]: source,
+					[expectedPath]: expected
+				},
+				(program) => ({
+					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+				})
+			);
+		});
+
+		it('ignores default exports that have the wrong signature', () => {
+			const source = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: () => { properties: () => B & T }) => string) {
+                		return (properties: B & T) => '';
+            	}
+    		};
+		}
+
+		const render = create().properties();
+		type Props = () => { bar: string; };
+		type Options = () => { properties: Props };
+		type Callback = (options: Options) => any;
+		const callback: Callback = () => 'foo';
+		const DojoInput = render(callback);
+		export default DojoInput;
+		`;
+			const expected = `
+		enum StringEnum { value1 = 'value1', value2 = 'value2' };
+		enum IntEnum { value1 = 0, value 2 = 1 };
+		type stringOrNumber = string | number;
+		function create<A = any, B = {}>() {
+    		return {
+        		properties: <T>() =>
+            		function render(callback: (options: () => { properties: () => B & T }) => string) {
+                		return (properties: B & T) => '';
+            	}
+    		};
+		}
+
+		const render = create().properties();
+		type Props = () => { bar: string; };
+		type Options = () => { properties: Props };
+		type Callback = (options: Options) => any;
+		const callback: Callback = () => 'foo';
+		const DojoInput = render(callback);
 		export default DojoInput;
 		`;
 			assertCompile(


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Updates the custom element transformation to support function-based widgets. 

I think the one thing worth explicitly calling out is the fact that I am not just doing a simple property assignment for the function-based widget.
The change to using an arrow function invocation is because the assignment to `FunctionalWidget.__customElementDescriptor` does not work when building in legacy mode. `FunctionalWidget = ...`  becomes `exports.FunctionalWidget = ...`, and it's not possible (as far as I can tell) to get TS to update the new property access to match. For a class the compiled output ends up being:
```
class X {}
exports.X = X;
```
So the same concern doesn't apply there.