### PR TITLE
Fix backwards compatibility support with cli-build-app

### DIFF
--- a/src/bootstrap-plugin/common.js
+++ b/src/bootstrap-plugin/common.js
@@ -1,8 +1,10 @@
 var has = require('@dojo/framework/core/has');
 var global = require('@dojo/framework/shim/global');
 
-if (!global.default[__DOJO_SCOPE]) {
-	global.default[__DOJO_SCOPE] = {};
+var scope = typeof __DOJO_SCOPE === 'string' ? __DOJO_SCOPE : undefined;
+
+if (scope && !global.default[scope]) {
+	global.default[scope] = {};
 }
 
 if (!has.exists('build-time-render')) {
@@ -13,15 +15,13 @@ if (!has.exists('build-serve')) {
 	has.add('build-serve', false, false);
 }
 
-var appBase = global.default[__DOJO_SCOPE].base ? global.default[__DOJO_SCOPE].base : global.default.__app_base__;
+var appBase = scope && global.default[scope].base ? global.default[scope].base : global.default.__app_base__;
 
-var initialPublicPath = global.default[__DOJO_SCOPE].publicPath
-	? global.default[__DOJO_SCOPE].publicPath
-	: global.default.__public_path__;
+var initialPublicPath =
+	scope && lobal.default[scope].publicPath ? global.default[scope].publicPath : global.default.__public_path__;
 
-var initialPublicOrigin = global.default[__DOJO_SCOPE].publicOrigin
-	? global.default[__DOJO_SCOPE].publicOrigin
-	: global.default.__public_origin__;
+var initialPublicOrigin =
+	scope && global.default[scope].publicOrigin ? global.default[scope].publicOrigin : global.default.__public_origin__;
 
 has.add('app-base', appBase || '/', true);
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fixes an issue of backwards compatibility with older v6 versions of `@dojo/cli-build-app`.