### PR TITLE
Disconnect SSE on beforeunload, which silences Firefox warning

### DIFF
--- a/src/webpack-hot-client/client.js
+++ b/src/webpack-hot-client/client.js
@@ -32,6 +32,7 @@ function EventSourceWrapper() {
 		source.onopen = handleOnline;
 		source.onerror = handleDisconnect;
 		source.onmessage = handleMessage;
+		global.addEventListener('beforeunload', handleDisconnect);
 	}
 
 	function handleOnline() {

--- a/tests/unit/webpack-hot-client/client.ts
+++ b/tests/unit/webpack-hot-client/client.ts
@@ -24,6 +24,7 @@ global.EventSource = EventSource;
 global.location = {
 	reload: sinon.stub()
 };
+global.addEventListener = sinon.stub();
 
 describe('client', () => {
 	const overlayMock = {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Resolves https://github.com/dojo/webpack-contrib/issues/205
