### PR TITLE
Skip BTR for build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3212,9 +3212,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.307.tgz",
-      "integrity": "sha512-01rTsAqHwf3D2X6NtlUvzB2hxDj67kiTVIO5GWdFb2unA0QvFvrjyrtc993ByRLF+surlr+9AvJdD0UYs5HzwA=="
+      "version": "1.3.309",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.309.tgz",
+      "integrity": "sha512-NZd91XD15v2UPLjYXoN/gLnkwIUQjdH4SQLpRCCQiYJH6BBkfgp5pWemBJPr1rZ2dl8Ee3o91O9Sa1QuAfZmog=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -3314,12 +3314,12 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.52",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
-      "integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.2",
+        "es6-symbol": "~3.1.3",
         "next-tick": "~1.0.0"
       },
       "dependencies": {
@@ -5747,11 +5747,11 @@
       }
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-there": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:static:dev": "cpx \"{src,tests}/**/*.{js.map,d.ts,html,md,json,js,css,txt}\" dist/dev && rimraf dist/dev/src/webpack-bundle-analyzer/client",
     "build:static:release": "cpx \"src/**/*.{js,d.ts,json}\" dist/release && rimraf dist/release/webpack-bundle-analyzer/client",
     "build:cjs": "tsc",
-    "build": "npm-run-all -s clean -p build:** -s dojo-package -s && rimraf src/webpack-bundle-analyzer/client/node_modules",
+    "build": "npm-run-all -s clean -p build:** -s webpack-bundle-analyzer -s dojo-package -s && rimraf src/webpack-bundle-analyzer/client/node_modules",
     "clean": "rimraf dist coverage && rimraf src/webpack-bundle-analyzer/client/node_modules",
     "dojo-package": "dojo-package",
     "dojo-release": "dojo-release",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:static:dev": "cpx \"{src,tests}/**/*.{js.map,d.ts,html,md,json,js,css,txt}\" dist/dev && rimraf dist/dev/src/webpack-bundle-analyzer/client",
     "build:static:release": "cpx \"src/**/*.{js,d.ts,json}\" dist/release && rimraf dist/release/webpack-bundle-analyzer/client",
     "build:cjs": "tsc",
