### PR TITLE
Only report runtime errors from the application domain (localhost)

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -319,8 +319,10 @@ ${blockCacheEntry}`
 
 	private async _createPage(browser: any) {
 		const reportError = (err: Error) => {
-			err.message = `BTR runtime ${err.message}`;
-			this._blockErrors.push(err);
+			if (err.message.indexOf('http://localhost') !== -1) {
+				err.message = `BTR runtime ${err.message}`;
+				this._blockErrors.push(err);
+			}
 		};
 		const page = await browser.newPage();
 		page.on('error', reportError);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Only report runtime errors from the application.