### PR TITLE
Respect additional assets option when using the factory

### DIFF
--- a/src/emit-all-plugin/EmitAllPlugin.ts
+++ b/src/emit-all-plugin/EmitAllPlugin.ts
@@ -49,9 +49,9 @@ function createTransformer<T extends ts.Node>(basePath: string, sharedDeclaratio
  *
  * @param options The plugin options
  */
-export function emitAllFactory(options?: EmitAllPluginOptions) {
-	const basePath = (options && options.basePath) || path.join(process.cwd(), 'src');
-	const sharedDeclarationFiles = new Set<string>();
+export function emitAllFactory(options: EmitAllPluginOptions = {}) {
+	const basePath = options.basePath || path.join(process.cwd(), 'src');
+	const sharedDeclarationFiles = options.additionalAssets || new Set<string>();
 
 	return {
 		plugin: new EmitAllPlugin({

--- a/src/emit-all-plugin/EmitAllPlugin.ts
+++ b/src/emit-all-plugin/EmitAllPlugin.ts
@@ -6,7 +6,7 @@ import * as webpack from 'webpack';
 import NormalModule = require('webpack/lib/NormalModule');
 
 export interface EmitAllPluginOptions {
-	additionalAssets?: Set<string>;
+	additionalAssets?: string[];
 	assetFilter?: (key: string, asset: any) => boolean;
 	basePath?: string;
 	inlineSourceMaps?: boolean;
@@ -27,13 +27,13 @@ const createSource = (content: string) => ({
  * any declaration files imported by the project must be manually injected into the build pipeline to avoid downstream
  * type errors.
  */
-function createTransformer<T extends ts.Node>(basePath: string, sharedDeclarationFiles: Set<string>) {
+function createTransformer<T extends ts.Node>(basePath: string, sharedDeclarationFiles: string[]) {
 	return (context: ts.TransformationContext) => {
 		const visit: any = (node: any) => {
 			if (node.resolvedModules) {
 				node.resolvedModules.forEach((value: any) => {
 					if (value && value.extension === '.d.ts' && value.resolvedFileName.startsWith(basePath)) {
-						sharedDeclarationFiles.add(value.resolvedFileName);
+						sharedDeclarationFiles.push(value.resolvedFileName);
 					}
 				});
 			}
@@ -51,7 +51,7 @@ function createTransformer<T extends ts.Node>(basePath: string, sharedDeclaratio
  */
 export function emitAllFactory(options: EmitAllPluginOptions = {}) {
 	const basePath = options.basePath || path.join(process.cwd(), 'src');
-	const sharedDeclarationFiles = options.additionalAssets || new Set<string>();
+	const sharedDeclarationFiles = options.additionalAssets ? [...options.additionalAssets] : [];
 
 	return {
 		plugin: new EmitAllPlugin({
@@ -64,14 +64,14 @@ export function emitAllFactory(options: EmitAllPluginOptions = {}) {
 }
 
 export default class EmitAllPlugin {
-	private additionalAssets: Set<string>;
+	private additionalAssets: string[];
 	private assetFilter: (key: string, asset: any) => boolean;
 	private basePath: string;
 	private inlineSourceMaps: boolean;
 	private legacy: boolean;
 
 	constructor(options: EmitAllPluginOptions = {}) {
-		this.additionalAssets = options.additionalAssets || new Set<string>();
+		this.additionalAssets = options.additionalAssets || [];
 		this.assetFilter = options.assetFilter || (() => true);
 		this.basePath = options.basePath || path.join(process.cwd(), 'src');
 		this.inlineSourceMaps = Boolean(options.inlineSourceMaps);
@@ -81,7 +81,7 @@ export default class EmitAllPlugin {
 	apply(compiler: webpack.Compiler) {
 		const { basePath, inlineSourceMaps, legacy } = this;
 		compiler.hooks.emit.tapAsync(this.constructor.name, async (compilation, callback) => {
-			this.additionalAssets.forEach((file) => {
+			new Set(this.additionalAssets).forEach((file) => {
 				if (fs.existsSync(file)) {
 					const assetName = file.replace(this.basePath, '').replace(/^(\/|\\)/, '');
 					const source = fs.readFileSync(file, 'utf-8').toString();

--- a/tests/unit/emit-all-plugin/EmitAllPlugin.ts
+++ b/tests/unit/emit-all-plugin/EmitAllPlugin.ts
@@ -78,6 +78,25 @@ describe('EmitAllPlugin', () => {
 			assert.deepEqual(compilation.assets, assets);
 		});
 
+		it('emits additional assets', () => {
+			const factory = mockModule.getModuleUnderTest().emitAllFactory;
+			const emitAll = factory({ additionalAssets: new Set(['additional.js']) }).plugin;
+			const compilation = createCompilation(compiler);
+			const assets = {
+				foo: {},
+				bar: {},
+				baz: {}
+			};
+			mockModule.getMock('fs').existsSync = stub().callsFake((file: string) => {
+				return file === 'additional.js';
+			});
+
+			compilation.assets = { ...assets };
+			emitAll.apply(compiler);
+			compiler.hooks.emit.callAsync(compilation, () => {});
+			assert.deepEqual(Object.keys(compilation.assets), ['foo', 'bar', 'baz', 'additional.js']);
+		});
+
 		describe('JavaScript assets', () => {
 			const applyPlugin = (
 				file: string,

--- a/tests/unit/emit-all-plugin/EmitAllPlugin.ts
+++ b/tests/unit/emit-all-plugin/EmitAllPlugin.ts
@@ -80,7 +80,7 @@ describe('EmitAllPlugin', () => {
 
 		it('emits additional assets', () => {
 			const factory = mockModule.getModuleUnderTest().emitAllFactory;
-			const emitAll = factory({ additionalAssets: new Set(['additional.js']) }).plugin;
+			const emitAll = factory({ additionalAssets: ['additional.js'] }).plugin;
 			const compilation = createCompilation(compiler);
 			const assets = {
 				foo: {},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure that the additionalAssets options is respected when using the factory.

Changes the additionalAssets option from a Set to an array.