### PR TITLE
Only write dts definition if absolutely neccessary

### DIFF
--- a/tests/unit/css-module-dts-loader/loader.ts
+++ b/tests/unit/css-module-dts-loader/loader.ts
@@ -72,6 +72,11 @@ describe('css-module-dts-loader', () => {
 		mockUtils.getOptions = sandbox.stub();
 		mockFs = mockModule.getMock('fs');
 		mockFs.statSync = sandbox.stub().returns({ mtime: dateNow });
+		mockFs.existsSync = sandbox.stub().returns(true);
+		mockFs.readFileSync = sandbox
+			.stub()
+			.withArgs(resourcePath)
+			.returns(cssContent);
 		mockInstances = mockModule.getMock('ts-loader/dist/instances');
 		instance = getInstance();
 		mockInstances.getTypeScriptInstance = sandbox.stub().returns({ instance });


### PR DESCRIPTION
**Type:** bug
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**
This should cut down on erroneous double builds when using css modules. We will now only write a declaration for the module if:

* the css differs from the last builds css
* the generated definitions differs from the existing definition on file
