### PR TITLE
180 - Prefetching later-used chunks

### DIFF
--- a/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/other/index.html
@@ -7,5 +7,5 @@
 		<script>
 	window.__public_path__ = window.location.pathname.replace(/(\/)?my-path\/other(\/)?$/, '/');
 </script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
-	</body>
+	<link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /></body>
 </html>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/expected/other/index.html
@@ -7,5 +7,5 @@
 		<script>
 	window.__public_path__ = window.location.pathname.replace(/(\/)?other(\/)?$/, '/');
 </script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
-	</body>
+	<link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /></body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/index.html
@@ -7,5 +7,5 @@
 		<script>
 	window.__public_path__ = window.location.pathname.replace(/(\/)?my-path(\/)?$/, '/');
 </script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
-	</body>
+	<link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
@@ -7,5 +7,5 @@
 		<script>
 	window.__public_path__ = window.location.pathname.replace(/(\/)?my-path\/other(\/)?$/, '/');
 </script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
-	<link rel="preload" href="my-path/additional.js" as="script"></body>
+	<link rel="preload" href="my-path/additional.js" as="script"><link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
 </html>

--- a/tests/support/fixtures/build-time-render/state/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/other/index.html
@@ -7,5 +7,5 @@
 		<script>
 	window.__public_path__ = window.location.pathname.replace(/(\/)?other(\/)?$/, '/');
 </script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
-	</body>
+	<link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
 </html>


### PR DESCRIPTION
**Type:** bug
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Preloading additional chunks during BTR. All chunks that aren't needed on the current page are output as `<link prefetch>` tags to make future requests faster.

![image](https://user-images.githubusercontent.com/2008858/63172659-369e5f00-c00c-11e9-923d-5202d1d821b9.png)


Resolves #180 
