### PR TITLE
Support empty css files through the css module loader pipeline

### DIFF
--- a/src/css-module-decorator-loader/loader.ts
+++ b/src/css-module-decorator-loader/loader.ts
@@ -13,11 +13,18 @@ export default function(this: webpack.loader.LoaderContext, content: string, map
 	let response = content;
 	const localsRexExp = /exports.locals = {([.\s\S]*)};/;
 	const matches = content.match(localsRexExp);
+	const key = `${packageName}/${basename(this.resourcePath, '.m.css')}`;
 
 	if (matches && matches.length > 0) {
-		const key = `${packageName}/${basename(this.resourcePath, '.m.css')}`;
 		const localExports = `{"${themeKey}": "${key}",${matches[1]}}`;
 		response = content.replace(localsRexExp, `exports.locals = ${localExports};`);
+	} else {
+		const localExports = `{"${themeKey}": "${key}"}`;
+		response = content.replace(
+			'// exports',
+			`// exports
+exports.locals = ${localExports};`
+		);
 	}
 
 	return response;

--- a/src/css-module-dts-loader/loader.ts
+++ b/src/css-module-dts-loader/loader.ts
@@ -1,4 +1,4 @@
-import { statSync, readFileSync, existsSync } from 'fs';
+import { statSync, readFileSync, existsSync, writeFileSync } from 'fs';
 import { dirname } from 'path';
 import { createSourceFile, forEachChild, Node, ScriptTarget, SyntaxKind } from 'typescript';
 import * as webpack from 'webpack';
@@ -43,11 +43,18 @@ function generateDTSFile(filePath: string, sourceFilesRegex: RegExp): Promise<vo
 			const css = cssMap.get(filePath) || '';
 			mTimeMap.set(filePath, mtime);
 
-			if (newCss !== css) {
+			if (newCss !== css || !definition) {
 				return creator.create(filePath, false, true).then((content) => {
 					cssMap.set(filePath, newCss);
 					const newDefinition = content.formatted;
-					if (newDefinition !== definition) {
+					if (!newDefinition) {
+						return writeFileSync(
+							dtsFilePath,
+							`declare const styles: {};
+export = styles;`,
+							'utf8'
+						);
+					} else if (newDefinition !== definition) {
 						return content.writeFile();
 					}
 				});

--- a/tests/unit/css-module-decorator-loader/loader.ts
+++ b/tests/unit/css-module-decorator-loader/loader.ts
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 const { describe, it } = intern.getInterface('bdd');
 
 describe('css-module-decorator-loader', () => {
-	it('should not effect content without local exports', () => {
+	it('should not effect content without local exports or "// exports" comment', () => {
 		const content = `exports = 'abc'
 		exports.push(['a', 'b'])`;
 
@@ -45,6 +45,17 @@ describe('css-module-decorator-loader', () => {
 		assert.equal(
 			result.replace(/\n|\t/g, ''),
 			'exports.locals = {" _key": "@dojo/webpack-contrib/testFile", "hello": "world " + require("-!stuff!./base.css").locals["hello"] + "", "foo": "bar"};'
+		);
+	});
+
+	it('should add key when only "// exports" comment is found', () => {
+		const content = `// exports`;
+
+		const result = loader.bind({ resourcePath: 'testFile.m.css' } as any)(content);
+		assert.equal(
+			result,
+			`// exports
+exports.locals = {" _key": "@dojo/webpack-contrib/testFile"};`
 		);
 	});
 });

--- a/tests/unit/css-module-dts-loader/loader.ts
+++ b/tests/unit/css-module-dts-loader/loader.ts
@@ -83,7 +83,7 @@ describe('css-module-dts-loader', () => {
 		mockFs.existsSync.returns(true);
 		mockFs.writeFileSync = sandbox.stub();
 		mockFs.readFileSync = sandbox.stub();
-		mockFs.readFileSync.withArgs('src/other.m.css').returns()
+		mockFs.readFileSync.withArgs('src/other.m.css').returns();
 		mockFs.readFileSync.withArgs(resourcePath).returns(cssContent);
 		mockInstances = mockModule.getMock('ts-loader/dist/instances');
 		instance = getInstance();
@@ -139,8 +139,14 @@ describe('css-module-dts-loader', () => {
 			assert.isTrue(mockDTSGenerator.create.calledOnce);
 			assert.isTrue(writeFile.notCalled);
 			assert.isTrue(mockFs.writeFileSync.calledOnce);
-			assert.isTrue(mockFs.writeFileSync.calledWith('src/other.m.css.d.ts', `declare const styles: {};
-export = styles;`, 'utf8'));
+			assert.isTrue(
+				mockFs.writeFileSync.calledWith(
+					'src/other.m.css.d.ts',
+					`declare const styles: {};
+export = styles;`,
+					'utf8'
+				)
+			);
 		});
 	});
 

--- a/tests/unit/css-module-dts-loader/loader.ts
+++ b/tests/unit/css-module-dts-loader/loader.ts
@@ -52,6 +52,7 @@ describe('css-module-dts-loader', () => {
 	const dateNow = new Date();
 	let instance: any;
 	const defaultScope = { async, resourcePath, resolve: loaderContextResolve };
+	let createResult: any;
 
 	function getInstance() {
 		return {
@@ -64,19 +65,26 @@ describe('css-module-dts-loader', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 		writeFile = sandbox.stub();
+		createResult = {
+			writeFile,
+			formatted: 'formatted css'
+		};
 		mockModule = new MockModule('../../../src/css-module-dts-loader/loader', require);
 		mockModule.dependencies(['typed-css-modules', 'ts-loader/dist/instances', 'loader-utils', 'fs']);
 		mockDTSGenerator = mockModule.getMock('typed-css-modules');
-		mockDTSGenerator.create = sandbox.stub().returns(Promise.resolve({ writeFile }));
+		mockDTSGenerator.create = sandbox.stub().returns(Promise.resolve(createResult));
 		mockUtils = mockModule.getMock('loader-utils');
 		mockUtils.getOptions = sandbox.stub();
 		mockFs = mockModule.getMock('fs');
 		mockFs.statSync = sandbox.stub().returns({ mtime: dateNow });
-		mockFs.existsSync = sandbox.stub().returns(true);
-		mockFs.readFileSync = sandbox
-			.stub()
-			.withArgs(resourcePath)
-			.returns(cssContent);
+		mockFs.existsSync = sandbox.stub();
+		mockFs.existsSync.withArgs('src/other.m.css').returns(false);
+		mockFs.existsSync.withArgs('src/other.m.css.d.ts').returns(false);
+		mockFs.existsSync.returns(true);
+		mockFs.writeFileSync = sandbox.stub();
+		mockFs.readFileSync = sandbox.stub();
+		mockFs.readFileSync.withArgs('src/other.m.css').returns()
+		mockFs.readFileSync.withArgs(resourcePath).returns(cssContent);
 		mockInstances = mockModule.getMock('ts-loader/dist/instances');
 		instance = getInstance();
 		mockInstances.getTypeScriptInstance = sandbox.stub().returns({ instance });
@@ -106,6 +114,33 @@ describe('css-module-dts-loader', () => {
 		}).then(() => {
 			assert.isTrue(mockDTSGenerator.create.calledOnce);
 			assert.isTrue(writeFile.calledOnce);
+			assert.isTrue(mockFs.writeFileSync.notCalled);
+		});
+	});
+
+	it('should generate a dts file when query type is css and the css file is empty', () => {
+		mockUtils.getOptions.returns({
+			type: 'css'
+		});
+
+		createResult.formatted = undefined;
+
+		return new Promise((resolve, reject) => {
+			loaderUnderTest.call(
+				{
+					async() {
+						return () => resolve();
+					},
+					resourcePath: 'src/other.m.css'
+				},
+				cssContent
+			);
+		}).then(() => {
+			assert.isTrue(mockDTSGenerator.create.calledOnce);
+			assert.isTrue(writeFile.notCalled);
+			assert.isTrue(mockFs.writeFileSync.calledOnce);
+			assert.isTrue(mockFs.writeFileSync.calledWith('src/other.m.css.d.ts', `declare const styles: {};
+export = styles;`, 'utf8'));
 		});
 	});
 
@@ -130,6 +165,7 @@ describe('css-module-dts-loader', () => {
 			assert.isTrue(mockFs.statSync.calledTwice);
 			assert.isTrue(mockDTSGenerator.create.calledOnce);
 			assert.isTrue(writeFile.calledOnce);
+			assert.isTrue(mockFs.writeFileSync.notCalled);
 		});
 	});
 
@@ -155,6 +191,7 @@ describe('css-module-dts-loader', () => {
 			assert.isTrue(mockFs.statSync.calledTwice);
 			assert.isTrue(mockDTSGenerator.create.calledTwice);
 			assert.isTrue(writeFile.calledTwice);
+			assert.isTrue(mockFs.writeFileSync.notCalled);
 		});
 	});
 
@@ -181,6 +218,7 @@ describe('css-module-dts-loader', () => {
 			assert.isTrue(mockDTSGenerator.create.calledOnce);
 			assert.isTrue(mockDTSGenerator.create.firstCall.calledWith(path.resolve('src', cssFilePath)));
 			assert.isTrue(writeFile.calledOnce);
+			assert.isTrue(mockFs.writeFileSync.notCalled);
 		});
 	});
 
@@ -205,6 +243,7 @@ describe('css-module-dts-loader', () => {
 			assert.isTrue(mockDTSGenerator.create.calledOnce);
 			assert.isTrue(mockDTSGenerator.create.firstCall.calledWith(path.resolve('src', cssFilePath)));
 			assert.isTrue(writeFile.calledOnce);
+			assert.isTrue(mockFs.writeFileSync.notCalled);
 		});
 	});
 
@@ -232,6 +271,7 @@ describe('css-module-dts-loader', () => {
 			assert.isTrue(mockDTSGenerator.create.firstCall.calledWith(path.resolve('src', cssFilePath)));
 			assert.isTrue(mockDTSGenerator.create.secondCall.calledWith(path.resolve('src', cssFilePath2)));
 			assert.isTrue(writeFile.calledTwice);
+			assert.isTrue(mockFs.writeFileSync.notCalled);
 		});
 	});
 
@@ -308,6 +348,7 @@ describe('css-module-dts-loader', () => {
 			assert.isFalse(mockInstances.getTypeScriptInstance.called);
 			assert.isFalse(mockFs.statSync.called);
 			assert.isFalse(mockDTSGenerator.create.called);
+			assert.isTrue(mockFs.writeFileSync.notCalled);
 		});
 	});
 
@@ -386,6 +427,7 @@ describe('css-module-dts-loader', () => {
 			.then(() => {
 				assert.isTrue(mockDTSGenerator.create.calledOnce);
 				assert.isTrue(writeFile.calledOnce);
+				assert.isTrue(mockFs.writeFileSync.notCalled);
 			});
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

To support theming variants where there might not be any classes in the variants css the css module decorator loader needs to add the key even if there is no existing `exports.local` in the loader content. Also need to create a valid "empty" definition.