### PR TITLE
Auto discover build time render paths from rendered links

### DIFF
--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -101,6 +101,17 @@ export async function getForSelector(page: any, selector: string) {
 	return page.$eval(selector, (element: Element) => element.outerHTML);
 }
 
+export async function getPageLinks(page: any) {
+	let links: string[] = await page.$$eval('a', (links: HTMLAnchorElement[]) =>
+		links.map((link) => {
+			const href = link.getAttribute('href') || '';
+			return href.replace(/#.*/, '');
+		})
+	);
+	links = [...new Set(links.filter((link) => /^http(s)?:\/\//.test(link) === false))];
+	return links;
+}
+
 export async function getScriptSources(page: any, port: number): Promise<string[]> {
 	const scripts: string[] = await page.$$eval('script', (elements: HTMLScriptElement[]) =>
 		elements.map((element) => element.src)

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/additional.js
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/additional.js
@@ -1,0 +1,1 @@
+(function additional() {})();

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/index.html
@@ -1,0 +1,13 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
+	<body>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<a href="my-path/other"></a></div></div>
+		<script>
+	if (!window['test']) {
+		window['test'].publicPath = window.location.pathname.replace(/(\/)?my-path(\/)?$/, '/');
+	}
+</script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
+	<link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/other/index.html
@@ -1,0 +1,13 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
+	<body>
+		<div id="app"><div class="other">Other</div></div>
+		<script>
+	if (!window['test']) {
+		window['test'].publicPath = window.location.pathname.replace(/(\/)?my-path\/other(\/)?$/, '/');
+	}
+</script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
+	<link rel="preload" href="my-path/additional.js" as="script"><link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/other/index.html
@@ -1,0 +1,13 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
+	<body>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"><a href="my-path"></a><a href="other"></a></div></div>
+		<script>
+	if (!window['test']) {
+		window['test'].publicPath = window.location.pathname.replace(/(\/)?other(\/)?$/, '/');
+	}
+</script><link rel="stylesheet" href="main.css" /><script src="runtime.js"></script><script src="main.js"></script>
+	<link rel="prefetch" href="other.js" /><link rel="prefetch" href="other.css" /><link rel="prefetch" href="additional.js" /></body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/main.css
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/main.css
@@ -1,0 +1,27 @@
+#root {
+	margin: 10px;
+}
+
+/* example comment */
+
+.hello {
+	background: red;
+}
+
+.other.another {
+	color: pink;
+	background: url("relative.png");
+	background: url("/root.png");
+	background: url("./relative.png");
+	background: url("../relative.png");
+	background: url("https://example.com");
+	background: url("http://example.com");
+	background: url(https://example.com);
+	background: url(http://example.com);
+}
+
+span {
+	width: 100%;
+}
+
+/*# sourceMappingURL=main.16469ae7e579bf3f6af50cbfcb734efa.bundle.css.map*/

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/main.js
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/main.js
@@ -1,0 +1,66 @@
+(function main() {
+	const app = document.getElementById('app');
+	let div = document.createElement('div');
+	const route = window.location.pathname;
+
+	function renderDefault() {
+		const imgOne = document.createElement('img');
+		const imgTwo = document.createElement('img');
+		const imgThree = document.createElement('img');
+		const imgFour = document.createElement('img');
+		const imgFive = document.createElement('img');
+		const linkOne = document.createElement('a');
+		const linkTwo = document.createElement('a');
+		div.classList.add('hello', 'another');
+		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
+		app.appendChild(div);
+
+		imgOne.setAttribute('src', 'https://example.com');
+		div.appendChild(imgOne);
+
+		imgTwo.setAttribute('src', 'http://example.com');
+		div.appendChild(imgTwo);
+
+		imgThree.setAttribute('src', '/image.svg');
+		div.appendChild(imgThree);
+
+		imgFour.setAttribute('src', './relative-image.svg');
+		div.appendChild(imgFour);
+
+		imgFive.setAttribute('src', '../other-relative-image.svg');
+		div.appendChild(imgFive);
+
+		linkOne.setAttribute('href', 'my-path');
+		div.appendChild(linkOne);
+
+		linkTwo.setAttribute('href', 'other');
+		div.appendChild(linkTwo);
+	}
+
+	if (route === '/') {
+		renderDefault();
+	} else if (route === '/my-path') {
+		div = document.createElement('div');
+		div.classList.add('hello', 'another');
+		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
+		const link = document.createElement('a');
+		link.setAttribute('href', 'my-path/other');
+		div.appendChild(link);
+		app.appendChild(div);
+	} else if (route === '/my-path/other') {
+		div = document.createElement('div');
+		div.classList.add('other');
+		div.innerHTML = 'Other';
+		app.appendChild(div);
+
+		let script = document.createElement('script');
+		script.setAttribute('src', 'additional.js');
+
+		document.body.appendChild(script);
+	} else {
+		renderDefault();
+	}
+	window.test = {
+		rendering: false
+	}
+})();

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/manifest.json
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/manifest.json
@@ -1,0 +1,9 @@
+{
+	"main.js": "main.js",
+	"other.js": "other.js",
+	"main.css": "main.css",
+	"other.css": "other.css",
+	"runtime.js": "runtime.js",
+	"index.html": "index.html",
+	"additional.js": "additional.js"
+}

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/other.css
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/other.css
@@ -1,0 +1,3 @@
+.another {
+	background: red;
+}

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/other.js
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/other.js
@@ -1,0 +1,1 @@
+(function other() {})();

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/runtime.js
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/runtime.js
@@ -1,0 +1,1 @@
+(function runtime() {})();

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -32,6 +32,7 @@ const callbackStub = stub();
 const createCompilation = (
 	type:
 		| 'state'
+		| 'state-auto-discovery'
 		| 'state-scoped'
 		| 'state-static'
 		| 'state-static-per-path'
@@ -625,6 +626,152 @@ describe('build-time-render', () => {
 									'fixtures',
 									'build-time-render',
 									'state',
+									'expected',
+									'my-path',
+									'other',
+									'index.html'
+								),
+								'utf8'
+							)
+						)
+					);
+				});
+			});
+
+			it('should auto discover paths to build from each rendered page', () => {
+				compiler = {
+					hooks: {
+						afterEmit: {
+							tapAsync: tapStub
+						},
+						normalModuleFactory: {
+							tap: stub()
+						}
+					},
+					options: {
+						output: {
+							path: path.join(
+								__dirname,
+								'..',
+								'..',
+								'support',
+								'fixtures',
+								'build-time-render',
+								'state-auto-discovery'
+							)
+						}
+					}
+				};
+				const fs = mockModule.getMock('fs-extra');
+				const outputFileSync = stub();
+				fs.outputFileSync = outputFileSync;
+				fs.readFileSync = readFileSync;
+				fs.existsSync = existsSync;
+				const Btr = getBuildTimeRenderModule();
+				const btr = new Btr({
+					basePath: '',
+					useHistory: true,
+					entries: ['runtime', 'main'],
+					root: 'app',
+					puppeteerOptions: { args: ['--no-sandbox'] },
+					scope: 'test'
+				});
+				btr.apply(compiler);
+				assert.isTrue(pluginRegistered);
+				return runBtr(createCompilation('state-auto-discovery'), callbackStub).then(() => {
+					assert.isTrue(callbackStub.calledOnce);
+					assert.strictEqual(outputFileSync.callCount, 4);
+					assert.isTrue(
+						outputFileSync.secondCall.args[0].indexOf(
+							path.join(
+								'support',
+								'fixtures',
+								'build-time-render',
+								'state-auto-discovery',
+								'my-path',
+								'index.html'
+							)
+						) > -1
+					);
+					assert.isTrue(
+						outputFileSync.thirdCall.args[0].indexOf(
+							path.join(
+								'support',
+								'fixtures',
+								'build-time-render',
+								'state-auto-discovery',
+								'other',
+								'index.html'
+							)
+						) > -1
+					);
+					assert.isTrue(
+						outputFileSync
+							.getCall(3)
+							.args[0].indexOf(
+								path.join(
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
+									'my-path',
+									'other',
+									'index.html'
+								)
+							) > -1
+					);
+					assert.strictEqual(
+						normalise(outputFileSync.secondCall.args[1]),
+						normalise(
+							readFileSync(
+								path.join(
+									__dirname,
+									'..',
+									'..',
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
+									'expected',
+									'my-path',
+									'index.html'
+								),
+								'utf8'
+							)
+						)
+					);
+					assert.strictEqual(
+						normalise(outputFileSync.thirdCall.args[1]),
+						normalise(
+							readFileSync(
+								path.join(
+									__dirname,
+									'..',
+									'..',
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
+									'expected',
+									'other',
+									'index.html'
+								),
+								'utf8'
+							)
+						)
+					);
+					assert.strictEqual(
+						normalise(outputFileSync.getCall(3).args[1]),
+						normalise(
+							readFileSync(
+								path.join(
+									__dirname,
+									'..',
+									'..',
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
 									'expected',
 									'my-path',
 									'other',
@@ -1628,6 +1775,234 @@ describe('build-time-render', () => {
 									'state',
 									'expected',
 									'my-path',
+									'other',
+									'index.html'
+								),
+								'utf8'
+							)
+						)
+					);
+				});
+			});
+
+			it('should auto discover paths to build from each rendered page', () => {
+				compiler = {
+					hooks: {
+						afterEmit: {
+							tapAsync: tapStub
+						},
+						normalModuleFactory: {
+							tap: stub()
+						}
+					},
+					options: {
+						output: {
+							path: path.join(
+								__dirname,
+								'..',
+								'..',
+								'support',
+								'fixtures',
+								'build-time-render',
+								'state-auto-discovery'
+							)
+						}
+					}
+				};
+				const fs = mockModule.getMock('fs-extra');
+				const outputFileSync = stub();
+				fs.outputFileSync = outputFileSync;
+				fs.readFileSync = readFileSync;
+				fs.existsSync = existsSync;
+				const Btr = getBuildTimeRenderModule();
+				const btr = new Btr({
+					basePath: '',
+					useHistory: true,
+					entries: ['runtime', 'main'],
+					root: 'app',
+					puppeteerOptions: { args: ['--no-sandbox'] },
+					scope: 'test',
+					renderer: 'jsdom'
+				});
+				btr.apply(compiler);
+				assert.isTrue(pluginRegistered);
+				return runBtr(createCompilation('state-auto-discovery'), callbackStub).then(() => {
+					assert.isTrue(callbackStub.calledOnce);
+					assert.strictEqual(outputFileSync.callCount, 4);
+					assert.isTrue(
+						outputFileSync.secondCall.args[0].indexOf(
+							path.join(
+								'support',
+								'fixtures',
+								'build-time-render',
+								'state-auto-discovery',
+								'my-path',
+								'index.html'
+							)
+						) > -1
+					);
+					assert.isTrue(
+						outputFileSync.thirdCall.args[0].indexOf(
+							path.join(
+								'support',
+								'fixtures',
+								'build-time-render',
+								'state-auto-discovery',
+								'other',
+								'index.html'
+							)
+						) > -1
+					);
+					assert.isTrue(
+						outputFileSync
+							.getCall(3)
+							.args[0].indexOf(
+								path.join(
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
+									'my-path',
+									'other',
+									'index.html'
+								)
+							) > -1
+					);
+					assert.strictEqual(
+						normalise(outputFileSync.secondCall.args[1]),
+						normalise(
+							readFileSync(
+								path.join(
+									__dirname,
+									'..',
+									'..',
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
+									'expected',
+									'my-path',
+									'index.html'
+								),
+								'utf8'
+							)
+						)
+					);
+					assert.strictEqual(
+						normalise(outputFileSync.thirdCall.args[1]),
+						normalise(
+							readFileSync(
+								path.join(
+									__dirname,
+									'..',
+									'..',
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
+									'expected',
+									'other',
+									'index.html'
+								),
+								'utf8'
+							)
+						)
+					);
+					assert.strictEqual(
+						normalise(outputFileSync.getCall(3).args[1]),
+						normalise(
+							readFileSync(
+								path.join(
+									__dirname,
+									'..',
+									'..',
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
+									'expected',
+									'my-path',
+									'other',
+									'index.html'
+								),
+								'utf8'
+							)
+						)
+					);
+				});
+			});
+
+			it('should not auto discover paths when option set to false', () => {
+				compiler = {
+					hooks: {
+						afterEmit: {
+							tapAsync: tapStub
+						},
+						normalModuleFactory: {
+							tap: stub()
+						}
+					},
+					options: {
+						output: {
+							path: path.join(
+								__dirname,
+								'..',
+								'..',
+								'support',
+								'fixtures',
+								'build-time-render',
+								'state-auto-discovery'
+							)
+						}
+					}
+				};
+				const fs = mockModule.getMock('fs-extra');
+				const outputFileSync = stub();
+				fs.outputFileSync = outputFileSync;
+				fs.readFileSync = readFileSync;
+				fs.existsSync = existsSync;
+				const Btr = getBuildTimeRenderModule();
+				const btr = new Btr({
+					basePath: '',
+					useHistory: true,
+					paths: ['other'],
+					discoverPaths: false,
+					entries: ['runtime', 'main'],
+					root: 'app',
+					puppeteerOptions: { args: ['--no-sandbox'] },
+					scope: 'test',
+					renderer: 'jsdom'
+				});
+				btr.apply(compiler);
+				assert.isTrue(pluginRegistered);
+				return runBtr(createCompilation('state-auto-discovery'), callbackStub).then(() => {
+					assert.isTrue(callbackStub.calledOnce);
+					assert.strictEqual(outputFileSync.callCount, 2);
+					assert.isTrue(
+						outputFileSync.secondCall.args[0].indexOf(
+							path.join(
+								'support',
+								'fixtures',
+								'build-time-render',
+								'state-auto-discovery',
+								'other',
+								'index.html'
+							)
+						) > -1
+					);
+					assert.strictEqual(
+						normalise(outputFileSync.secondCall.args[1]),
+						normalise(
+							readFileSync(
+								path.join(
+									__dirname,
+									'..',
+									'..',
+									'support',
+									'fixtures',
+									'build-time-render',
+									'state-auto-discovery',
+									'expected',
 									'other',
 									'index.html'
 								),


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Enable discovery of BTR paths by scraping the rendered anchor tags and using adding the discovered paths to the BTR processing.

Using `@dojo/site` as a reference, this reduces the need to maintain the complete application paths in the `.dojorc` completely.

### New @dojo/site `.dojorc` build-time-render configuration

```json
"build-time-render": {
	"root": "root",
	"static": true
}
```

### Existing @dojo/site `.dojorc` build-time-render configuration

```json
"build-time-render": {
	"root": "root",
	"static": true,
	"paths": [
		"home",
		"blog",
		"blog/version-4-dojo",
		"blog/version-5-dojo",
		"blog/version-6-dojo",
		"blog/building-pwa-dojo",
		"blog/dojo-version-3-release",
		"blog/dojo2-0-0-release",
		"blog/dojo-2-rc1",
		"blog/announcing-dojo-2-beta-5",
		"blog/announcing-dojo-2-beta-4",
		"blog/dojo-2-is-coming",
		"roadmap",
		"examples",
		"playground",
		"learn",
		"learn/overview",
		"learn/overview/introduction",
		"learn/overview/preamble--crafting-enterprise-web-applications",
		"learn/overview/components-of-a-dojo-application",
		"learn/overview/state-management",
		"learn/overview/user-experience",
		"learn/overview/efficiency-and-performance",
		"learn/overview/accessibility-and-internationalization",
		"learn/overview/adaptable-presentation",
		"learn/overview/application-development-lifecycle",
		"learn/routing",
		"learn/routing/introduction",
		"learn/routing/router-api",
		"learn/routing/route-configuration",
		"learn/routing/router-api",
		"learn/routing/using-the-outlet-matchdetails",
		"learn/routing/history-managers",
		"learn/routing/error-outlet",
		"learn/building",
		"learn/building/introduction",
		"learn/building/creating-bundles",
		"learn/building/static-assets",
		"learn/building/progressive-web-applications",
		"learn/building/buildtime-rendering",
		"learn/building/conditional-code",
		"learn/building/externals",
		"learn/building/ejecting",
		"learn/testing",
		"learn/testing/introduction",
		"learn/testing/dojo-test-harness",
		"learn/testing/assertion-templates",
		"learn/testing/mocking",
		"learn/testing/functional-tests",
		"learn/testing/using-remote-testing-services",
		"learn/styling",
		"learn/styling/introduction",
		"learn/styling/styling-and-theming-in-dojo",
		"learn/styling/theming-a-dojo-application",
		"learn/styling/working-with-themes",
		"learn/middleware",
		"learn/middleware/introduction",
		"learn/middleware/middleware-fundamentals",
		"learn/middleware/available-middleware",
		"learn/middleware/core-render-middleware",
		"learn/creating-widgets",
		"learn/creating-widgets/introduction",
		"learn/creating-widgets/widget-fundamentals",
		"learn/creating-widgets/rendering-widgets",
		"learn/creating-widgets/configuring-widgets-through-properties",
		"learn/creating-widgets/enabling-interactivity",
		"learn/creating-widgets/managing-state",
		"learn/creating-widgets/best-practice-development",
		"learn/i18n",
		"learn/i18n/introduction",
		"learn/i18n/working-with-message-bundles",
		"learn/i18n/internationalizing-a-dojo-application",
		"learn/i18n/advanced-formatting-cldr",
		"learn/i18n/standalone-api",
		"learn/stores",
		"learn/stores/introduction",
		"learn/stores/store-concepts-in-detail",
		"learn/stores/common-state-management-patterns",
		"learn/stores/advanced-store-operations"
	]
}
```