### PR TITLE
On demand Build Time Rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '10'
+- '12'
 install:
 - travis_retry npm install
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dojo/framework": {
-      "version": "7.0.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.16.tgz",
-      "integrity": "sha512-dgzJmQPD90WWDmrzNRc0EagdOTlm5x8bS27wsbVMAL00YXd6vYv658Rh3SX9yjutFfy+M240aE6kSSkAqCJZaA==",
+      "version": "7.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-beta.1.tgz",
+      "integrity": "sha512-nGHc2ryeze0JgSVILr4oqJbUyfVv/DdKzC/UFy31OfrK6E/0fGQAawIylyVgr+APIlozzy92N/6/KC/SLV8cWg==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
@@ -157,9 +157,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.9.0.tgz",
-      "integrity": "sha512-OBIKtF6ttIJotDXe4KJMUyTBO4xMii+mFjlA8R4CORuD4HvCUaCK3lPjhdTRCvuEv6gzWNbAvd9DNBv0v780lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.10.0.tgz",
+      "integrity": "sha512-hlueNXU51c3CwQjBw/i5fwt+VfQgSQVUTdicpCHkhEjNZaa4CXJ5W1GaxSwtLE2dvRmAHjpIjUMHTqJ53uojfg==",
       "requires": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -391,9 +391,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.4.tgz",
-      "integrity": "sha512-dPs6CaRWxsfHbYDVU51VjEJaUJEcli4UI0fFMT4oWmgCvHj+j7oIxz5MLHVL0Rv++N004c21ylJNdWQvPkkb5w==",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz",
+      "integrity": "sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -572,9 +572,9 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.5.tgz",
-      "integrity": "sha512-L7EbSkhSaWBpkl+PZAEAqZTqtTeIsq7s/oX/q0LNnxxJoRVKQE0T81XDVyaxjiiKQwiV2vhVeYRqxdRNqGOGJw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.0.tgz",
+      "integrity": "sha512-3ZcoyPYHVOCcLpnfZwD47KFLr8W/mpUcgjpf1M4Q78TMJIw7KMAHSjiCLJp1z3ZrBR9pTLbe191O0TldFK5zcw==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -1646,9 +1646,9 @@
       }
     },
     "buffer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -1862,9 +1862,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001040",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001040.tgz",
-      "integrity": "sha512-Ep0tEPeI5wCvmJNrXjE3etgfI+lkl1fTDU6Y3ZH1mhrjkPlVI9W4pcKbMo+BQLpEWKVYYp2EmYaRsqpPC3k7lQ=="
+      "version": "1.0.30001042",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
+      "integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -2328,9 +2328,9 @@
       }
     },
     "command-exists": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-      "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "dev": true
     },
     "commander": {
@@ -2491,9 +2491,9 @@
       }
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
       "optional": true
     },
     "core-util-is": {
@@ -3582,9 +3582,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.401",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.401.tgz",
-      "integrity": "sha512-9tvSOS1++0EQP0tkgyD8KJergVZsld1/UqOusZVTbx9MWZHw5NCezkOjIQ5YWeB45jKdQerDfRrt28HwidI9Ow=="
+      "version": "1.3.412",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.412.tgz",
+      "integrity": "sha512-4bVdSeJScR8fT7ERveLWbxemY5uXEHVseqMRyORosiKcTUSGtVwBkV8uLjXCqoFLeImA57Z9hbz3TOid01U4Hw=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -5417,9 +5417,9 @@
       }
     },
     "html-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
     },
     "html-webpack-include-assets-plugin": {
       "version": "1.0.6",
@@ -9695,9 +9695,9 @@
       "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
+      "integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -9880,9 +9880,9 @@
       }
     },
     "semver": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.1.tgz",
