### PR TITLE
Normalise automatically discovered page links

### DIFF
--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -105,7 +105,11 @@ export async function getPageLinks(page: any) {
 	let links: string[] = await page.$$eval('a', (links: HTMLAnchorElement[]) =>
 		links.map((link) => {
 			const href = link.getAttribute('href') || '';
-			return href.replace(/#.*/, '').replace(/\/$/, '');
+			return href
+				.replace(/#.*/, '')
+				.replace(/\/$/, '')
+				.replace(/^\//, '')
+				.toLowerCase();
 		})
 	);
 	links = [...new Set(links.filter((link) => /^http(s)?:\/\//.test(link) === false))];


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

When crawling the page for links to ensure that BTR doesn't attempt to more than one version of a page, we need to normalise the links. This involves stripping a leading `/` if found and lower casing the link.
