### PR TITLE
Export loading promise from bootstrap

### DIFF
--- a/src/bootstrap-plugin/async.js
+++ b/src/bootstrap-plugin/async.js
@@ -34,6 +34,6 @@ if (!has.default('dom-pointer-events')) {
 	modules.push(import(/* webpackChunkName: "runtime/pointerEvents" */ '@dojo/framework/shim/pointerEvents'));
 }
 
-Promise.all(modules).then(function() {
-	import(/* webpackChunkName: "main" */ __MAIN_ENTRY);
+export default Promise.all(modules).then(function() {
+	return import(/* webpackChunkName: "main" */ __MAIN_ENTRY);
 });


### PR DESCRIPTION
**Type:** feature

* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)

**Description:**
Export the module loading promise and the main loading promise from bootstrap, this in some advance cases is beneficial when trying to load this from another module system like AMD.
