### PR TITLE
Resolve static add in has, only resolve `add` if it is not a `staticOnly` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,18 @@ work if acting on the compiled output.
 
 ### Features
 
-The loader examines code, looking for usages of `@dojo/has` or _has pragmas_ to _optimize_. It does this by parsing the [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) structure of the code, and modifying it when appropriate.
+The loader examines code, looking for usages of `@dojo/has`, `@dojo/has.exists`, `@dojo/has.add`, or _has pragmas_ to _optimize_. It does this by parsing the [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) structure of the code, and modifying it when appropriate.
 
-The loader takes two options:
+The loader takes three options:
 
 * `features`: A map of _static_ features or a feature or list of features that resolve to a similar static map
 based on the functionality provided by the specified targets. Each key in the map is the name of the feature
 and the value is `true` if the feature is present in that context, otherwise `false`.
 * `isRunningInNode`: An optional boolean parameter. If set to `false` this indicates that the loader will not be
 running in an environment with a Node-like require.
+* `staticOnly`: A list of feature keys that should _not_ have `has.add` calls modified. In most cases, this option
+will not be needed. It is provided for cases where a module will sometimes be parsed and have its flags resolved statically if so, but
+may also not be parsed and may require a different runtime value for the flag.
 
 For example in a webpack configuration, the map of features would look like this:
 
@@ -127,7 +130,8 @@ For example in a webpack configuration, the map of features would look like this
                 features: {
                     'foo': true,
                     'bar': false
-                }
+                },
+                staticOnly: ['bar']
             }
         }
     ]

--- a/src/static-build-loader/loader.ts
+++ b/src/static-build-loader/loader.ts
@@ -116,7 +116,7 @@ export default function loader(
 	}
 	// copy features to a local scope, because `this` gets weird
 	const options = getOptions(this);