-      "integrity": "sha512-aHhm1pD02jXXkyIpq25qBZjr3CQgg8KST8uX0OWXch3xE6jw+1bfbWnCjzMwojsTquroUmKFHNzU6x26mEiRxw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "optional": true
     },
     "semver-compare": {
@@ -10469,9 +10469,9 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
-      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -10498,9 +10498,9 @@
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
-      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -11062,14 +11062,13 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
-      "integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.1.tgz",
+      "integrity": "sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
+        "commander": "~2.20.3"
       },
       "dependencies": {
         "commander": {
@@ -11120,9 +11119,9 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.0.tgz",
-      "integrity": "sha512-kVx7CDAsdBSWVf404Mw7oI9i09w5/mTT/Ruk+RWa64PLYKvsAucLLFHvQtnvjeADM4ZizxrvG5SHnF4Te4T2Cg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.1.tgz",
+      "integrity": "sha512-sgDYfSDPMsA4Hr2/w7vOlrJBlwzmyakk1+hW8ObLvxSp0LA36LcL2XItGvOT3OSblohSdevMuT8FQjLsqyy4sA==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,9 +190,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@sinonjs/commons": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
-      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -391,9 +391,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.3.tgz",
-      "integrity": "sha512-sHEsvEzjqN+zLbqP+8OXTipc10yH1QLR+hnr5uw29gi9AhCAAAdri8ClNV7iMdrJrIzXIQtlkPvq8tJGhj3QJQ==",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.4.tgz",
+      "integrity": "sha512-dPs6CaRWxsfHbYDVU51VjEJaUJEcli4UI0fFMT4oWmgCvHj+j7oIxz5MLHVL0Rv++N004c21ylJNdWQvPkkb5w==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1862,9 +1862,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001039",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
-      "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
+      "version": "1.0.30001040",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001040.tgz",
+      "integrity": "sha512-Ep0tEPeI5wCvmJNrXjE3etgfI+lkl1fTDU6Y3ZH1mhrjkPlVI9W4pcKbMo+BQLpEWKVYYp2EmYaRsqpPC3k7lQ=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3575,16 +3575,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.34",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
-          "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g=="
+          "version": "12.12.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
+          "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ=="
         }
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.398",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.398.tgz",
-      "integrity": "sha512-BJjxuWLKFbM5axH3vES7HKMQgAknq9PZHBkMK/rEXUQG9i1Iw5R+6hGkm6GtsQSANjSUrh/a6m32nzCNDNo/+w=="
+      "version": "1.3.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.401.tgz",
+      "integrity": "sha512-9tvSOS1++0EQP0tkgyD8KJergVZsld1/UqOusZVTbx9MWZHw5NCezkOjIQ5YWeB45jKdQerDfRrt28HwidI9Ow=="
     },
     "elegant-spinner": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "watch": "run-p watch:ts \"build:static:** -- --watch\""
   },
   "dependencies": {
-    "@dojo/framework": "7.0.0-alpha.16",
+    "@dojo/framework": "7.0.0-beta.1",
     "acorn": "6.1.1",
     "acorn-dynamic-import": "4.0.0",
     "acorn-walk": "6.1.1",

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -99,6 +99,7 @@ class MockCompilation {
 			{} as { [index: string]: MockAsset }
 		);
 		this.assets['manifest.json'] = new MockAsset(join(output, 'manifest.json'));
+		this.assets['index.html'] = new MockAsset(join(output, 'btr-index.html'));
 	}
 }
 
@@ -710,6 +711,10 @@ ${blockCacheEntry}`
 		}
 
 		compiler.hooks.afterEmit.tapAsync(this.constructor.name, async (compilation, callback) => {
+			if (!this._output) {
+				return callback();
+			}
+			outputFileSync(join(this._output, 'btr-index.html'), compilation.assets['index.html'].source(), 'utf8');
 			if (this._onDemand && !this._initialBtr) {
 				return callback();
 			}

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -1,5 +1,5 @@
 import { Compiler, compilation } from 'webpack';
-import { outputFileSync, removeSync, ensureDirSync, readFileSync, existsSync } from 'fs-extra';
+import { outputFileSync, removeSync, ensureDirSync, readFileSync, existsSync, writeFileSync } from 'fs-extra';
 
 import { join, resolve } from 'path';
 import {
@@ -714,7 +714,7 @@ ${blockCacheEntry}`
 			if (!this._output) {
 				return callback();
 			}
