### PR TITLE
Clear jsdom timeout handle

### DIFF
--- a/src/build-time-render/Renderer.ts
+++ b/src/build-time-render/Renderer.ts
@@ -77,7 +77,7 @@ export default (renderer: Renderer = 'puppeteer') => {
 							};
 							let timeout = false;
 							const jsdom = JSDOM.fromURL(url, jsdomOptions);
-							setTimeout(() => {
+							const timeoutHandle = setTimeout(() => {
 								timeout = true;
 							}, 30000);
 							await new Promise((resolve) => setTimeout(resolve, 10));
@@ -87,6 +87,7 @@ export default (renderer: Renderer = 'puppeteer') => {
 							if (timeout) {
 								throw new Error(`Page ${url} timed out`);
 							}
+							clearTimeout(timeoutHandle);
 							return jsdom;
 						},
 						exposeFunction: (name: string, func: () => any) => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The timeout for jsdom needs to be cleared when the BTR process is successful.