### PR TITLE
Support multiple named compilations in webpack-hot-client

### DIFF
--- a/src/webpack-hot-client/client.js
+++ b/src/webpack-hot-client/client.js
@@ -136,10 +136,11 @@ var reporter = {
 	}
 };
 
-var buildHash = null;
+var buildHash = {};
 
 function processMessage(obj) {
 	if (obj.action === 'built' || obj.action === 'sync') {
+		var name = obj.name || 'default';
 		var applyUpdate = true;
 		if (obj.errors.length > 0) {
 			reporter.problems('errors', obj);
@@ -152,10 +153,10 @@ function processMessage(obj) {
 			reporter.cleanProblemsCache();
 		}
 		if (applyUpdate) {
-			if ( obj.action === 'built' || (buildHash && buildHash !== obj.hash)) {
+			if ( obj.action === 'built' || (buildHash[name] && buildHash[name] !== obj.hash)) {
 				global.location.reload();
 			}
 		}
-		buildHash = obj.hash;
+		buildHash[name] = obj.hash;
 	}
 }

--- a/tests/unit/webpack-hot-client/client.ts
+++ b/tests/unit/webpack-hot-client/client.ts
@@ -43,6 +43,8 @@ describe('client', () => {
 	});
 
 	afterEach(() => {
+		global.location.reload.reset();
+		global.addEventListener.reset();
 		consoleStub.reset();
 		consoleWarnStub.reset();
 		overlayMock.clear.reset();
@@ -182,5 +184,51 @@ describe('client', () => {
 		assert.strictEqual(global.location.reload.callCount, 5);
 		assert.isTrue(overlayMock.showProblems.calledTwice);
 		assert.isTrue(overlayMock.clear.calledTwice);
+	});
+
+	it('supports multiple compilations', () => {
+		source.onmessage({
+			data: JSON.stringify({
+				name: 'main',
+				action: 'sync',
+				errors: [],
+				warnings: [],
+				hash: 'first'
+			})
+		});
+
+		source.onmessage({
+			data: JSON.stringify({
+				name: 'another',
+				action: 'sync',
+				errors: [],
+				warnings: [],
+				hash: 'another-first'
+			})
+		});
+
+		source.onmessage({
+			data: JSON.stringify({
+				name: 'main',
+				action: 'built',
+				errors: [],
+				warnings: [],
+				hash: 'hash'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledOnce);
+
+		source.onmessage({
+			data: JSON.stringify({
+				name: 'another',
+				action: 'built',
+				errors: [],
+				warnings: [],
+				hash: 'hash'
+			})
+		});
+
+		assert.isTrue(global.location.reload.calledTwice);
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
webpack-hot-client doesn't currently support multiple compilations. Which means in a multiple compilation scenario the hash is always flip flopping between the multiple compilations resulting in an infinite reload loop. This adds a basic build hash for named compilations which fixes it.
