### PR TITLE
Ensure the block chunk hash is recalculated

### DIFF
--- a/tests/support/fixtures/build-time-render/build-bridge-hash/expected/manifest.json
+++ b/tests/support/fixtures/build-time-render/build-bridge-hash/expected/manifest.json
@@ -5,6 +5,6 @@
   "bootstrap.js": "bootstrap.247d4597a12706983d2c.bundle.js",
   "bootstrap.js.map": "bootstrap.abcdefghij0123456789.bundle.js.map",
   "index.html": "index.html",
-  "runtime/blocks.js": "runtime/blocks.abcdefghij0123456789.bundle.js",
+  "runtime/blocks.js": "runtime/blocks.dbe2bc78e8fdc3f593cb.bundle.js",
   "runtime/block-49e457933c3c36eeb77f.js": "runtime/block-49e457933c3c36eeb77f.9eba5eaa6f8cfe7b34e3.bundle.js"
 }

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -1282,7 +1282,7 @@ describe('build-time-render', () => {
 					normalise(bootstrap),
 					normalise(readFileSync(path.join(outputPath, 'expected', 'bootstrap.js'), 'utf-8'))
 				);
-				assert.strictEqual(blocksFileName, 'blocks.abcdefghij0123456789.bundle.js');
+				assert.strictEqual(blocksFileName, 'blocks.dbe2bc78e8fdc3f593cb.bundle.js');
 				assert.strictEqual(
 					normalise(blocks),
 					normalise(readFileSync(path.join(outputPath, 'expected', 'blocks.js'), 'utf-8'))


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure the `blocks` chunk hash is calculated as the content changes (i.e. new blocks are generated).

Backport of #234 