-			outputFileSync(join(this._output, 'btr-index.html'), compilation.assets['index.html'].source(), 'utf8');
+			writeFileSync(join(this._output, 'btr-index.html'), compilation.assets['index.html'].source(), 'utf8');
 			if (this._onDemand && !this._initialBtr) {
 				return callback();
 			}

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -686,7 +686,7 @@ ${blockCacheEntry}`
 				`On demand BTR: This path (${path}) has not been previously discovered by BTR, please make sure that it is discoverable or included in the btr paths array`
 			);
 		}
-
+		this._initialBtr = false;
 		return this._run(compilation, callback, path);
 	}
 

--- a/src/build-time-render/BuildTimeRenderMiddleware.ts
+++ b/src/build-time-render/BuildTimeRenderMiddleware.ts
@@ -1,0 +1,56 @@
+import BuildTimeRender, { BuildTimeRenderArguments } from './BuildTimeRender';
+import { Request, Response, NextFunction } from 'express';
+import * as url from 'url';
+
+export class OnDemandBuildTimeRender {
+	private _pages = new Set();
+	private _btrArgs: BuildTimeRenderArguments;
+	private _output: string;
+	private _jsonpName: string;
+	private _libName: string;
+	private _base: string;
+	private _active = false;
+	private _entry: {};
+
+	constructor(args: BuildTimeRenderArguments, config: any, libraryName: string, base: string) {
+		this._btrArgs = args;
+		this._output = (config.output && config.output.path) || process.cwd();
+		this._jsonpName = (config.output && config.output.jsonpFunction) || 'unknown';
+		this._libName = libraryName;
+		this._base = base || '/';
+		this._entry = config.entry;
+	}
+
+	public resetPages() {
+		this._pages.clear();
+	}
+
+	public start() {
+		this._active = true;
+	}
+
+	public middleware(req: Request, _: Response, next: NextFunction) {
+		const { pathname: originalPath } = url.parse(req.url);
+		if (
+			this._active &&
+			req.accepts('html') &&
+			originalPath &&
+			!originalPath.match(/\..*$/) &&
+			!this._pages.has(originalPath)
+		) {
+			const path = originalPath.replace(/^\//, '').replace(/\/$/, '');
+			const btr = new BuildTimeRender({
+				...this._btrArgs,
+				scope: this._libName,
+				baseUrl: this._base,
+				basePath: process.cwd(),
+				entries: Object.keys(this._entry!)
+			});
+
+			this._pages.add(originalPath);
+			btr.runPath(next, path, this._output, this._jsonpName);
+		} else {
+			next();
+		}
+	}
+}

--- a/src/build-time-render/BuildTimeRenderMiddleware.ts
+++ b/src/build-time-render/BuildTimeRenderMiddleware.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction } from 'express';
 import * as url from 'url';
 import webpack = require('webpack');
 
-export interface OnDemandBuildTimeRender {
+export interface OnDemandBuildTimeRenderOptions {
 	buildTimeRenderOptions: any;
 	scope: string;
 	base: string;
@@ -23,7 +23,7 @@ export class OnDemandBuildTimeRender {
 	private _active = false;
 	private _entries: string[];
 
-	constructor(options: OnDemandBuildTimeRender) {
+	constructor(options: OnDemandBuildTimeRenderOptions) {
 		this._btrArgs = options.buildTimeRenderOptions;
 		this._output = options.outputPath;
 		this._jsonpName = options.jsonpName;
@@ -51,7 +51,8 @@ export class OnDemandBuildTimeRender {
 				scope: this._scope,
 				baseUrl: this._base,
 				basePath: process.cwd(),
-				entries: this._entries
+				entries: this._entries,
+				onDemand: true
 			});
 
 			this._pages.add(originalPath);

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -12,6 +12,12 @@ export interface ServeDetails {
 export async function serve(directory: string, base: string): Promise<ServeDetails> {
 	const app = express();
 	const port = await getPort();
+	app.use(
+		base,
+		history({
+			index: '/btr-index.html'
+		})
+	);
 	app.use(base, express.static(directory));
 	app.use(
 		base,

--- a/tests/support/fixtures/build-time-render/build-bridge-blocks-only/btr-index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-blocks-only/btr-index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/build-bridge-error/btr-index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-error/btr-index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/build-bridge-hash/btr-index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-hash/btr-index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="bootstrap.abcdefghij0123456789.bundle.js"></script>
+		<script type="text/javascript" src="main.0123456789abcdefghij.bundle.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/build-bridge-single-bundle/btr-index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge-single-bundle/btr-index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/build-bridge/btr-index.html
+++ b/tests/support/fixtures/build-time-render/build-bridge/btr-index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/hash/btr-index.html
+++ b/tests/support/fixtures/build-time-render/hash/btr-index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/btr-index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/btr-index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/btr-manifest.json
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/btr-manifest.json
@@ -1,0 +1,6 @@
+[
+    "",
+    "my-path",
+    "other",
+    "my-path/other"
+]

--- a/tests/support/fixtures/build-time-render/state-static-no-paths/btr-index.html
+++ b/tests/support/fixtures/build-time-render/state-static-no-paths/btr-index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/btr-index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/btr-index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state-static/btr-index.html
+++ b/tests/support/fixtures/build-time-render/state-static/btr-index.html
@@ -1,0 +1,11 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+		<title>Original Title</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/support/fixtures/build-time-render/state/btr-index.html
+++ b/tests/support/fixtures/build-time-render/state/btr-index.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<link rel="manifest" href="manifest.json" />
+		<link href="main.css" rel="stylesheet">
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="main.js"></script>
+	</body>
+</html>

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -122,6 +122,7 @@ describe('build-time-render', () => {
 		fs.outputFileSync = outputFileSync;
 		fs.readFileSync = readFileSync;
 		fs.existsSync = existsSync;
+		fs.writeFileSync = stub();
 		const Btr = getBuildTimeRenderModule();
 		const basePath = path.join(process.cwd(), 'tests/support/fixtures/build-time-render/build-bridge');
 		const btr = new Btr({
@@ -2513,6 +2514,7 @@ describe('build-time-render', () => {
 						renderer: 'jsdom'
 					});
 					btr.apply(compiler);
+
 					assert.isTrue(pluginRegistered);
 					return runBtr(createCompilation('state-static'), callbackStub).then(() => {
 						assert.isTrue(callbackStub.calledOnce);
@@ -2668,6 +2670,7 @@ describe('build-time-render', () => {
 						renderer: 'jsdom'
 					});
 					btr.apply(compiler);
+
 					assert.isTrue(pluginRegistered);
 					return runBtr(createCompilation('state-static-per-path'), callbackStub).then(() => {
 						assert.isTrue(callbackStub.calledOnce);
@@ -2816,6 +2819,7 @@ describe('build-time-render', () => {
 						renderer: 'jsdom'
 					});
 					btr.apply(compiler);
+
 					assert.isTrue(pluginRegistered);
 					return runBtr(createCompilation('state-static-no-paths'), callbackStub).then(() => {
 						assert.isTrue(callbackStub.calledOnce);

--- a/tests/unit/build-time-render/BuildTimeRenderMiddleware.ts
+++ b/tests/unit/build-time-render/BuildTimeRenderMiddleware.ts
@@ -1,0 +1,98 @@
+import { stub, SinonStub } from 'sinon';
+import MockModule from '../../support/MockModule';
+
+const { beforeEach, describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+let mockModule: MockModule;
+
+describe('build-time-render middleware', () => {
+	beforeEach(() => {
+		mockModule = new MockModule('../../../src/build-time-render/BuildTimeRenderMiddleware', require);
+		mockModule.dependencies(['./BuildTimeRender']);
+	});
+
+	it('test', () => {
+		const compiler = {
+			hooks: {
+				invalid: {
+					tap: stub()
+				}
+			}
+		};
+		const mockRequest = {
+			accepts() {
+				return true;
+			},
+			url: 'http://localhost/blog'
+		};
+		const runPathStub = stub();
+		const BuildTimeRenderMock: SinonStub = mockModule
+			.getMock('./BuildTimeRender')
+			.default.returns({ runPath: runPathStub });
+		const OnDemandBuildTimeRender = mockModule.getModuleUnderTest().default;
+		const nextStub = stub();
+		const onDemandBuildTimeRender = new OnDemandBuildTimeRender({
+			buildTimeRenderOptions: {
+				root: 'app',
+				onDemand: true
+			},
+			scope: 'lib',
+			outputPath: 'path',
+			jsonpName: 'jsonpFunction',
+			compiler,
+			base: 'base',
+			entries: ['main']
+		});
+		onDemandBuildTimeRender.middleware(mockRequest, {}, nextStub);
+		assert.isTrue(BuildTimeRenderMock.notCalled);
+		compiler.hooks.invalid.tap.firstCall.callArg(1);
+		onDemandBuildTimeRender.middleware(mockRequest, {}, nextStub);
+		assert.isTrue(BuildTimeRenderMock.calledOnce);
+		assert.deepEqual(BuildTimeRenderMock.firstCall.args, [
+			{
+				basePath: process.cwd(),
+				baseUrl: 'base',
+				entries: ['main'],
+				root: 'app',
+				onDemand: true,
+				scope: 'lib'
+			}
+		]);
+		assert.isTrue(runPathStub.calledOnce);
+		assert.deepEqual(runPathStub.firstCall.args, [nextStub, 'blog', 'path', 'jsonpFunction']);
+		onDemandBuildTimeRender.middleware(mockRequest, {}, nextStub);
+		assert.isTrue(BuildTimeRenderMock.calledOnce);
+		assert.isTrue(runPathStub.calledOnce);
+		onDemandBuildTimeRender.middleware(
+			{
+				url: 'http://localhost/blog.html',
+				accepts() {
+					return false;
+				}
+			},
+			{},
+			nextStub
+		);
+		assert.isTrue(BuildTimeRenderMock.calledOnce);
+		assert.isTrue(runPathStub.calledOnce);
+		onDemandBuildTimeRender.middleware({ ...mockRequest, url: 'http://localhost/other.js' }, {}, nextStub);
+		assert.isTrue(BuildTimeRenderMock.calledOnce);
+		assert.isTrue(runPathStub.calledOnce);
+		compiler.hooks.invalid.tap.firstCall.callArg(1);
+		onDemandBuildTimeRender.middleware(mockRequest, {}, nextStub);
+		assert.isTrue(BuildTimeRenderMock.calledTwice);
+		assert.deepEqual(BuildTimeRenderMock.secondCall.args, [
+			{
+				basePath: process.cwd(),
+				baseUrl: 'base',
+				entries: ['main'],
+				root: 'app',
+				onDemand: true,
+				scope: 'lib'
+			}
+		]);
+		assert.isTrue(runPathStub.calledTwice);
+		assert.deepEqual(runPathStub.secondCall.args, [nextStub, 'blog', 'path', 'jsonpFunction']);
+	});
+});

--- a/tests/unit/build-time-render/all.ts
+++ b/tests/unit/build-time-render/all.ts
@@ -1,1 +1,2 @@
 import './BuildTimeRender';
+import './BuildTimeRenderMiddleware';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Decouples build time rendering from webpack to be able to use "on demand" for a single path. Includes an express middleware that can be used to generate the static html for a visited path if it has not been generated since the last re-build. Once the html has been generated it will not re-run until the build has invalidated.

Related to https://github.com/dojo/cli-build-app/issues/367
