### PR TITLE
Support custom tag for custom element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dojo/framework": {
-      "version": "6.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-rc.1.tgz",
-      "integrity": "sha512-VGZP5rXOE7KzeQFMATl+lmCMJA96hwxKnai0sjhFFgceFipYA0Qj7y3CEKMDRWr05GzFd1Sit4TpHL+pyXVF5g==",
+      "version": "6.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-rc.2.tgz",
+      "integrity": "sha512-knez+1LInltL4ArCqVszM8GpmBZTLZccqN86rfre7JMe05R3+HVndiKbA1nDWBsNECdEbrKh2XHjIBC02naixA==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
@@ -1760,9 +1760,9 @@
       "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
     },
     "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "requires": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
@@ -3189,9 +3189,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.236",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.236.tgz",
-      "integrity": "sha512-LWOvuJ80pLO3FtFqTcGuXB0dxdMtzSCkRmbXdY5mHUvXRQGor3sTVmyfU70aD2yF5i+fbHz52ncWr5T3xUYHlA=="
+      "version": "1.3.237",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.237.tgz",
+      "integrity": "sha512-SPAFjDr/7iiVK2kgTluwxela6eaWjjFkS9rO/iYpB/KGXgccUom5YC7OIf19c8m8GGptWxLU0Em8xM64A/N7Fg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -6862,9 +6862,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
-      "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.28.tgz",
+      "integrity": "sha512-AQw4emh6iSXnCpDiFe0phYcThiccmkNWMZnFZ+lDJjAP8J0m2fVd59duvUUyuTirQOhIAajTFkzG6FHCLBO59g==",
       "requires": {
         "semver": "^5.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "watch": "run-p watch:ts \"build:static:** -- --watch\""
   },
   "dependencies": {
-    "@dojo/framework": "6.0.0-rc.1",
+    "@dojo/framework": "6.0.0-rc.2",
     "acorn": "6.1.1",
     "acorn-dynamic-import": "4.0.0",
     "acorn-walk": "6.1.1",

--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -330,16 +330,7 @@ export default function elementTransformer<T extends ts.Node>(
 						}
 					}
 
-					return [
-						node,
-						createCustomElementExpression(
-							widgetName,
-							tag,
-							attributes,
-							properties,
-							events
-						)
-					];
+					return [node, createCustomElementExpression(widgetName, tag, attributes, properties, events)];
 				}
 			}
 

--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -13,6 +13,10 @@ export interface ElementTransformerOptions {
 	customElementFiles: CustomElementFile[];
 }
 
