### PR TITLE
Add the eventsource polyfill for sync bootstrap

### DIFF
--- a/src/bootstrap-plugin/sync.js
+++ b/src/bootstrap-plugin/sync.js
@@ -2,6 +2,9 @@ var has = require('@dojo/framework/core/has');
 require('./common');
 
 if (has.default('build-serve')) {
+	`has('dojo-debug')`;
+	require('eventsource-polyfill');
+	`has('dojo-debug')`;
 	require('../webpack-hot-client/client');
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add the `eventsource` polyfill for `sync` bootstrap and stop including the HMR for dist builds.

Related to https://github.com/dojo/cli-build-app/issues/320
