### PR TITLE
Check scoped global before main global for public path etc

### DIFF
--- a/src/bootstrap-plugin/common.js
+++ b/src/bootstrap-plugin/common.js
@@ -1,6 +1,10 @@
 var has = require('@dojo/framework/core/has');
 var global = require('@dojo/framework/shim/global');
 
+if (!global.default[__DOJO_SCOPE]) {
+	global.default[__DOJO_SCOPE] = {};
+}
+
 if (!has.exists('build-time-render')) {
 	has.add('build-time-render', false, false);
 }
@@ -9,13 +13,23 @@ if (!has.exists('build-serve')) {
 	has.add('build-serve', false, false);
 }
 
-has.add('app-base', global.default.__app_base__ || '/', true);
+var appBase = global.default[__DOJO_SCOPE].base ? global.default[__DOJO_SCOPE].base : global.default.__app_base__;
 
-if (global.default.__public_path__ || global.default.__public_origin__) {
-	var publicPath = global.default.__public_origin__ || window.location.origin;
-	if (global.default.__public_path__) {
-		publicPath = publicPath + global.default.__public_path__;
-		has.add('public-path', global.default.__public_path__, true);
+var initialPublicPath = global.default[__DOJO_SCOPE].publicPath
+	? global.default[__DOJO_SCOPE].publicPath
+	: global.default.__public_path__;
+
+var initialPublicOrigin = global.default[__DOJO_SCOPE].publicOrigin
+	? global.default[__DOJO_SCOPE].publicOrigin
+	: global.default.__public_origin__;
+
+has.add('app-base', appBase || '/', true);
+
+if (initialPublicPath || initialPublicOrigin) {
+	var publicPath = initialPublicOrigin || window.location.origin;
+	if (initialPublicPath) {
+		publicPath = publicPath + initialPublicPath;
+		has.add('public-path', initialPublicPath, true);
 	}
 	__webpack_public_path__ = publicPath;
 }

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -47,6 +47,7 @@ export interface BuildTimeRenderArguments {
 	puppeteerOptions?: any;
 	basePath: string;
 	baseUrl?: string;
+	scope?: string;
 }
 
 function genHash(content: string): string {
@@ -80,6 +81,7 @@ export default class BuildTimeRender {
 	private _bridgePromises: Promise<any>[] = [];
 	private _blockErrors: Error[] = [];
 	private _hasBuildBridgeCache = false;
+	private _scope: string | undefined;
 
 	constructor(args: BuildTimeRenderArguments) {
 		const { paths = [], root = '', entries, useHistory, puppeteerOptions, basePath, baseUrl = '/' } = args;
@@ -397,7 +399,7 @@ ${blockCacheEntry}`
 		const page = await browser.newPage();
 		page.on('error', reportError);
 		page.on('pageerror', reportError);
-		await setupEnvironment(page, this._baseUrl);
+		await setupEnvironment(page, this._baseUrl, this._scope);
 		await page.exposeFunction('__dojoBuildBridge', this._buildBridge.bind(this));
 		return page;
 	}

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -84,7 +84,7 @@ export default class BuildTimeRender {
 	private _scope: string | undefined;
 
 	constructor(args: BuildTimeRenderArguments) {
-		const { paths = [], root = '', entries, useHistory, puppeteerOptions, basePath, baseUrl = '/' } = args;
+		const { paths = [], scope, root = '', entries, useHistory, puppeteerOptions, basePath, baseUrl = '/' } = args;
 		const path = paths[0];
 		const initialPath = typeof path === 'object' ? path.path : path;
 
@@ -99,6 +99,7 @@ export default class BuildTimeRender {
 		this._puppeteerOptions = puppeteerOptions;
 		this._paths = paths;
 		this._root = root;
+		this._scope = scope;
 		this._entries = entries.map((entry) => `${entry.replace('.js', '')}.js`);
 		this._useHistory = useHistory !== undefined ? useHistory : paths.length > 0 && !/^#.*/.test(initialPath);
 		if (this._useHistory || paths.length === 0) {
@@ -235,7 +236,7 @@ export default class BuildTimeRender {
 		content = content.replace(/http:\/\/localhost:\d+\//g, '');
 		content = content.replace(new RegExp(this._baseUrl.slice(1), 'g'), '');
 		if (this._useHistory) {
-			script = generateBasePath(pathValue);
+			script = generateBasePath(pathValue, this._scope);
 		}
 
 		return {

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -67,19 +67,23 @@ export async function getClasses(page: any): Promise<String[]> {
 
 export async function setupEnvironment(page: any, base: string, scope?: string): Promise<void> {
 	if (scope) {
-		await page.evaluateOnNewDocument((base: string, scope: string) => {
-			// @ts-ignore
-			window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };
-			// @ts-ignore
-			if (!window[scope]) {
+		await page.evaluateOnNewDocument(
+			(base: string, scope: string) => {
 				// @ts-ignore
-				window[scope] = {};
-			}
-			// @ts-ignore
-			window[scope].publicPath = base;
-			// @ts-ignore
-			window[scope].base = base;
-		}, base, scope);
+				window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };
+				// @ts-ignore
+				if (!window[scope]) {
+					// @ts-ignore
+					window[scope] = {};
+				}
+				// @ts-ignore
+				window[scope].publicPath = base;
+				// @ts-ignore
+				window[scope].base = base;
+			},
+			base,
+			scope
+		);
 	} else {
 		await page.evaluateOnNewDocument((base: string) => {
 			// @ts-ignore

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -65,15 +65,26 @@ export async function getClasses(page: any): Promise<String[]> {
 	});
 }
 
-export async function setupEnvironment(page: any, base: string): Promise<void> {
-	await page.evaluateOnNewDocument((base: string) => {
-		// @ts-ignore
-		window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };
-		// @ts-ignore
-		window.__public_path__ = base;
-		// @ts-ignore
-		window.__app_base__ = base;
-	}, base);
+export async function setupEnvironment(page: any, base: string, scope?: string): Promise<void> {
+	if (scope) {
+		await page.evaluateOnNewDocument((base: string, scope: string) => {
+			// @ts-ignore
+			window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };
+			// @ts-ignore
+			window[scope].publicPath = base;
+			// @ts-ignore
+			window[scope].base = base;
+		}, base, scope);
+	} else {
+		await page.evaluateOnNewDocument((base: string) => {
+			// @ts-ignore
+			window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };
+			// @ts-ignore
+			window.__public_path__ = base;
+			// @ts-ignore
+			window.__app_base__ = base;
+		}, base);
+	}
 }
 
 export async function getForSelector(page: any, selector: string) {

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -129,7 +129,14 @@ export function generateRouteInjectionScript(html: string[], paths: any[], root:
 </script>`;
 }
 
-export function generateBasePath(route = '') {
+export function generateBasePath(route = '', scope: string) {
+	if (scope) {
+		return `<script>
+	if (!window['${scope}']) {
+		window['${scope}'].publicPath = window.location.pathname.replace(${new RegExp(`(\/)?${route}(\/)?$`)}, '/');
+	}
+</script>`;
+	}
 	return `<script>
 	window.__public_path__ = window.location.pathname.replace(${new RegExp(`(\/)?${route}(\/)?$`)}, '/');
 </script>`;

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -129,7 +129,7 @@ export function generateRouteInjectionScript(html: string[], paths: any[], root:
 </script>`;
 }
 
-export function generateBasePath(route = '', scope: string) {
+export function generateBasePath(route = '', scope?: string) {
 	if (scope) {
 		return `<script>
 	if (!window['${scope}']) {

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -71,6 +71,11 @@ export async function setupEnvironment(page: any, base: string, scope?: string):
 			// @ts-ignore
 			window.DojoHasEnvironment = { staticFeatures: { 'build-time-render': true } };
 			// @ts-ignore
+			if (!window[scope]) {
+				// @ts-ignore
+				window[scope] = {};
+			}
+			// @ts-ignore
 			window[scope].publicPath = base;
 			// @ts-ignore
 			window[scope].base = base;

--- a/src/webpack-bundle-analyzer/client/package-lock.json
+++ b/src/webpack-bundle-analyzer/client/package-lock.json
@@ -1181,7 +1181,6 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -2737,8 +2736,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -3535,8 +3533,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -3570,8 +3567,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -5007,8 +5003,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5029,14 +5024,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5051,20 +5044,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5181,8 +5171,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5194,7 +5183,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5209,7 +5197,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -5217,14 +5204,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -5243,7 +5228,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5324,8 +5308,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5337,7 +5320,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5423,8 +5405,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5460,7 +5441,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5480,7 +5460,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5524,14 +5503,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -5546,7 +5523,6 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -5562,15 +5538,13 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5580,7 +5554,6 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5592,7 +5565,6 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5937,8 +5909,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -8083,7 +8054,6 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -13872,15 +13842,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
 			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}

--- a/tests/support/fixtures/build-time-render/state-scoped/additional.js
+++ b/tests/support/fixtures/build-time-render/state-scoped/additional.js
@@ -1,0 +1,1 @@
+(function additional() {})();

--- a/tests/support/fixtures/build-time-render/state-scoped/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-scoped/expected/my-path/index.html
@@ -1,0 +1,13 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
+	<body>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}</div></div>
+		<script>
+	if (!window['app-scope']) {
+		window['app-scope'].publicPath = window.location.pathname.replace(/(\/)?my-path(\/)?$/, '/');
+	}
+</script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
+	<link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-scoped/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-scoped/expected/my-path/other/index.html
@@ -1,0 +1,13 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
+	<body>
+		<div id="app"><div class="other">Other</div></div>
+		<script>
+	if (!window['app-scope']) {
+		window['app-scope'].publicPath = window.location.pathname.replace(/(\/)?my-path\/other(\/)?$/, '/');
+	}
+</script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
+	<link rel="preload" href="my-path/additional.js" as="script"><link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-scoped/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-scoped/expected/other/index.html
@@ -1,0 +1,13 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
+	<body>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"></div></div>
+		<script>
+	if (!window['app-scope']) {
+		window['app-scope'].publicPath = window.location.pathname.replace(/(\/)?other(\/)?$/, '/');
+	}
+</script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
+	<link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-scoped/index.html
+++ b/tests/support/fixtures/build-time-render/state-scoped/index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-scoped/main.css
+++ b/tests/support/fixtures/build-time-render/state-scoped/main.css
@@ -1,0 +1,27 @@
+#root {
+	margin: 10px;
+}
+
+/* example comment */
+
+.hello {
+	background: red;
+}
+
+.other.another {
+	color: pink;
+	background: url("relative.png");
+	background: url("/root.png");
+	background: url("./relative.png");
+	background: url("../relative.png");
+	background: url("https://example.com");
+	background: url("http://example.com");
+	background: url(https://example.com);
+	background: url(http://example.com);
+}
+
+span {
+	width: 100%;
+}
+
+/*# sourceMappingURL=main.16469ae7e579bf3f6af50cbfcb734efa.bundle.css.map*/

--- a/tests/support/fixtures/build-time-render/state-scoped/main.js
+++ b/tests/support/fixtures/build-time-render/state-scoped/main.js
@@ -1,0 +1,52 @@
+(function main() {
+	const app = document.getElementById('app');
+	let div = document.createElement('div');
+	const route = window.location.pathname;
+
+	function renderDefault() {
+		const imgOne = document.createElement('img');
+		const imgTwo = document.createElement('img');
+		const imgThree = document.createElement('img');
+		const imgFour = document.createElement('img');
+		const imgFive = document.createElement('img');
+		div.classList.add('hello', 'another');
+		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
+		app.appendChild(div);
+
+		imgOne.setAttribute('src', 'https://example.com');
+		div.appendChild(imgOne);
+
+		imgTwo.setAttribute('src', 'http://example.com');
+		div.appendChild(imgTwo);
+
+		imgThree.setAttribute('src', '/image.svg');
+		div.appendChild(imgThree);
+
+		imgFour.setAttribute('src', './relative-image.svg');
+		div.appendChild(imgFour);
+
+		imgFive.setAttribute('src', '../other-relative-image.svg');
+		div.appendChild(imgFive);
+	}
+
+	if (route === '/') {
+		renderDefault();
+	} else if (route === '/my-path') {
+		div = document.createElement('div');
+		div.classList.add('hello', 'another');
+		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
+		app.appendChild(div);
+	} else if (route === '/my-path/other') {
+		div = document.createElement('div');
+		div.classList.add('other');
+		div.innerHTML = 'Other';
+		app.appendChild(div);
+
+		let script = document.createElement('script');
+		script.setAttribute('src', 'additional.js');
+
+		document.body.appendChild(script);
+	} else {
+		renderDefault();
+	}
+})();

--- a/tests/support/fixtures/build-time-render/state-scoped/manifest.json
+++ b/tests/support/fixtures/build-time-render/state-scoped/manifest.json
@@ -1,0 +1,9 @@
+{
+	"main.js": "main.js",
+	"other.js": "other.js",
+	"main.css": "main.css",
+	"other.css": "other.css",
+	"runtime.js": "runtime.js",
+	"index.html": "index.html",
+	"additional.js": "additional.js"
+}

--- a/tests/support/fixtures/build-time-render/state-scoped/other.css
+++ b/tests/support/fixtures/build-time-render/state-scoped/other.css
@@ -1,0 +1,3 @@
+.another {
+	background: red;
+}

--- a/tests/support/fixtures/build-time-render/state-scoped/other.js
+++ b/tests/support/fixtures/build-time-render/state-scoped/other.js
@@ -1,0 +1,1 @@
+(function other() {})();

--- a/tests/support/fixtures/build-time-render/state-scoped/runtime.js
+++ b/tests/support/fixtures/build-time-render/state-scoped/runtime.js
@@ -1,0 +1,1 @@
+(function runtime() {})();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The current mechanism for specifying the base, public path and public origin is to add the values to the global. This can lead to collisions when there are multiple dojo applications being run in the same page. This change adds a scoped section to the global that is checked first.

Resolves #202 