+function parseTagName(name: string) {
+	return name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
 export default function elementTransformer<T extends ts.Node>(
 	program: ts.Program,
 	{ customElementFiles, elementPrefix }: ElementTransformerOptions
@@ -63,7 +67,7 @@ export default function elementTransformer<T extends ts.Node>(
 			typeof identifier === 'string' ? ts.createIdentifier(identifier) : identifier,
 			'__customElementDescriptor'
 		);
-		const tagName = `${preparedElementPrefix}-${tag.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`;
+		const tagName = `${preparedElementPrefix}-${tag}`;
 
 		const customElementDeclaration = ts.createObjectLiteral([
 			ts.createPropertyAssignment('tagName', ts.createLiteral(tagName)),
@@ -244,7 +248,7 @@ export default function elementTransformer<T extends ts.Node>(
 								});
 								if (variableNode) {
 									const widgetName = variableNode.name!.getText();
-									const tag = widgetConfig.tag || widgetName;
+									const tag = widgetConfig.tag || parseTagName(widgetName);
 
 									const uniqueIdentifier = ts.createUniqueName('temp');
 									return [
@@ -274,7 +278,7 @@ export default function elementTransformer<T extends ts.Node>(
 												.pop() || '';
 										widgetName = fileName.split('.')[0];
 									}
-									const tag = widgetConfig.tag || widgetName;
+									const tag = widgetConfig.tag || parseTagName(widgetName);
 
 									if (widgetName) {
 										const uniqueIdentifier = ts.createUniqueName('temp');
@@ -308,7 +312,7 @@ export default function elementTransformer<T extends ts.Node>(
 				const classNode = node as ts.ClassDeclaration;
 				if (classNode.heritageClauses && classNode.heritageClauses.length > 0) {
 					const widgetName = classNode.name!.getText();
-					const tag = widgetConfig.tag || widgetName;
+					const tag = widgetConfig.tag || parseTagName(widgetName);
 
 					const [
 						{

--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -4,7 +4,7 @@ import * as ts from 'typescript';
 require('ts-node').register();
 
 export interface CustomElementFile {
-	name?: string;
+	tag?: string;
 	file: string;
 }
 
@@ -22,9 +22,9 @@ export default function elementTransformer<T extends ts.Node>(
 	const customElementFilesIncludingDefaults = customElementFiles.map(
 		(file): CustomElementFile => {
 			const fileName = typeof file === 'string' ? file : file.file;
-			const name =
-				typeof file !== 'string' && file.name
-					? file.name
+			const tag =
+				typeof file !== 'string' && file.tag
+					? file.tag
 							.toLowerCase()
 							.replace(/[^a-z]/g, '-')
 							.replace(/[-{2,]/g, '-')
@@ -34,12 +34,12 @@ export default function elementTransformer<T extends ts.Node>(
 			try {
 				return {
 					file: require.resolve(path.resolve(fileName)),
-					name
+					tag
 				};
 			} catch (e) {
 				return {
 					file: fileName,
-					name
+					tag
 				};
 			}
 		}
@@ -243,7 +243,8 @@ export default function elementTransformer<T extends ts.Node>(
 									parsePropertyType(prop, node);
 								});
 								if (variableNode) {
-									const widgetName = widgetConfig.name || variableNode.name!.getText();
+									const widgetName = variableNode.name!.getText();
+									const tag = widgetConfig.tag || widgetName;
 
 									const uniqueIdentifier = ts.createUniqueName('temp');
 									return [
@@ -254,7 +255,7 @@ export default function elementTransformer<T extends ts.Node>(
 											createCallExpression(
 												uniqueIdentifier,
 												initializer,
-												widgetConfig.name || widgetName,
+												tag,
 												attributes,
 												properties,
 												events
@@ -264,7 +265,7 @@ export default function elementTransformer<T extends ts.Node>(
 								} else {
 									let widgetName;
 									if (renderOptionsCallback && (renderOptionsCallback as any).name) {
-										widgetName = widgetConfig.name || (renderOptionsCallback as any).name.getText();
+										widgetName = (renderOptionsCallback as any).name.getText();
 									} else {
 										const fileName =
 											node
@@ -273,6 +274,7 @@ export default function elementTransformer<T extends ts.Node>(
 												.pop() || '';
 										widgetName = fileName.split('.')[0];
 									}
+									const tag = widgetConfig.tag || widgetName;
 
 									if (widgetName) {
 										const uniqueIdentifier = ts.createUniqueName('temp');
@@ -285,7 +287,7 @@ export default function elementTransformer<T extends ts.Node>(
 												createCallExpression(
 													uniqueIdentifier,
 													initializer,
-													widgetConfig.name || widgetName,
+													tag,
 													attributes,
 													properties,
 													events
@@ -306,6 +308,7 @@ export default function elementTransformer<T extends ts.Node>(
 				const classNode = node as ts.ClassDeclaration;
 				if (classNode.heritageClauses && classNode.heritageClauses.length > 0) {
 					const widgetName = classNode.name!.getText();
+					const tag = widgetConfig.tag || widgetName;
 
 					const [
 						{
@@ -331,7 +334,7 @@ export default function elementTransformer<T extends ts.Node>(
 						node,
 						createCustomElementExpression(
 							widgetName,
-							widgetConfig.name || widgetName,
+							tag,
 							attributes,
 							properties,
 							events

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -825,7 +825,7 @@ describe('element-transformer', () => {
 				before: [
 					elementTransformer(program, {
 						elementPrefix: 'widget',
-						customElementFiles: [{ file: actualPath, name: 'foo-bar' }]
+						customElementFiles: [{ file: actualPath, tag: 'foo-bar' }]
 					})
 				]
 			})
@@ -896,7 +896,7 @@ describe('element-transformer', () => {
 				before: [
 					elementTransformer(program, {
 						elementPrefix: 'widget',
-						customElementFiles: [{ name: 'foo-bar', file: actualPath }]
+						customElementFiles: [{ tag: 'foo-bar', file: actualPath }]
 					})
 				]
 			})

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -22,7 +22,12 @@ describe('element-transformer', () => {
 					[expectedPath]: source
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -46,7 +51,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -73,7 +83,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -145,7 +160,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -163,7 +183,12 @@ describe('element-transformer', () => {
 					[expectedPath]: source
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -191,7 +216,7 @@ describe('element-transformer', () => {
 					before: [
 						elementTransformer(program, {
 							elementPrefix: 'widget',
-							customElementFiles: [actualPath]
+							customElementFiles: [{ file: actualPath }]
 						})
 					]
 				})
@@ -221,7 +246,12 @@ describe('element-transformer', () => {
 					[expectedPath]: source
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -267,7 +297,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -362,7 +397,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -430,7 +470,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -500,7 +545,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -566,7 +616,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -616,7 +671,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -674,7 +734,12 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
@@ -728,10 +793,114 @@ describe('element-transformer', () => {
 					[expectedPath]: expected
 				},
 				(program) => ({
-					before: [elementTransformer(program, { elementPrefix: 'widget', customElementFiles: [actualPath] })]
+					before: [
+						elementTransformer(program, {
+							elementPrefix: 'widget',
+							customElementFiles: [{ file: actualPath }]
+						})
+					]
 				})
 			);
 		});
+	});
+	it('can specify custom element name for class', () => {
+		const source = `
+	class WidgetBase<T> {}
+	interface DojoInputProperties {}
+	export default class DojoInput extends WidgetBase<DojoInputProperties> {
+	}`;
+		const expected = `
+	class WidgetBase<T> {}
+	interface DojoInputProperties {}
+	export default class DojoInput extends WidgetBase<DojoInputProperties> {
+	}
+	DojoInput.__customElementDescriptor = { ...{ tagName: "widget-foo-bar", attributes: [], properties: [], events: [] }, ...DojoInput.__customElementDescriptor || {} };
+`;
+		assertCompile(
+			{
+				[actualPath]: source,
+				[expectedPath]: expected
+			},
+			(program) => ({
+				before: [
+					elementTransformer(program, {
+						elementPrefix: 'widget',
+						customElementFiles: [{ file: actualPath, name: 'foo-bar' }]
+					})
+				]
+			})
+		);
+	});
+
+	it('can specify custom element name for function', () => {
+		const source = `
+	enum StringEnum { value1 = 'value1', value2 = 'value2' };
+	enum IntEnum { value1 = 0, value 2 = 1 };
+	type stringOrNumber = string | number;
+	function create<A = any, B = {}>() {
+		return {
+			properties: <T>() =>
+				function render(callback: (options: { properties: () => B & T }) => string) {
+					return (properties: B & T) => '';
+			}
+		};
+	}
+
+	interface DojoInputProperties {
+		attribute: string;
+		property: boolean;
+		onClick: () => void;
+		onChange(value: string): void;
+		stringEnum: StringEnum;
+		intEnum?: IntEnum;
+		stringOrNumber: stringOrNumber;
+	}
+	const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+	export default render(({ properties }) => 'foo');
+	`;
+		const expected = `
+	enum StringEnum { value1 = 'value1', value2 = 'value2' };
+	enum IntEnum { value1 = 0, value 2 = 1 };
+	type stringOrNumber = string | number;
+	function create<A = any, B = {}>() {
+		return {
+			properties: <T>() =>
+				function render(callback: (options: { properties: () => B & T }) => string) {
+					return (properties: B & T) => '';
+			}
+		};
+	}
+
+	interface DojoInputProperties {
+		attribute: string;
+		property: boolean;
+		onClick: () => void;
+		onChange(value: string): void;
+		stringEnum: StringEnum;
+		intEnum?: IntEnum;
+		stringOrNumber: stringOrNumber;
+	}
+	const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+	export default (() => {
+		var temp_1 = render(({ properties }) => 'foo');
+		temp_1.__customElementDescriptor = { ...{ tagName: "widget-foo-bar", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };	
+		return temp_1;
+	})();
+	`;
+		assertCompile(
+			{
+				[actualPath]: source,
+				[expectedPath]: expected
+			},
+			(program) => ({
+				before: [
+					elementTransformer(program, {
+						elementPrefix: 'widget',
+						customElementFiles: [{ name: 'foo-bar', file: actualPath }]
+					})
+				]
+			})
+		);
 	});
 });
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support passing a custom tag name to the ElementTransformer