### PR TITLE
Ensure the block chunk hash is recalculated

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -357,6 +357,7 @@ export default class BuildTimeRender {
 				}
 
 				if (mainHash) {
+					const currentMainChunkName = this._manifest['main.js'];
 					const currentMainHash = this._manifest['main.js']
 						.replace('main.js'.replace('js', ''), '')
 						.replace(/\..*/, '');
@@ -365,7 +366,7 @@ export default class BuildTimeRender {
 					const mainChunkName = `main.${newMainHash}.bundle.js`;
 					this._manifest['main.js'] = mainChunkName;
 					this._updateHTML(currentMainHash, newMainHash);
-					this._filesToRemove.add(currentMainHash);
+					this._filesToRemove.add(currentMainChunkName);
 					this._filesToRemove.add(mainChunkName);
 				}
 				this._filesToWrite.add('main.js');
@@ -411,19 +412,35 @@ ${blockCacheEntry}`
 					);
 					this._manifest[`${chunkName}.js`] = `${chunkName}.js`;
 					if (mainHash) {
+						const newBlockHash = genHash(this._manifestContent[blockChunk]);
+						const currentBlockChunkName = this._manifest[blockChunk];
+						const currentBootstrapChunkName = this._manifest['bootstrap.js'];
+						const currentBlockHash = currentBlockChunkName
+							.replace(blockChunk.replace('js', ''), '')
+							.replace(/\..*/, '');
 						const blockResultChunkHash = genHash(blockResultChunk);
 						this._manifest[`${chunkName}.js`] = `${chunkName}.${blockResultChunkHash}.bundle.js`;
 						this._manifestContent['bootstrap.js'] = this._manifestContent['bootstrap.js'].replace(
 							chunkMarker,
 							`${chunkMarker}"${chunkName}":"${blockResultChunkHash}",`
 						);
+						this._manifestContent['bootstrap.js'] = this._manifestContent['bootstrap.js'].replace(
+							currentBlockHash,
+							newBlockHash
+						);
 						const currentBootstrapHash = this._manifest['bootstrap.js']
 							.replace('bootstrap.js'.replace('js', ''), '')
 							.replace(/\..*/, '');
 						const newBootstrapHash = genHash(this._manifestContent['bootstrap.js']);
 						const bootstrapChunkName = `bootstrap.${newBootstrapHash}.bundle.js`;
+						const blockChunkName = `runtime/blocks.${newBlockHash}.bundle.js`;
 						this._manifest['bootstrap.js'] = bootstrapChunkName;
+						this._manifest[blockChunk] = blockChunkName;
 						this._updateHTML(currentBootstrapHash, newBootstrapHash);
+						this._updateHTML(currentBlockHash, newBlockHash);
+						this._filesToRemove.add(currentBootstrapChunkName);
+						this._filesToRemove.add(currentBlockChunkName);
+						this._filesToRemove.add(blockChunkName);
 						this._filesToRemove.add(bootstrapChunkName);
 						this._filesToWrite.add('bootstrap.js');
 					}

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -376,7 +376,7 @@ export default class BuildTimeRender {
 		return [];
 	}
 
-	private _writeBuildBridgeCache(modules: string[]) {
+	private _writeBuildBridgeCache(additionalScripts: string[]) {
 		const scripts: string[] = [];
 		const [, , mainHash] = this._manifest['main.js'].match(/(main\.)(.*)(\.bundle)/) || ([] as any);
 		const chunkMarker = `main:"${mainHash}",`;
@@ -443,6 +443,10 @@ ${blockCacheEntry}`
 						this._filesToRemove.add(blockChunkName);
 						this._filesToRemove.add(bootstrapChunkName);
 						this._filesToWrite.add('bootstrap.js');
+						const additionalScriptIndex = additionalScripts.indexOf(currentBlockChunkName);
+						if (additionalScriptIndex !== -1) {
+							additionalScripts[additionalScriptIndex] = blockChunkName;
+						}
 					}
 					this._manifestContent[`${chunkName}.js`] = blockResultChunk;
 					this._filesToWrite.add(blockChunk);
@@ -575,7 +579,7 @@ ${blockCacheEntry}`
 					);
 					const blockScripts = this._sync
 						? this._writeSyncBuildBridgeCache()
-						: this._writeBuildBridgeCache(scripts);
+						: this._writeBuildBridgeCache(additionalScripts);
 					await page.screenshot({
 						path: join(screenshotDirectory, `${parsedPath ? parsedPath.replace('#', '') : 'default'}.png`)
 					});

--- a/tests/support/fixtures/build-time-render/build-bridge-hash/expected/manifest.json
+++ b/tests/support/fixtures/build-time-render/build-bridge-hash/expected/manifest.json
@@ -5,6 +5,6 @@
   "bootstrap.js": "bootstrap.247d4597a12706983d2c.bundle.js",
   "bootstrap.js.map": "bootstrap.abcdefghij0123456789.bundle.js.map",
   "index.html": "index.html",
-  "runtime/blocks.js": "runtime/blocks.abcdefghij0123456789.bundle.js",
+  "runtime/blocks.js": "runtime/blocks.dbe2bc78e8fdc3f593cb.bundle.js",
   "runtime/block-49e457933c3c36eeb77f.js": "runtime/block-49e457933c3c36eeb77f.9eba5eaa6f8cfe7b34e3.bundle.js"
 }

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -1448,7 +1448,7 @@ describe('build-time-render', () => {
 						normalise(bootstrap),
 						normalise(readFileSync(path.join(outputPath, 'expected', 'bootstrap.js'), 'utf-8'))
 					);
-					assert.strictEqual(blocksFileName, 'blocks.abcdefghij0123456789.bundle.js');
+					assert.strictEqual(blocksFileName, 'blocks.dbe2bc78e8fdc3f593cb.bundle.js');
 					assert.strictEqual(
 						normalise(blocks),
 						normalise(readFileSync(path.join(outputPath, 'expected', 'blocks.js'), 'utf-8'))
@@ -2831,7 +2831,7 @@ describe('build-time-render', () => {
 						normalise(bootstrap),
 						normalise(readFileSync(path.join(outputPath, 'expected', 'bootstrap.js'), 'utf-8'))
 					);
-					assert.strictEqual(blocksFileName, 'blocks.abcdefghij0123456789.bundle.js');
+					assert.strictEqual(blocksFileName, 'blocks.dbe2bc78e8fdc3f593cb.bundle.js');
 					assert.strictEqual(
 						normalise(blocks),
 						normalise(readFileSync(path.join(outputPath, 'expected', 'blocks.js'), 'utf-8'))


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure the `blocks` chunk hash is calculated as the content changes (i.e. new blocks are generated).

Resolves #233 