-	const { features: featuresOption } = options;
+	const { features: featuresOption, staticOnly = [] } = options;
 	const parseOptions: any = {
 		parser: {
 			parse(source: string) {
@@ -357,7 +357,8 @@ export default function loader(
 					if (
 						namedTypes.Literal.check(feature) &&
 						typeof feature.value === 'string' &&
-						feature.value in features
+						feature.value in features &&
+						staticOnly.indexOf(feature.value) === -1
 					) {
 						path.replace(
 							builders.callExpression(callee, [args[0], builders.literal(features[feature.value])])

--- a/src/static-build-loader/loader.ts
+++ b/src/static-build-loader/loader.ts
@@ -22,6 +22,7 @@ const acorn = Parser.extend(dynamicImport);
 
 const HAS_MID = /\/has$/;
 const HAS_PRAGMA = /^\s*(!?)\s*has\s*\(["']([^'"]+)['"]\)\s*$/;
+const HAS_MODULE_REGEXP = /@dojo(\/|\\)framework(\/|\\)core(\/|\\)has\.(js|mjs|ts)$/;
 
 function hasCheck(hasIdentifier: string, hasNamespaceIdentifier: string | undefined, args: any, callee: any) {
 	return (
@@ -101,7 +102,12 @@ export default function loader(
 	content: string,
 	sourceMap?: webpack.RawSourceMap
 ): string | void {
-	if (content.indexOf('/has') < 0 && content.indexOf('has(') < 0 && content.indexOf('exists(') < 0) {
+	if (
+		!HAS_MODULE_REGEXP.test(this.resourcePath) &&
+		content.indexOf('/has') < 0 &&
+		content.indexOf('has(') < 0 &&
+		content.indexOf('exists(') < 0
+	) {
 		if (sourceMap) {
 			this.callback(null, content, sourceMap);
 			return;
@@ -141,167 +147,179 @@ export default function loader(
 		features = featuresOption;
 	}
 
-	types.visit(ast, {
-		visitExpressionStatement(path) {
-			const { node, parentPath, name } = path;
-			const expressionValue = getExpressionValue(node);
-			if (expressionValue) {
-				const hasPragma = HAS_PRAGMA.exec(expressionValue);
-				if (hasPragma) {
-					const [, negate, flag] = hasPragma;
-					comment = ` ${negate}has('${flag}')`;
-					if (flag in features) {
-						elideNextImport = negate ? !!features[flag] : !features[flag];
+	if (HAS_MODULE_REGEXP.test(this.resourcePath)) {
+		addIdentifier = 'add';
+		hasIdentifier = 'has';
+	} else {
+		types.visit(ast, {
+			visitExpressionStatement(path) {
+				const { node, parentPath, name } = path;
+				const expressionValue = getExpressionValue(node);
+				if (expressionValue) {
+					const hasPragma = HAS_PRAGMA.exec(expressionValue);
+					if (hasPragma) {
+						const [, negate, flag] = hasPragma;
+						comment = ` ${negate}has('${flag}')`;
+						if (flag in features) {
+							elideNextImport = negate ? !!features[flag] : !features[flag];
+						}
 					}
 				}
-			}
 
-			if (
-				namedTypes.CallExpression.check(node.expression) &&
-				namedTypes.Identifier.check(node.expression.callee)
-			) {
 				if (
-					node.expression.callee.name === 'require' &&
-					node.expression.arguments.length === 1 &&
-					elideNextImport === true
+					namedTypes.CallExpression.check(node.expression) &&
+					namedTypes.Identifier.check(node.expression.callee)
 				) {
-					const [arg] = node.expression.arguments;
-					if (namedTypes.Literal.check(arg)) {
-						comment = ` elided: import '${arg.value}'`;
+					if (
+						node.expression.callee.name === 'require' &&
+						node.expression.arguments.length === 1 &&
+						elideNextImport === true
+					) {
+						const [arg] = node.expression.arguments;
+						if (namedTypes.Literal.check(arg)) {
+							comment = ` elided: import '${arg.value}'`;
+							elideNextImport = false;
+						}
+					}
+				}
+
+				if (comment && parentPath && typeof name !== 'undefined') {
+					setComment(node, path, comment, parentPath, name);
+					comment = undefined;
+					return false;
+				}
+
+				comment = undefined;
+				this.traverse(path);
+			},
+
+			visitDeclaration(path) {
+				const { node, parentPath, name } = path;
+				if (namedTypes.ImportDeclaration.check(path.node)) {
+					const value = path.node.source.value;
+
+					if (elideNextImport) {
+						comment = ` elided: import '${value}'`;
 						elideNextImport = false;
 					}
-				}
-			}
+					if (comment && parentPath && typeof name !== 'undefined') {
+						let replacement: any = null;
+						if (path.node.specifiers.length) {
+							replacement = builders.variableDeclaration(
+								'var',
+								path.node.specifiers.map((specifier) => {
+									return builders.variableDeclarator(
+										specifier.local,
+										builders.identifier('undefined')
+									);
+								})
+							);
+						}
 
-			if (comment && parentPath && typeof name !== 'undefined') {
-				setComment(node, path, comment, parentPath, name);
-				comment = undefined;
-				return false;
-			}
-
-			comment = undefined;
-			this.traverse(path);
-		},
-
-		visitDeclaration(path) {
-			const { node, parentPath, name } = path;
-			if (namedTypes.ImportDeclaration.check(path.node)) {
-				const value = path.node.source.value;
-
-				if (elideNextImport) {
-					comment = ` elided: import '${value}'`;
-					elideNextImport = false;
-				}
-				if (comment && parentPath && typeof name !== 'undefined') {
-					let replacement: any = null;
-					if (path.node.specifiers.length) {
-						replacement = builders.variableDeclaration(
-							'var',
-							path.node.specifiers.map((specifier) => {
-								return builders.variableDeclarator(specifier.local, builders.identifier('undefined'));
-							})
-						);
+						setComment(node, path, comment, parentPath, name, replacement);
+						comment = undefined;
+						return false;
 					}
 
-					setComment(node, path, comment, parentPath, name, replacement);
 					comment = undefined;
-					return false;
-				}
 
-				comment = undefined;
-
-				if (typeof value === 'string' && HAS_MID.test(value)) {
-					path.node.specifiers.forEach((specifier) => {
-						if (
-							specifier.type === 'ImportDefaultSpecifier' ||
-							(specifier.type === 'ImportSpecifier' && specifier.imported.name === 'default')
-						) {
-							hasIdentifier = specifier.local.name;
-						} else if (specifier.type === 'ImportNamespaceSpecifier') {
-							hasNamespaceIdentifier = specifier.local.name;
-						} else if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'exists') {
-							existsIdentifier = specifier.local.name;
-						} else if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'add') {
-							addIdentifier = specifier.local.name;
-						}
-					});
-				}
-			}
-			this.traverse(path);
-		},
-
-		// Look for `require('*/has');` and set the variable name to `hasNamespaceIdentifier`
-		visitVariableDeclaration(path) {
-			const {
-				name,
-				node,
-				parentPath,
-				parentPath: { node: parentNode },
-				node: { declarations }
-			} = path;
-
-			let identifier: any = undefined;
-
-			if (elideNextImport === true && declarations.length === 1) {
-				const callExpression = declarations[0];
-				if (namedTypes.VariableDeclarator.check(callExpression)) {
-					if (
-						callExpression.init &&
-						namedTypes.CallExpression.check(callExpression.init) &&
-						namedTypes.Identifier.check(callExpression.init.callee)
-					) {
-						if (
-							callExpression.init.callee.name === 'require' &&
-							callExpression.init.arguments.length === 1
-						) {
-							if (callExpression.id) {
-								identifier = callExpression.id;
+					if (typeof value === 'string' && HAS_MID.test(value)) {
+						path.node.specifiers.forEach((specifier) => {
+							if (
+								specifier.type === 'ImportDefaultSpecifier' ||
+								(specifier.type === 'ImportSpecifier' && specifier.imported.name === 'default')
+							) {
+								hasIdentifier = specifier.local.name;
+							} else if (specifier.type === 'ImportNamespaceSpecifier') {
+								hasNamespaceIdentifier = specifier.local.name;
+							} else if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'exists') {
+								existsIdentifier = specifier.local.name;
+							} else if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'add') {
+								addIdentifier = specifier.local.name;
 							}
-
-							const [arg] = callExpression.init.arguments;
-							if (namedTypes.Literal.check(arg)) {
-								comment = ` elided: import '${arg.value}'`;
-								elideNextImport = false;
-							}
-						}
+						});
 					}
 				}
+				this.traverse(path);
+			},
 
-				if (comment && parentPath && typeof name !== 'undefined') {
-					const replacement = builders.variableDeclaration('var', [
-						builders.variableDeclarator(identifier, builders.identifier('undefined'))
-					]);
-					setComment(node, path, comment, parentPath, name, replacement);
+			// Look for `require('*/has');` and set the variable name to `hasNamespaceIdentifier`
+			visitVariableDeclaration(path) {
+				const {
+					name,
+					node,
+					parentPath,
+					parentPath: { node: parentNode },
+					node: { declarations }
+				} = path;
 
-					comment = undefined;
-					return false;
-				}
-				comment = undefined;
-			}
+				let identifier: any = undefined;
 
-			// Get all the top level variable declarations
-			if (ast.program === parentNode && !hasNamespaceIdentifier) {
-				declarations.forEach(({ id, init }) => {
-					if (!hasNamespaceIdentifier) {
-						if (namedTypes.Identifier.check(id) && init && namedTypes.CallExpression.check(init)) {
-							const { callee, arguments: args } = init;
-							if (namedTypes.Identifier.check(callee) && callee.name === 'require' && args.length === 1) {
-								const [arg] = args;
-								if (
-									namedTypes.Literal.check(arg) &&
-									typeof arg.value === 'string' &&
-									HAS_MID.test(arg.value)
-								) {
-									hasNamespaceIdentifier = id.name;
+				if (elideNextImport === true && declarations.length === 1) {
+					const callExpression = declarations[0];
+					if (namedTypes.VariableDeclarator.check(callExpression)) {
+						if (
+							callExpression.init &&
+							namedTypes.CallExpression.check(callExpression.init) &&
+							namedTypes.Identifier.check(callExpression.init.callee)
+						) {
+							if (
+								callExpression.init.callee.name === 'require' &&
+								callExpression.init.arguments.length === 1
+							) {
+								if (callExpression.id) {
+									identifier = callExpression.id;
+								}
+
+								const [arg] = callExpression.init.arguments;
+								if (namedTypes.Literal.check(arg)) {
+									comment = ` elided: import '${arg.value}'`;
+									elideNextImport = false;
 								}
 							}
 						}
 					}
-				});
+
+					if (comment && parentPath && typeof name !== 'undefined') {
+						const replacement = builders.variableDeclaration('var', [
+							builders.variableDeclarator(identifier, builders.identifier('undefined'))
+						]);
+						setComment(node, path, comment, parentPath, name, replacement);
+
+						comment = undefined;
+						return false;
+					}
+					comment = undefined;
+				}
+
+				// Get all the top level variable declarations
+				if (ast.program === parentNode && !hasNamespaceIdentifier) {
+					declarations.forEach(({ id, init }) => {
+						if (!hasNamespaceIdentifier) {
+							if (namedTypes.Identifier.check(id) && init && namedTypes.CallExpression.check(init)) {
+								const { callee, arguments: args } = init;
+								if (
+									namedTypes.Identifier.check(callee) &&
+									callee.name === 'require' &&
+									args.length === 1
+								) {
+									const [arg] = args;
+									if (
+										namedTypes.Literal.check(arg) &&
+										typeof arg.value === 'string' &&
+										HAS_MID.test(arg.value)
+									) {
+										hasNamespaceIdentifier = id.name;
+									}
+								}
+							}
+						}
+					});
+				}
+				this.traverse(path);
 			}
-			this.traverse(path);
-		}
-	});
+		});
+	}
 
 	// Now we want to walk the AST and find an expressions where the default import or `exists` of `*/has` is
 	// called. This will be a CallExpression, where the callee is an object named the import from above
@@ -344,9 +362,8 @@ export default function loader(
 						path.replace(
 							builders.callExpression(callee, [args[0], builders.literal(features[feature.value])])
 						);
+						return false;
 					}
-
-					return false;
 				}
 				this.traverse(path);
 			}

--- a/src/webpack-bundle-analyzer/client/package-lock.json
+++ b/src/webpack-bundle-analyzer/client/package-lock.json
@@ -1181,6 +1181,7 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -2736,7 +2737,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -3533,7 +3535,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -3567,7 +3570,8 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -5003,7 +5007,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5024,12 +5029,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5044,17 +5051,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5171,7 +5181,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5183,6 +5194,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5197,6 +5209,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -5204,12 +5217,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -5228,6 +5243,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5308,7 +5324,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5320,6 +5337,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5405,7 +5423,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5441,6 +5460,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5460,6 +5480,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5503,12 +5524,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -5523,6 +5546,7 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -5538,13 +5562,15 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5554,6 +5580,7 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5565,6 +5592,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5909,7 +5937,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -8054,6 +8083,7 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -13842,13 +13872,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
 			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}

--- a/tests/support/fixtures/static-build-loader/has-es6-foo-true.js
+++ b/tests/support/fixtures/static-build-loader/has-es6-foo-true.js
@@ -36,6 +36,11 @@ add('foo', true);
 add('bar', true);
 add('bar', false, true);
 add('bar', function () { return true }, true);
+add('do-not-touch', function () { return true });
+
+if (true) {
+	doY();
+}
 
 // Should not parse
 if (checkHas.exists('foo')) {

--- a/tests/support/fixtures/static-build-loader/has-es6.js
+++ b/tests/support/fixtures/static-build-loader/has-es6.js
@@ -36,6 +36,11 @@ add('foo', () => true, false);
 add('bar', true);
 add('bar', false, true);
 add('bar', function () { return true }, true);
+add('do-not-touch', function () { return true });
+
+if (checkHas('do-not-touch')) {
+	doY();
+}
 
 // Should not parse
 if (checkHas.exists('foo')) {

--- a/tests/support/fixtures/static-build-loader/has-foo-true.js
+++ b/tests/support/fixtures/static-build-loader/has-foo-true.js
@@ -1,0 +1,29 @@
+export function add(feature, value, overwrite = false ) {
+	// Add
+}
+
+export default function has(feature, strict = false) {
+	// Has
+}
+
+function doTheThing() {
+
+}
+
+if (true) {
+	doTheThing();
+}
+
+if (!has('bar')) {
+	doTheThing();
+}
+
+add('foo', true);
+
+add('bar', () => {
+	return 1 + 1 < 2;
+});
+
+add('baz', () => true);
+
+add('foo', true);

--- a/tests/support/fixtures/static-build-loader/has.js
+++ b/tests/support/fixtures/static-build-loader/has.js
@@ -1,0 +1,31 @@
+export function add(feature, value, overwrite = false ) {
+	// Add
+}
+
+export default function has(feature, strict = false) {
+	// Has
+}
+
+function doTheThing() {
+
+}
+
+if (has('foo')) {
+	doTheThing();
+}
+
+if (!has('bar')) {
+	doTheThing();
+}
+
+add('foo', () => {
+	return 1 + 1 > 2;
+});
+
+add('bar', () => {
+	return 1 + 1 < 2;
+});
+
+add('baz', () => has('foo'));
+
+add('foo', false, true);

--- a/tests/unit/static-build-loader/loader.ts
+++ b/tests/unit/static-build-loader/loader.ts
@@ -84,7 +84,8 @@ registerSuite('static-build-loader', {
 		'static features with es6 import'() {
 			const code = loadCode('has-es6');
 			mockLoaderUtils.getOptions.returns({
-				features: { foo: true }
+				features: { foo: true, 'do-not-touch': true },
+				staticOnly: ['do-not-touch']
 			});
 
 			const context = {

--- a/tests/unit/static-build-loader/loader.ts
+++ b/tests/unit/static-build-loader/loader.ts
@@ -58,7 +58,7 @@ registerSuite('static-build-loader', {
 			mockLoaderUtils.getOptions.returns({
 				features: {}
 			});
-			assert.equal(loader(code)!.replace(/\r\n/g, '\n'), code);
+			assert.equal(loader.call({}, code)!.replace(/\r\n/g, '\n'), code);
 		},
 
 		'static features'() {
@@ -220,7 +220,7 @@ registerSuite('static-build-loader', {
 				features: { foo: true }
 			});
 			assert.equal(
-				loader(code)!.replace(/\r\n/g, '\n'),
+				loader.call({}, code)!.replace(/\r\n/g, '\n'),
 				loadCode('no-import-foo-true'),
 				'Should not replace has calls, but should still support has pragma if has was not imported'
 			);
@@ -228,9 +228,24 @@ registerSuite('static-build-loader', {
 
 		'should not parse a module that does not contain has pragmas or a possible call to require has'() {
 			const code = loadCode('should-not-parse');
-			assert.equal(loader(code), code, 'Should not have modified code');
+			assert.equal(loader.call({}, code), code, 'Should not have modified code');
 			assert.isFalse(mockRecast.parse.called, 'Should not have called parse');
 			assert.isFalse(mockRecast.print.called, 'Should not have called print');
+		},
+
+		'should parse add calls in has module itself'() {
+			const code = loadCode('has');
+			mockLoaderUtils.getOptions.returns({
+				features: { foo: true }
+			});
+
+			const context = {
+				callback: sandbox.stub(),
+				resourcePath: '@dojo/framework/core/has.mjs'
+			};
+
+			const resultCode = loader.call(context, code).replace(/\r\n/g, '\n');
+			assert.equal(resultCode, loadCode('has-foo-true'));
 		},
 
 		'should call callback with sourcemap in code with no pragmas or calls to has'() {


### PR DESCRIPTION
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

This restores the logic in the static-build-loader to resolve calls to `add` (and `has`) in `has.ts`, but it also modifies the add parsing logic so that it will ignore any feature specified in the `staticOnly` option
