### PR TITLE
Use blocks sync in sync mode

### DIFF
--- a/src/bootstrap-plugin/sync.js
+++ b/src/bootstrap-plugin/sync.js
@@ -7,3 +7,5 @@ if (has.default('build-serve')) {
 	`has('dojo-debug')`;
 	require('../webpack-hot-client/client');
 }
+
+require('../build-time-render/blocks-sync');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Imports the blocks-sync required for blocks in single bundle mode.