### PR TITLE
Add missing Globalize import for sync mode

### DIFF
--- a/src/cldr/loader.ts
+++ b/src/cldr/loader.ts
@@ -154,7 +154,8 @@ ${loadLocaleCldrTemplate(locale)}`;
 		})
 		.join(',');
 
-	const syncLoaders = `${loadSupplementalCldrTemplate()}
+	const syncLoaders = `var Globalize = require('globalize/dist/globalize/message');
+${loadSupplementalCldrTemplate()}
 ${syncLocaleCldrData}
 Globalize.load(cldrData)`;
 

--- a/tests/support/fixtures/cldr/expectedMultipleLocaleBootstrapSync.js
+++ b/tests/support/fixtures/cldr/expectedMultipleLocaleBootstrapSync.js
@@ -1,5 +1,6 @@
 var has = require('@dojo/framework/core/has').default;
 var i18n = require('@dojo/framework/i18n/i18n');
+var Globalize = require('globalize/dist/globalize/message');
 
 var weekData = require('cldr-core/supplemental/weekData.json');
 var ordinals = require('cldr-core/supplemental/ordinals.json');

--- a/tests/support/fixtures/cldr/expectedSingleLocaleBootstrapSync.js
+++ b/tests/support/fixtures/cldr/expectedSingleLocaleBootstrapSync.js
@@ -1,5 +1,6 @@
 var has = require('@dojo/framework/core/has').default;
 var i18n = require('@dojo/framework/i18n/i18n');
+var Globalize = require('globalize/dist/globalize/message');
 
 var weekData = require('cldr-core/supplemental/weekData.json');
 var ordinals = require('cldr-core/supplemental/ordinals.json');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

In sync mode all the cldr-data is registered with globalize synchronously, the import/require for globalize was missing from the sync bootstrap code.