### PR TITLE
EmitAllPlugin fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3968,7 +3968,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3986,11 +3987,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4003,15 +4006,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4114,7 +4120,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4124,6 +4131,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4136,17 +4144,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4163,6 +4174,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4235,7 +4247,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4245,6 +4258,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4320,7 +4334,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4350,6 +4365,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4367,6 +4383,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4405,11 +4422,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/emit-all-plugin/EmitAllPlugin.ts
+++ b/src/emit-all-plugin/EmitAllPlugin.ts
@@ -101,7 +101,7 @@ export default class EmitAllPlugin {
 					if ((resource || '').includes(basePath)) {
 						const extension = legacy ? '.js' : '.mjs';
 						const source = module.originalSource().source();
-						const assetName = resource.replace(basePath, '').replace(/\.ts$/, extension);
+						const assetName = resource.replace(basePath, '').replace(/\.ts(x)?$/, extension);
 
 						if (assetName.includes('.css')) {
 							await Promise.all(
@@ -156,7 +156,7 @@ export default class EmitAllPlugin {
 			? `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
 					JSON.stringify(fixedSourceMap)
 			  ).toString('base64')}*/`
-			: `\n/*# sourceMappingURL=${assetName.split('/').pop()}.map*/`;
+			: `\n/*# sourceMappingURL=${assetName.split(path.sep).pop()}.map*/`;
 
 		return { map: fixedSourceMap, url };
 	}

--- a/src/webpack-bundle-analyzer/client/package-lock.json
+++ b/src/webpack-bundle-analyzer/client/package-lock.json
@@ -1181,6 +1181,7 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -2736,7 +2737,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -3533,7 +3535,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -3567,7 +3570,8 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -5003,7 +5007,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5024,12 +5029,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5044,17 +5051,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5171,7 +5181,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5183,6 +5194,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5197,6 +5209,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -5204,12 +5217,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -5228,6 +5243,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5308,7 +5324,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5320,6 +5337,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5405,7 +5423,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5441,6 +5460,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5460,6 +5480,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5503,12 +5524,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -5523,6 +5546,7 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -5538,13 +5562,15 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5554,6 +5580,7 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5565,6 +5592,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5909,7 +5937,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -8054,6 +8083,7 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -13842,13 +13872,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
 			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}

--- a/tests/unit/emit-all-plugin/EmitAllPlugin.ts
+++ b/tests/unit/emit-all-plugin/EmitAllPlugin.ts
@@ -277,7 +277,7 @@ describe('EmitAllPlugin', () => {
 			function applyCssModule(cssModule: any, pluginOptions?: EmitAllPluginOptions): Promise<any> {
 				const factory = mockModule.getModuleUnderTest().emitAllFactory;
 				const emitAll = factory({
-					basePath: 'src/',
+					basePath: `src${path.sep}`,
 					...pluginOptions
 				}).plugin;
 
@@ -295,20 +295,20 @@ describe('EmitAllPlugin', () => {
 			it('outputs individual CSS files', () => {
 				const source = '.root {}';
 				const cssModule = {
-					resource: 'src/dir/styles.css',
+					resource: `src${path.sep}dir${path.sep}styles.css`,
 					originalSource: () => ({
 						source: () => source
 					}),
 					dependencies: [
 						{
 							content: source,
-							identifier: 'src/dir/styles.css'
+							identifier: `src${path.sep}dir${path.sep}styles.css`
 						}
 					]
 				};
 
 				return applyCssModule(cssModule).then((compilation) => {
-					const asset = compilation.assets['dir/styles.css'];
+					const asset = compilation.assets[`dir${path.sep}styles.css`];
 					assert.isObject(asset);
 					assert.strictEqual(asset.source(), source);
 					assert.strictEqual(asset.size(), Buffer.byteLength(source));
@@ -318,14 +318,14 @@ describe('EmitAllPlugin', () => {
 			it('excludes files outside the base path', () => {
 				const source = '.root {}';
 				const cssModule = {
-					resource: 'other/dir/styles.css',
+					resource: `other${path.sep}dir${path.sep}styles.css`,
 					originalSource: () => ({
 						source: () => source
 					}),
 					dependencies: [
 						{
 							content: source,
-							identifier: 'other/dir/styles.css'
+							identifier: `other${path.sep}dir${path.sep}styles.css`
 						}
 					]
 				};
@@ -338,14 +338,14 @@ describe('EmitAllPlugin', () => {
 			it('ignores dependencies with a mismatched identifier', () => {
 				const source = '.root {}';
 				const cssModule = {
-					resource: 'src/dir/styles.css',
+					resource: `src${path.sep}dir${path.sep}styles.css`,
 					originalSource: () => ({
 						source: () => source
 					}),
 					dependencies: [
 						{
 							content: source,
-							identifier: 'src/other/asset.css'
+							identifier: `src${path.sep}other${path.sep}asset.css`
 						}
 					]
 				};
@@ -358,22 +358,22 @@ describe('EmitAllPlugin', () => {
 			it('outputs CSS sourcemaps', () => {
 				const source = '.root {}';
 				const cssModule = {
-					resource: 'src/dir/styles.css',
+					resource: `src${path.sep}dir${path.sep}styles.css`,
 					originalSource: () => ({
 						source: () => source
 					}),
 					dependencies: [
 						{
 							content: source,
-							identifier: 'src/dir/styles.css',
+							identifier: `src${path.sep}dir${path.sep}styles.css`,
 							sourceMap: { mappings: 'abcd' }
 						}
 					]
 				};
 
 				return applyCssModule(cssModule).then((compilation) => {
-					const asset = compilation.assets['dir/styles.css'];
-					const assetMap = compilation.assets['dir/styles.css.map'];
+					const asset = compilation.assets[`dir${path.sep}styles.css`];
+					const assetMap = compilation.assets[`dir${path.sep}styles.css.map`];
 					const assetMapSource = {
 						mappings: 'abcd',
 						sources: []
@@ -390,26 +390,26 @@ describe('EmitAllPlugin', () => {
 				const source = `module.exports = {}`;
 				const sourceMap = { mappings: 'abcd', sources: [] };
 				const cssModule = {
-					resource: 'src/dir/styles.css',
+					resource: `src${path.sep}dir${path.sep}styles.css`,
 					originalSource: () => ({
 						source: () => source
 					}),
 					dependencies: [
 						{
 							content: source,
-							identifier: 'src/dir/styles.css',
+							identifier: `src${path.sep}dir${path.sep}styles.css`,
 							sourceMap
 						}
 					]
 				};
 
 				return applyCssModule(cssModule, { inlineSourceMaps: true }).then((compilation) => {
-					const asset = compilation.assets['dir/styles.css'];
+					const asset = compilation.assets[`dir${path.sep}styles.css`];
 					const sourceMapUrl = `\n/*# sourceMappingURL=data:application/json;base64,${Buffer.from(
 						JSON.stringify(sourceMap)
 					).toString('base64')}*/`;
 					assert.isTrue(asset.source().endsWith(sourceMapUrl));
-					assert.isUndefined(compilation.assets['dir/styles.css.map']);
+					assert.isUndefined(compilation.assets[`dir${path.sep}styles.css.map`]);
 				});
 			});
 
@@ -417,27 +417,27 @@ describe('EmitAllPlugin', () => {
 				const source = `module.exports = {}`;
 				const sourceMap = {
 					mappings: 'abcd',
-					sources: ['src/dir/styles.css']
+					sources: [`src${path.sep}dir${path.sep}styles.css`]
 				};
 				const cssModule = {
-					resource: 'src/dir/styles.css',
+					resource: `src${path.sep}dir${path.sep}styles.css`,
 					originalSource: () => ({
 						source: () => source
 					}),
 					dependencies: [
 						{
 							content: source,
-							identifier: 'src/dir/styles.css',
+							identifier: `src${path.sep}dir${path.sep}styles.css`,
 							sourceMap
 						}
 					]
 				};
 
 				return applyCssModule(cssModule).then((compilation) => {
-					const assetMap = compilation.assets['dir/styles.css.map'];
+					const assetMap = compilation.assets[`dir${path.sep}styles.css.map`];
 					const assetMapSource = {
 						mappings: 'abcd',
-						sources: [path.relative('src/', 'src/dir/styles.css')]
+						sources: [path.relative(`src${path.sep}`, `src${path.sep}dir${path.sep}styles.css`)]
 					};
 					const assetMapSourceString = JSON.stringify(assetMapSource);
 					assert.strictEqual(assetMap.source(), assetMapSourceString);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Update EmitAllPlugin to properly rename `.tsx` files to either `.mjs` or `.js`, depending on the `legacy` option value. Previously, `.tsx` files would have their extensions preserved. Also fix the source map URLs in Windows environments.

Resolves dojo/cli-build-widget#59
