### PR TITLE
css module class map loader

### DIFF
--- a/src/css-module-class-map-loader/index.ts
+++ b/src/css-module-class-map-loader/index.ts
@@ -1,0 +1,3 @@
+import loader from './loader';
+
+module.exports = loader;

--- a/src/css-module-class-map-loader/loader.ts
+++ b/src/css-module-class-map-loader/loader.ts
@@ -1,0 +1,27 @@
+export const classesMap = new Map<string, { [index: string]: string }>();
+
+export default function(this: any, content: string) {
+	const resourcePath = this.resourcePath;
+	const localsRexExp = /exports.locals = ({[.\s\S]*});/;
+	const matches = content.match(localsRexExp);
+	const moduleMappings = classesMap.get(resourcePath);
+	if (matches && matches.length && moduleMappings) {
+		const transformedClassNames = JSON.parse(matches[1]);
+		const updatedModuleMappings = Object.keys(moduleMappings).reduce(
+			(updated, className) => {
+				const classNamesString = moduleMappings[className];
+				const classNames = classNamesString.split(' ');
+				updated[className] = classNames
+					.map((lookup) => {
+						return transformedClassNames[lookup];
+					})
+					.join(' ');
+				return updated;
+			},
+			{} as { [index: string]: any }
+		);
+		const response = content.replace(localsRexExp, `exports.locals = ${JSON.stringify(updatedModuleMappings)};`);
+		return response;
+	}
+	return content;
+}

--- a/src/css-module-class-map-loader/loader.ts
+++ b/src/css-module-class-map-loader/loader.ts
@@ -6,22 +6,7 @@ export default function(this: any, content: string) {
 	const matches = content.match(localsRexExp);
 	const moduleMappings = classesMap.get(resourcePath);
 	if (matches && matches.length && moduleMappings) {
-		const transformedClassNames = JSON.parse(matches[1]);
-		const updatedModuleMappings = Object.keys(moduleMappings).reduce(
-			(updated, className) => {
-				const classNamesString = moduleMappings[className];
-				const classNames = classNamesString.split(' ');
-				updated[className] = classNames
-					.map((lookup) => {
-						return transformedClassNames[lookup];
-					})
-					.join(' ');
-				return updated;
-			},
-			{} as { [index: string]: any }
-		);
-		const response = content.replace(localsRexExp, `exports.locals = ${JSON.stringify(updatedModuleMappings)};`);
-		return response;
+		return content.replace(localsRexExp, `exports.locals = ${JSON.stringify(moduleMappings)};`);
 	}
 	return content;
 }

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -4,6 +4,7 @@ import './external-loader-plugin/ExternalLoaderPlugin';
 import './static-build-loader/all';
 import './css-module-decorator-loader/all';
 import './css-module-dts-loader/all';
+import './css-module-class-map-loader/all';
 import './css-module-plugin/CssModulePlugin';
 import './i18n-plugin/dependencies/InjectedModuleDependency';
 import './i18n-plugin/I18nPlugin';

--- a/tests/unit/css-module-class-map-loader/all.ts
+++ b/tests/unit/css-module-class-map-loader/all.ts
@@ -1,0 +1,2 @@
+import './index';
+import './loader';

--- a/tests/unit/css-module-class-map-loader/index.ts
+++ b/tests/unit/css-module-class-map-loader/index.ts
@@ -1,0 +1,10 @@
+import * as loader from '../../../src/css-module-class-map-loader/index';
+
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+
+registerSuite('css-module-class-map-loader index', {
+	exists() {
+		assert(loader);
+	}
+});

--- a/tests/unit/css-module-class-map-loader/loader.ts
+++ b/tests/unit/css-module-class-map-loader/loader.ts
@@ -1,0 +1,35 @@
+import loader, { classesMap } from '../../../src/css-module-class-map-loader/loader';
+
+const { assert } = intern.getPlugin('chai');
+const { describe, it } = intern.getInterface('bdd');
+
+describe('css-module-class-map-loader', () => {
+	it('Should transform module locals based on the classes map', () => {
+		const content = `exports.locals = {
+			"hello": "world",
+			"foo": "bar"
+		};`;
+		classesMap.set('blah', {
+			foo: 'foo hello'
+		});
+
+		const result = loader.call({ resourcePath: 'blah' }, content);
+		assert.equal(result, 'exports.locals = {"foo":"bar world"};');
+	});
+
+	it('Should return the original content if no matches are found in the class map', () => {
+		const content = `exports.locals = {
+			"hello": "world",
+			"foo": "bar"
+		};`;
+
+		const result = loader.call({ resourcePath: 'other' }, content);
+		assert.equal(
+			result,
+			`exports.locals = {
+			"hello": "world",
+			"foo": "bar"
+		};`
+		);
+	});
+});

--- a/tests/unit/css-module-class-map-loader/loader.ts
+++ b/tests/unit/css-module-class-map-loader/loader.ts
@@ -6,11 +6,11 @@ const { describe, it } = intern.getInterface('bdd');
 describe('css-module-class-map-loader', () => {
 	it('Should transform module locals based on the classes map', () => {
 		const content = `exports.locals = {
-			"hello": "world",
-			"foo": "bar"
+			"world": "world",
+			"bar": "bar"
 		};`;
 		classesMap.set('blah', {
-			foo: 'foo hello'
+			foo: 'bar world'
 		});
 
 		const result = loader.call({ resourcePath: 'blah' }, content);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

A loader that maps original class names to the css module'd class names.