### PR TITLE
Only clear modules in src

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -1,7 +1,7 @@
 import { Compiler } from 'webpack';
 import { outputFileSync, removeSync, ensureDirSync } from 'fs-extra';
 
-import { join } from 'path';
+import { join, resolve } from 'path';
 import {
 	serve,
 	getClasses,
@@ -459,7 +459,7 @@ ${blockCacheEntry}`
 				})
 				.map((key) => this._manifest[key]);
 
-			clearModule.all();
+			clearModule.match(new RegExp(`${resolve(this._basePath, 'src')}.*`));
 			const browser = await puppeteer.launch(this._puppeteerOptions);
 			const app = await serve(`${this._output}`, this._baseUrl);
 			try {

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -110,6 +110,7 @@ describe('build-time-render', () => {
 			fs.existsSync = existsSync;
 			const Btr = mockModule.getModuleUnderTest().default;
 			const btr = new Btr({
+				basePath: '',
 				entries: ['runtime', 'main'],
 				root: 'missing',
 				puppeteerOptions: { args: ['--no-sandbox'] }
@@ -264,6 +265,7 @@ describe('build-time-render', () => {
 			fs.existsSync = existsSync;
 			const Btr = mockModule.getModuleUnderTest().default;
 			const btr = new Btr({
+				basePath: '',
 				paths: [],
 				entries: ['runtime', 'main'],
 				root: 'app',
@@ -287,6 +289,7 @@ describe('build-time-render', () => {
 			fs.existsSync = existsSync;
 			const Btr = mockModule.getModuleUnderTest().default;
 			const btr = new Btr({
+				basePath: '',
 				paths: [
 					{
 						path: '#my-path'
@@ -314,6 +317,7 @@ describe('build-time-render', () => {
 			fs.existsSync = existsSync;
 			const Btr = mockModule.getModuleUnderTest().default;
 			const btr = new Btr({
+				basePath: '',
 				paths: [],
 				entries: ['runtime', 'main'],
 				puppeteerOptions: { args: ['--no-sandbox'] }
@@ -372,6 +376,7 @@ describe('build-time-render', () => {
 			fs.existsSync = existsSync;
 			const Btr = mockModule.getModuleUnderTest().default;
 			const btr = new Btr({
+				basePath: '',
 				paths: [
 					{
 						path: 'my-path'
@@ -485,6 +490,7 @@ describe('build-time-render', () => {
 			fs.existsSync = existsSync;
 			const Btr = mockModule.getModuleUnderTest().default;
 			const btr = new Btr({
+				basePath: '',
 				paths: [
 					{
 						path: 'my-path'
@@ -627,6 +633,7 @@ describe('build-time-render', () => {
 				fs.existsSync = existsSync;
 				const Btr = mockModule.getModuleUnderTest().default;
 				const btr = new Btr({
+					basePath: '',
 					paths: [
 						{
 							path: 'my-path'
@@ -772,6 +779,7 @@ describe('build-time-render', () => {
 				fs.existsSync = existsSync;
 				const Btr = mockModule.getModuleUnderTest().default;
 				const btr = new Btr({
+					basePath: '',
 					paths: [
 						{
 							path: 'my-path',
@@ -924,6 +932,7 @@ describe('build-time-render', () => {
 				fs.existsSync = existsSync;
 				const Btr = mockModule.getModuleUnderTest().default;
 				const btr = new Btr({
+					basePath: '',
 					static: true,
 					entries: ['runtime', 'main'],
 					root: 'app',
@@ -991,6 +1000,7 @@ describe('build-time-render', () => {
 			fs.existsSync = existsSync;
 			const Btr = mockModule.getModuleUnderTest().default;
 			const btr = new Btr({
+				basePath: '',
 				paths: [
 					{
 						path: 'my-path'


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Built time rendering currently clears *all* loaded modules when it is run in watch which is problematic and unnecessary, it only needs to unload modules loaded from the project's source. This change filters the modules that are cleared to only modules that live in the project (blocks).
