### PR TITLE
Backport to v6: Disconnect SSE on beforeunload, which silences Firefox warning

### DIFF
--- a/src/webpack-hot-client/client.js
+++ b/src/webpack-hot-client/client.js
@@ -32,6 +32,7 @@ function EventSourceWrapper() {
 		source.onopen = handleOnline;
 		source.onerror = handleDisconnect;
 		source.onmessage = handleMessage;
+		global.addEventListener('beforeunload', handleDisconnect);
 	}
 
 	function handleOnline() {

--- a/tests/unit/webpack-hot-client/client.ts
+++ b/tests/unit/webpack-hot-client/client.ts
@@ -24,6 +24,7 @@ global.EventSource = EventSource;
 global.location = {
 	reload: sinon.stub()
 };
+global.addEventListener = sinon.stub();
 
 describe('client', () => {
 	const overlayMock = {


### PR DESCRIPTION
(cherry picked from commit 6783b95f1a04edc808a5922cbe48a9d8dbbe4c49)

**Type:** bug

**Description:**

Backport https://github.com/dojo/webpack-contrib/pull/206
