### PR TITLE
Add chunks to html scripts that are loaded on Build Time Render

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -147,7 +147,7 @@ export default class BuildTimeRender {
 
 			additionalScripts
 				.sort((script1, script2) => {
-					return script1 === mainScript && !script2 === mainScript ? 1 : -1;
+					return script1 === mainScript && !(script2 === mainScript) ? 1 : -1;
 				})
 				.forEach((additionalChunk: string) => {
 					html = html.replace(

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -126,7 +126,7 @@ export default class BuildTimeRender {
 		}, '');
 
 		css = additionalCss.reduce((prev, url) => {
-			return `${prev}<link href="${prefix}${url}" rel="stylesheet">`;
+			return `${prev}<link rel="preload" href="${prefix}${url}" as="style">`;
 		}, css);
 
 		styles = await this._processCss(styles);
@@ -152,7 +152,7 @@ export default class BuildTimeRender {
 				.forEach((additionalChunk: string) => {
 					html = html.replace(
 						'</body>',
-						`<script type="text/javascript" src="${scriptPrefix}${additionalChunk}"></script></body>`
+						`<link rel="preload" href="${scriptPrefix}${additionalChunk}" as="script"></body>`
 					);
 				});
 		}
@@ -442,8 +442,8 @@ ${blockCacheEntry}`
 				await wait;
 				await this._waitForBridge();
 				const scripts = await getScriptSources(page, app.port);
-				const additionalScripts = scripts.filter((script) =>
-					this._entries.every((entry) => !script.endsWith(originalManifest[entry]))
+				const additionalScripts = scripts.filter(
+					(script) => script && this._entries.every((entry) => !script.endsWith(originalManifest[entry]))
 				);
 				const additionalCss = (await getPageStyles(page)).filter((url: string) =>
 					this._entries.every((entry) => !url.endsWith(originalManifest[entry.replace('.js', '.css')]))
@@ -473,8 +473,8 @@ ${blockCacheEntry}`
 					await wait;
 					await this._waitForBridge();
 					const scripts = await getScriptSources(page, app.port);
-					const additionalScripts = scripts.filter((script) =>
-						this._entries.every((entry) => !script.endsWith(originalManifest[entry]))
+					const additionalScripts = scripts.filter(
+						(script) => script && this._entries.every((entry) => !script.endsWith(originalManifest[entry]))
 					);
 					const additionalCss = (await getPageStyles(page)).filter((url: string) =>
 						this._entries.every((entry) => !url.endsWith(originalManifest[entry.replace('.js', '.css')]))

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -10,7 +10,9 @@ import {
 	generateRouteInjectionScript,
 	getScriptSources,
 	getForSelector,
-	setHasFlags
+	setHasFlags,
+	getPageScripts,
+	getPageStyles
 } from './helpers';
 import * as cssnano from 'cssnano';
 const filterCss = require('filter-css');
@@ -212,18 +214,12 @@ export default class BuildTimeRender {
 
 			const entryFilenames = this._entries.map((entry) => this._manifest[entry]);
 
-			additionalScripts = (await page.$$eval(
-				'script',
-				(scripts: any) => scripts.map((script: any) => script.getAttribute('src')) as string[]
-			))
+			additionalScripts = (await getPageScripts(page))
 				.map((url: string) => url.replace(/http:\/\/localhost:\d+\//g, ''))
 				.filter((url: string) => ignoreAdditionalScripts.every((rule) => !url.startsWith(rule)))
 				.filter((url: string) => entryFilenames.indexOf(url) === -1);
 
-			additionalCss = (await page.$$eval(
-				'link[rel=stylesheet]',
-				(links: any) => links.map((link: any) => link.getAttribute('href')) as string[]
-			))
+			additionalCss = (await getPageStyles(page))
 				.map((url: string) => url.replace(/http:\/\/localhost:\d+\//g, ''))
 				.filter((url: string) => ignoreAdditionalCss.every((rule) => !url.startsWith(rule)))
 				.filter((url: string) => entryFilenames.indexOf(url.replace('.css', '.js')) === -1);

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -54,6 +54,8 @@ function genHash(content: string): string {
 		.substr(0, 20);
 }
 
+const ignoreAdditionalChunks = ['main.js', 'bootstrap.js', 'runtime.js'];
+
 export default class BuildTimeRender {
 	private _cssFiles: string[] = [];
 	private _entries: string[];
@@ -74,7 +76,6 @@ export default class BuildTimeRender {
 	private _bridgePromises: Promise<any>[] = [];
 	private _blockErrors: Error[] = [];
 	private _hasBuildBridgeCache = false;
-	private _ignoreScripts = ['main.js', 'bootstrap.js'];
 
 	constructor(args: BuildTimeRenderArguments) {
 		const { paths = [], root = '', entries, useHistory, puppeteerOptions, basePath } = args;
@@ -200,7 +201,7 @@ export default class BuildTimeRender {
 			const jsCoverage = await page.coverage.stopJSCoverage();
 			additionalChunks = jsCoverage
 				.map((coverage: any) => coverage.url.replace(/http:\/\/localhost:\d+\//g, ''))
-				.filter((url: string) => this._ignoreScripts.indexOf(url) === -1);
+				.filter((url: string) => ignoreAdditionalChunks.every((rule) => !url.endsWith(rule)));
 		}
 
 		return {

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -146,9 +146,12 @@ export default class BuildTimeRender {
 					`<script type="text/javascript" src="${scriptPrefix}${blockScript}"></script></body>`
 				);
 			});
+
+			const mainScript = this._manifest['main.js'];
+
 			additionalScripts
 				.sort((script1, script2) => {
-					return script1.startsWith('main.') && !script2.startsWith('main.') ? 1 : -1;
+					return script1 === mainScript && !script2 === mainScript ? 1 : -1;
 				})
 				.forEach((additionalChunk: string) => {
 					html = html.replace(

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -120,3 +120,17 @@ export function getPrefix(path?: string) {
 				.join('/')}/`
 		: '';
 }
+
+export async function getPageScripts(page: any): Promise<string[]> {
+	return page.$$eval(
+		'script',
+		(scripts: any) => scripts.map((script: any) => script.getAttribute('src')) as string[]
+	);
+}
+
+export async function getPageStyles(page: any): Promise<string[]> {
+	return page.$$eval(
+		'link[rel=stylesheet]',
+		(links: any) => links.map((link: any) => link.getAttribute('href')) as string[]
+	);
+}

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -121,16 +121,11 @@ export function getPrefix(path?: string) {
 		: '';
 }
 
-export async function getPageScripts(page: any): Promise<string[]> {
-	return page.$$eval(
-		'script',
-		(scripts: any) => scripts.map((script: any) => script.getAttribute('src')) as string[]
-	);
-}
-
 export async function getPageStyles(page: any): Promise<string[]> {
-	return page.$$eval(
+	const css = await page.$$eval(
 		'link[rel=stylesheet]',
 		(links: any) => links.map((link: any) => link.getAttribute('href')) as string[]
 	);
+
+	return css.map((url: string) => url.replace(/http:\/\/localhost:\d+\//g, ''));
 }

--- a/tests/support/fixtures/build-time-render/build-bridge-hash/expected/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-hash/expected/index.html
@@ -5,5 +5,5 @@
 		<div id="app"><div>hello world a</div></div>
 		<script type="text/javascript" src="bootstrap.247d4597a12706983d2c.bundle.js"></script>
 		<script type="text/javascript" src="main.0123456789abcdefghij.bundle.js"></script>
-	<script type="text/javascript" src="runtime/block-49e457933c3c36eeb77f.9eba5eaa6f8cfe7b34e3.bundle.js" async="true"></script></body>
+	<script type="text/javascript" src="runtime/block-49e457933c3c36eeb77f.9eba5eaa6f8cfe7b34e3.bundle.js"></script></body>
 </html>

--- a/tests/support/fixtures/build-time-render/build-bridge/expected/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge/expected/index.html
@@ -4,5 +4,5 @@
 	<body>
 		<div id="app"><div>hello world a</div></div>
 		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
-	<script type="text/javascript" src="runtime/block-49e457933c3c36eeb77f.js" async="true"></script></body>
+	<script type="text/javascript" src="runtime/block-49e457933c3c36eeb77f.js"></script></body>
 </html>

--- a/tests/support/fixtures/build-time-render/build-bridge/expected/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge/expected/index.html
@@ -3,6 +3,6 @@
 	<style>span{width:100%}</style></head>
 	<body>
 		<div id="app"><div>hello world a</div></div>
-		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+		<script type="text/javascript" src="main.js"></script>
 	<script type="text/javascript" src="runtime/block-49e457933c3c36eeb77f.js"></script></body>
 </html>

--- a/tests/support/fixtures/build-time-render/build-bridge/index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge/index.html
@@ -4,6 +4,6 @@
 	</head>
 	<body>
 		<div id="app"></div>
-		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+		<script type="text/javascript" src="main.js"></script>
 	</body>
 </html>

--- a/tests/support/fixtures/build-time-render/hash/expected/index.html
+++ b/tests/support/fixtures/build-time-render/hash/expected/index.html
@@ -3,6 +3,6 @@
 	<style>.hello{background:red}.link{line-height:20px;color:#00b0e8}span{width:100%;height:100%}</style></head>
 	<body>
 		<div id="app"><div class="hello link">Hello</div></div>
-		<link rel="stylesheet" href="main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+		<link rel="stylesheet" href="main.css" /><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
 	</body>
 </html>

--- a/tests/support/fixtures/build-time-render/hash/expected/indexWithPaths.html
+++ b/tests/support/fixtures/build-time-render/hash/expected/indexWithPaths.html
@@ -21,6 +21,6 @@
 		element.parentNode.replaceChild(frag, element);
 	}
 }())
-</script><link rel="stylesheet" href="main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+</script><link rel="stylesheet" href="main.css" /><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
 	</body>
 </html>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/other/index.html
@@ -6,6 +6,6 @@
 		<div id="app"><div class="other">Other</div></div>
 		<script>
 window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/, '');
-</script><link rel="stylesheet" href="../../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
+</script><link rel="stylesheet" href="../../main.css" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
 	</body>
 </html>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/expected/other/index.html
@@ -6,6 +6,6 @@
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src=".././relative-image.svg"><img src="../../other-relative-image.svg"></div></div>
 		<script>
 window.__public_path__ = window.location.pathname.replace(/other(\/)?/, '');
-</script><link rel="stylesheet" href="../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
+</script><link rel="stylesheet" href="../main.css" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
 	</body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/additional.js
+++ b/tests/support/fixtures/build-time-render/state/additional.js
@@ -1,0 +1,1 @@
+(function additional() {})();

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/index.html
@@ -6,6 +6,6 @@
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}</div></div>
 		<script>
 window.__public_path__ = window.location.pathname.replace(/my-path(\/)?/, '');
-</script><link rel="stylesheet" href="../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
+</script><link rel="stylesheet" href="../main.css" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
 	</body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
@@ -7,5 +7,6 @@
 		<script>
 window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/, '');
 </script><link rel="stylesheet" href="../../main.css" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
-	<script type="text/javascript" src="../../my-path/additional.js"></script></body>
+	<link rel="preload" href="../../my-path/additional.js" as="script"></body>
 </html>
+git

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
@@ -7,5 +7,5 @@
 		<script>
 window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/, '');
 </script><link rel="stylesheet" href="../../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
-	</body>
+	<script type="text/javascript" src="../../my-path/additional.js" async="true"></script></body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
@@ -7,5 +7,5 @@
 		<script>
 window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/, '');
 </script><link rel="stylesheet" href="../../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
-	<script type="text/javascript" src="../../my-path/additional.js" async="true"></script></body>
+	<script type="text/javascript" src="../../my-path/additional.js"></script></body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
@@ -7,5 +7,5 @@
 		<script>
 window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/, '');
 </script><link rel="stylesheet" href="../../main.css" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
-	<script type="text/javascript" src="../../additional.js"></script></body>
+	<script type="text/javascript" src="../../my-path/additional.js"></script></body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
@@ -6,6 +6,6 @@
 		<div id="app"><div class="other">Other</div></div>
 		<script>
 window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/, '');
-</script><link rel="stylesheet" href="../../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
-	<script type="text/javascript" src="../../my-path/additional.js"></script></body>
+</script><link rel="stylesheet" href="../../main.css" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
+	<script type="text/javascript" src="../../additional.js"></script></body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
@@ -9,4 +9,3 @@ window.__public_path__ = window.location.pathname.replace(/my-path\/other(\/)?/,
 </script><link rel="stylesheet" href="../../main.css" /><script type="text/javascript" src="../../runtime.js"></script><script type="text/javascript" src="../../main.js"></script>
 	<link rel="preload" href="../../my-path/additional.js" as="script"></body>
 </html>
-git

--- a/tests/support/fixtures/build-time-render/state/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/other/index.html
@@ -6,6 +6,6 @@
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src=".././relative-image.svg"><img src="../../other-relative-image.svg"></div></div>
 		<script>
 window.__public_path__ = window.location.pathname.replace(/other(\/)?/, '');
-</script><link rel="stylesheet" href="../main.css" media="none" onload="if(media!='all')media='all'" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
+</script><link rel="stylesheet" href="../main.css" /><script type="text/javascript" src="../runtime.js"></script><script type="text/javascript" src="../main.js"></script>
 	</body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/main.js
+++ b/tests/support/fixtures/build-time-render/state/main.js
@@ -41,6 +41,11 @@
 		div.classList.add('other');
 		div.innerHTML = 'Other';
 		app.appendChild(div);
+
+		let script = document.createElement('script');
+		script.setAttribute('src', 'additional.js');
+
+		document.body.appendChild(script);
 	} else {
 		renderDefault();
 	}

--- a/tests/support/fixtures/build-time-render/state/manifest.json
+++ b/tests/support/fixtures/build-time-render/state/manifest.json
@@ -4,5 +4,6 @@
 	"main.css": "main.css",
 	"other.css": "other.css",
 	"runtime.js": "runtime.js",
-	"index.html": "index.html"
+	"index.html": "index.html",
+	"additional.js": "additional.js"
 }


### PR DESCRIPTION
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

During a BTR build, the page may loads an additional scripts like async bundles. These additional scripts are now captured and injected into the emitted html pages if you use the `StateHistory` history manager.

Resolves #179 
