### PR TITLE
Decouple the BTR process from the Webpack Plugin

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -55,7 +55,7 @@ export interface BuildTimeRenderArguments {
 	renderer?: Renderer;
 	discoverPaths?: boolean;
 	writeHtml?: boolean;
-	watch?: boolean;
+	executeBtr?: boolean;
 }
 
 function genHash(content: string): string {
@@ -127,7 +127,7 @@ export default class BuildTimeRender {
 	private _sync: boolean;
 	private _writeHtml: boolean;
 	private _writtenHtmlFiles: string[] = [];
-	private _watch: boolean;
+	private _executeBtr: boolean;
 
 	constructor(args: BuildTimeRenderArguments) {
 		const {
@@ -143,7 +143,7 @@ export default class BuildTimeRender {
 			discoverPaths = true,
 			sync = false,
 			writeHtml = true,
-			watch = false
+			executeBtr = true
 		} = args;
 		const path = paths[0];
 		const initialPath = typeof path === 'object' ? path.path : path;
@@ -169,7 +169,7 @@ export default class BuildTimeRender {
 		if (this._useHistory || paths.length === 0) {
 			this._static = !!args.static;
 		}
-		this._watch = watch;
+		this._executeBtr = executeBtr;
 	}
 
 	private async _writeIndexHtml({
@@ -685,7 +685,7 @@ ${blockCacheEntry}`
 			this._jsonpName = compiler.options.output.jsonpFunction;
 		}
 
-		if (!this._watch) {
+		if (this._executeBtr) {
 			compiler.hooks.afterEmit.tapAsync(this.constructor.name, async (compilation, callback) => {
 				return this.run(compilation, callback);
 			});

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -183,8 +183,8 @@ export default class BuildTimeRender {
 	}: RenderResult) {
 		let staticPath = this._static;
 		if (typeof path === 'object') {
-			if (this._useHistory && !staticPath) {
-				staticPath = !!path.static;
+			if (this._useHistory) {
+				staticPath = path.static === undefined ? staticPath : path.static;
 			}
 			path = path.path;
 		} else {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

In order to run build time rendering independently of the webpack build, the main process needs to be decoupled from the webpack `apply` API and called directly. In addition this adds a new API that enables a single page/path to be executed.

Related to https://github.com/dojo/cli-build-app/issues/367
