### PR TITLE
Always copy custom sw to service-worker.js as well a fixing passed params

### DIFF
--- a/src/service-worker-plugin/ServiceWorkerPlugin.ts
+++ b/src/service-worker-plugin/ServiceWorkerPlugin.ts
@@ -150,7 +150,7 @@ export default class ServiceWorkerPlugin {
 		}
 
 		compiler.hooks.beforeRun.tapAsync(this.constructor.name, (compiler, next) => {
-			new CopyWebpackPlugin({ from: this._serviceWorker }).apply(compiler);
+			new CopyWebpackPlugin([{ from: this._serviceWorker, to: 'service-worker.js' }]).apply(compiler);
 			next();
 		});
 	}

--- a/tests/unit/service-worker-plugin/ServiceWorkerPlugin.ts
+++ b/tests/unit/service-worker-plugin/ServiceWorkerPlugin.ts
@@ -32,7 +32,7 @@ describe('ServiceWorkerPlugin', () => {
 		const compilation = createCompilation(compiler);
 		compiler.hooks.beforeRun.callAsync(compilation, next);
 		assert.isTrue(next.called);
-		assert.deepEqual(CopyPlugin.firstCall.args, [{ from: swPath }]);
+		assert.deepEqual(CopyPlugin.firstCall.args, [[{ from: swPath, to: 'service-worker.js' }]]);
 	});
 
 	it('should throw an error with an invalid service worker path', () => {


### PR DESCRIPTION
**Type:** bug
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
Always copies a custom sw over to `service-worker.js` this will allow us to in a later PR register them automatically which the user currently has to manually do.

Resolves Fix the arguments passed to the CopyWebpackPlugin to ensure custom service workers are correctly copied to the output directory.

Supersedes https://github.com/dojo/webpack-contrib/pull/147
Resolves dojo/cli-build-app#276