-    "build": "npm-run-all -s clean -p build:** -s webpack-bundle-analyzer -s dojo-package -s && rimraf src/webpack-bundle-analyzer/client/node_modules",
+    "build": "npm-run-all -s clean -p build:** -s dojo-package -s && rimraf src/webpack-bundle-analyzer/client/node_modules",
     "clean": "rimraf dist coverage && rimraf src/webpack-bundle-analyzer/client/node_modules",
     "dojo-package": "dojo-package",
     "dojo-release": "dojo-release",

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -486,12 +486,13 @@ ${blockCacheEntry}`
 
 		compiler.hooks.afterEmit.tapAsync(this.constructor.name, async (compilation, callback) => {
 			this._buildBridgeResult = {};
+			this._blockErrors = [];
 			if (compiler.options.output) {
 				this._output = compiler.options.output.path;
 				this._jsonpName = compiler.options.output.jsonpFunction;
 			}
 
-			if (!this._output) {
+			if (!this._output || compilation.errors.length > 0) {
 				return Promise.resolve().then(() => {
 					callback();
 				});

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -96,6 +96,63 @@ describe('build-time-render', () => {
 		runBtr = () => {};
 	});
 
+	it('skip build time rendering when there are build errors ', () => {
+		outputPath = path.join(__dirname, '..', '..', 'support', 'fixtures', 'build-time-render', 'build-bridge');
+		compiler = {
+			hooks: {
+				afterEmit: {
+					tapAsync: tapStub
+				},
+				normalModuleFactory: {
+					tap: stub()
+				}
+			},
+			options: {
+				output: {
+					path: outputPath,
+					jsonpFunction: 'foo'
+				}
+			}
+		};
+		const fs = mockModule.getMock('fs-extra');
+		const outputFileSync = stub();
+		fs.outputFileSync = outputFileSync;
+		fs.readFileSync = readFileSync;
+		fs.existsSync = existsSync;
+		const Btr = getBuildTimeRenderModule();
+		const basePath = path.join(process.cwd(), 'tests/support/fixtures/build-time-render/build-bridge');
+		const btr = new Btr({
+			basePath,
+			paths: [],
+			entries: ['bootstrap', 'main'],
+			root: 'app',
+			puppeteerOptions: { args: ['--no-sandbox'] },
+			scope: 'test',
+			renderer: 'jsdom',
+			writeHtml: false
+		});
+		btr.apply(compiler);
+		const callback = normalModuleReplacementPluginStub.firstCall.args[1];
+		const resource = {
+			context: `${basePath}/foo/bar`,
+			request: `something.build.js`,
+			contextInfo: {
+				issuer: 'foo'
+			}
+		};
+		callback(resource);
+		assert.equal(
+			resource.request,
+			"@dojo/webpack-contrib/build-time-render/build-bridge-loader?modulePath='foo/bar/something.build.js'!@dojo/webpack-contrib/build-time-render/bridge"
+		);
+		const compilations = createCompilation('build-bridge');
+		compilations.errors.push(new Error('An errors'));
+		return runBtr(createCompilation('build-bridge'), callbackStub).then(() => {
+			assert.isTrue(callbackStub.calledOnce);
+			assert.isTrue(outputFileSync.notCalled);
+		});
+	});
+
 	describe('puppeteer', () => {
 		describe('errors', () => {
 			beforeEach(() => {
@@ -149,6 +206,11 @@ describe('build-time-render', () => {
 						compilation.errors[0].message,
 						'Failed to run build time rendering. Could not find DOM node with id: "missing" in src/index.html'
 					);
+					const noErrorCompilation = createCompilation('build-bridge');
+					return runBtr(noErrorCompilation, callbackStub).then(() => {
+						assert.isTrue(callbackStub.calledOnce);
+						assert.lengthOf(compilation.errors, 0);
+					});
 				});
 			});
 

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -145,9 +145,9 @@ describe('build-time-render', () => {
 			resource.request,
 			"@dojo/webpack-contrib/build-time-render/build-bridge-loader?modulePath='foo/bar/something.build.js'!@dojo/webpack-contrib/build-time-render/bridge"
 		);
-		const compilations = createCompilation('build-bridge');
-		compilations.errors.push(new Error('An errors'));
-		return runBtr(createCompilation('build-bridge'), callbackStub).then(() => {
+		const compilation = createCompilation('build-bridge');
+		compilation.errors.push(new Error('An errors'));
+		return runBtr(compilation, callbackStub).then(() => {
 			assert.isTrue(callbackStub.calledOnce);
 			assert.isTrue(outputFileSync.notCalled);
 		});
@@ -206,11 +206,6 @@ describe('build-time-render', () => {
 						compilation.errors[0].message,
 						'Failed to run build time rendering. Could not find DOM node with id: "missing" in src/index.html'
 					);
-					const noErrorCompilation = createCompilation('build-bridge');
-					return runBtr(noErrorCompilation, callbackStub).then(() => {
-						assert.isTrue(callbackStub.calledOnce);
-						assert.lengthOf(compilation.errors, 0);
-					});
 				});
 			});
 
@@ -256,6 +251,37 @@ describe('build-time-render', () => {
 						compilation.errors[1].message,
 						'BTR runtime Error: runtime error\n    at main (http://localhost'
 					);
+
+					const noErrorCompilation = createCompilation('build-bridge');
+					outputPath = path.join(
+						__dirname,
+						'..',
+						'..',
+						'support',
+						'fixtures',
+						'build-time-render',
+						'build-bridge'
+					);
+					compiler = {
+						hooks: {
+							afterEmit: {
+								tapAsync: tapStub
+							},
+							normalModuleFactory: {
+								tap: stub()
+							}
+						},
+						options: {
+							output: {
+								path: outputPath
+							}
+						}
+					};
+					btr.apply(compiler);
+					btr._basePath = path.join(process.cwd(), 'tests/support/fixtures/build-time-render/build-bridge');
+					return runBtr(noErrorCompilation, callbackStub).then(() => {
+						assert.lengthOf(noErrorCompilation.errors, 0);
+					});
 				});
 			});
 

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -128,7 +128,6 @@ describe('build-time-render', () => {
 			root: 'app',
 			puppeteerOptions: { args: ['--no-sandbox'] },
 			scope: 'test',
-			renderer: 'jsdom',
 			writeHtml: false
 		});
 		btr.apply(compiler);
@@ -1563,6 +1562,91 @@ describe('build-time-render', () => {
 				});
 			});
 		});
+
+		describe('build bridge - single bundle', () => {
+			it('should call node module, return result to render in html, and write to cache in single bundle', () => {
+				outputPath = path.join(
+					__dirname,
+					'..',
+					'..',
+					'support',
+					'fixtures',
+					'build-time-render',
+					'build-bridge-single-bundle'
+				);
+				compiler = {
+					hooks: {
+						afterEmit: {
+							tapAsync: tapStub
+						},
+						normalModuleFactory: {
+							tap: stub()
+						}
+					},
+					options: {
+						output: {
+							path: outputPath,
+							jsonpFunction: 'foo'
+						}
+					}
+				};
+				const fs = mockModule.getMock('fs-extra');
+				const outputFileSync = stub();
+				fs.outputFileSync = outputFileSync;
+				fs.readFileSync = readFileSync;
+				fs.existsSync = existsSync;
+				const Btr = getBuildTimeRenderModule();
+				const basePath = path.join(
+					process.cwd(),
+					'tests/support/fixtures/build-time-render/build-bridge-single-bundle'
+				);
+				const btr = new Btr({
+					basePath,
+					paths: [],
+					entries: ['bootstrap', 'main'],
+					root: 'app',
+					puppeteerOptions: { args: ['--no-sandbox'] },
+					scope: 'test',
+					sync: true
+				});
+				btr.apply(compiler);
+				const callback = normalModuleReplacementPluginStub.firstCall.args[1];
+				const resource = {
+					context: `${basePath}/foo/bar`,
+					request: `something.build.js`,
+					contextInfo: {
+						issuer: 'foo'
+					}
+				};
+				callback(resource);
+				assert.equal(
+					resource.request,
+					"@dojo/webpack-contrib/build-time-render/build-bridge-loader?modulePath='foo/bar/something.build.js'!@dojo/webpack-contrib/build-time-render/bridge"
+				);
+				return runBtr(createCompilation('build-bridge-single-bundle'), callbackStub).then(() => {
+					const calls = outputFileSync.getCalls();
+					let html = '';
+					let main = '';
+					calls.map((call) => {
+						const [filename, content] = call.args;
+						if (filename.match(/index\.html$/)) {
+							html = content;
+						}
+						if (filename.match(/main\.js$/)) {
+							main = content;
+						}
+					});
+					assert.strictEqual(
+						normalise(html),
+						normalise(readFileSync(path.join(outputPath, 'expected', 'index.html'), 'utf-8'))
+					);
+					assert.strictEqual(
+						normalise(main),
+						normalise(readFileSync(path.join(outputPath, 'expected', 'main.js'), 'utf-8'))
+					);
+				});
+			});
+		});
 	});
 
 	describe('jsdom', () => {
@@ -1584,35 +1668,6 @@ describe('build-time-render', () => {
 						}
 					}
 				};
-			});
-
-			it('should inject btr using entry names', () => {
-				const fs = mockModule.getMock('fs-extra');
-				const outputFileSync = stub();
-				fs.outputFileSync = outputFileSync;
-				fs.readFileSync = readFileSync;
-				fs.existsSync = existsSync;
-				const Btr = getBuildTimeRenderModule();
-				const basePath = path.join(
-					process.cwd(),
-					'tests/support/fixtures/build-time-render/build-bridge-error'
-				);
-				const btr = new Btr({
-					basePath,
-					entries: ['runtime', 'main'],
-					root: 'app',
-					puppeteerOptions: { args: ['--no-sandbox'] },
-					scope: 'test',
-					renderer: 'jsdom'
-				});
-				btr.apply(compiler);
-				assert.isTrue(pluginRegistered);
-				return runBtr(createCompilation('hash'), callbackStub).then(() => {
-					assert.isTrue(callbackStub.calledOnce);
-					const expected = readFileSync(path.join(outputPath, 'expected', 'index.html'), 'utf-8');
-					const actual = outputFileSync.firstCall.args[1];
-					assert.strictEqual(normalise(actual), normalise(expected));
-				});
 			});
 
 			it('should inject btr using manifest to map', () => {
@@ -2793,186 +2848,6 @@ describe('build-time-render', () => {
 					assert.strictEqual(
 						normalise(manifest),
 						normalise(readFileSync(path.join(outputPath, 'expected', 'manifest.json'), 'utf-8'))
-					);
-				});
-			});
-		});
-
-		describe('build bridge - single bundle', () => {
-			it('should call node module, return result to render in html, and write to cache in single bundle', () => {
-				outputPath = path.join(
-					__dirname,
-					'..',
-					'..',
-					'support',
-					'fixtures',
-					'build-time-render',
-					'build-bridge-single-bundle'
-				);
-				compiler = {
-					hooks: {
-						afterEmit: {
-							tapAsync: tapStub
-						},
-						normalModuleFactory: {
-							tap: stub()
-						}
-					},
-					options: {
-						output: {
-							path: outputPath,
-							jsonpFunction: 'foo'
-						}
-					}
-				};
-				const fs = mockModule.getMock('fs-extra');
-				const outputFileSync = stub();
-				fs.outputFileSync = outputFileSync;
-				fs.readFileSync = readFileSync;
-				fs.existsSync = existsSync;
-				const Btr = getBuildTimeRenderModule();
-				const basePath = path.join(
-					process.cwd(),
-					'tests/support/fixtures/build-time-render/build-bridge-single-bundle'
-				);
-				const btr = new Btr({
-					basePath,
-					paths: [],
-					entries: ['bootstrap', 'main'],
-					root: 'app',
-					puppeteerOptions: { args: ['--no-sandbox'] },
-					scope: 'test',
-					renderer: 'jsdom',
-					sync: true
-				});
-				btr.apply(compiler);
-				const callback = normalModuleReplacementPluginStub.firstCall.args[1];
-				const resource = {
-					context: `${basePath}/foo/bar`,
-					request: `something.build.js`,
-					contextInfo: {
-						issuer: 'foo'
-					}
-				};
-				callback(resource);
-				assert.equal(
-					resource.request,
-					"@dojo/webpack-contrib/build-time-render/build-bridge-loader?modulePath='foo/bar/something.build.js'!@dojo/webpack-contrib/build-time-render/bridge"
-				);
-				return runBtr(createCompilation('build-bridge-single-bundle'), callbackStub).then(() => {
-					const calls = outputFileSync.getCalls();
-					let html = '';
-					let main = '';
-					calls.map((call) => {
-						const [filename, content] = call.args;
-						if (filename.match(/index\.html$/)) {
-							html = content;
-						}
-						if (filename.match(/main\.js$/)) {
-							main = content;
-						}
-					});
-					assert.strictEqual(
-						normalise(html),
-						normalise(readFileSync(path.join(outputPath, 'expected', 'index.html'), 'utf-8'))
-					);
-					assert.strictEqual(
-						normalise(main),
-						normalise(readFileSync(path.join(outputPath, 'expected', 'main.js'), 'utf-8'))
-					);
-				});
-			});
-		});
-
-		describe('build bridge with blocks only', () => {
-			it('should call node module, return result to render in html, and write to cache in bundle', () => {
-				outputPath = path.join(
-					__dirname,
-					'..',
-					'..',
-					'support',
-					'fixtures',
-					'build-time-render',
-					'build-bridge-blocks-only'
-				);
-				compiler = {
-					hooks: {
-						afterEmit: {
-							tapAsync: tapStub
-						},
-						normalModuleFactory: {
-							tap: stub()
-						}
-					},
-					options: {
-						output: {
-							path: outputPath,
-							jsonpFunction: 'foo'
-						}
-					}
-				};
-				const fs = mockModule.getMock('fs-extra');
-				const outputFileSync = stub();
-				fs.outputFileSync = outputFileSync;
-				fs.readFileSync = readFileSync;
-				fs.existsSync = existsSync;
-				const Btr = getBuildTimeRenderModule();
-				const basePath = path.join(
-					process.cwd(),
-					'tests/support/fixtures/build-time-render/build-bridge-blocks-only'
-				);
-				const btr = new Btr({
-					basePath,
-					paths: [],
-					entries: ['bootstrap', 'main'],
-					root: 'app',
-					puppeteerOptions: { args: ['--no-sandbox'] },
-					scope: 'test',
-					renderer: 'jsdom',
-					writeHtml: false
-				});
-				btr.apply(compiler);
-				const callback = normalModuleReplacementPluginStub.firstCall.args[1];
-				const resource = {
-					context: `${basePath}/foo/bar`,
-					request: `something.build.js`,
-					contextInfo: {
-						issuer: 'foo'
-					}
-				};
-				callback(resource);
-				assert.equal(
-					resource.request,
-					"@dojo/webpack-contrib/build-time-render/build-bridge-loader?modulePath='foo/bar/something.build.js'!@dojo/webpack-contrib/build-time-render/bridge"
-				);
-				return runBtr(createCompilation('build-bridge-blocks-only'), callbackStub).then(() => {
-					const calls = outputFileSync.getCalls();
-					let html = '';
-					let blocks = '';
-					let block = '';
-					calls.map((call) => {
-						const [filename, content] = call.args;
-						if (filename.match(/index\.html$/)) {
-							html = content;
-						}
-						if (filename.match(/blocks\.js$/)) {
-							blocks = content;
-						}
-						if (filename.match(/block-.*\.js$/)) {
-							block = content;
-						}
-					});
-					assert.strictEqual(
-						normalise(html),
-						normalise(readFileSync(path.join(outputPath, 'expected', 'index.html'), 'utf-8'))
-					);
-					assert.strictEqual(
-						normalise(blocks),
-						normalise(readFileSync(path.join(outputPath, 'expected', 'blocks.js'), 'utf-8'))
-					);
-					assert.strictEqual(
-						normalise(block),
-						normalise(readFileSync(path.join(outputPath, 'expected', 'block.js'), 'utf-8'))
 					);
 				});
 			});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Skips BTR when there are compilation errors. Also resets the block errors each build so that stale errors do not get output on subsequent builds (in watch).

Resolves #222 