### PR TITLE
Only generate .d.ts file for css modules

### DIFF
--- a/src/css-module-dts-loader/loader.ts
+++ b/src/css-module-dts-loader/loader.ts
@@ -76,7 +76,7 @@ export = styles;`,
 function getCssImport(node: Node, loaderContext: webpack.loader.LoaderContext): Promise<string> | void {
 	if (node.kind === SyntaxKind.StringLiteral) {
 		const importPath = node.getText().replace(/\'|\"/g, '');
-		if (/\.css$/.test(importPath) && isRelative(importPath)) {
+		if (/\.m\.css$/.test(importPath) && isRelative(importPath)) {
 			const parentFileName = node.getSourceFile().fileName;
 			return new Promise((resolve, reject) => {
 				loaderContext.resolve(dirname(parentFileName), importPath, (error, path) => {

--- a/tests/unit/css-module-dts-loader/loader.ts
+++ b/tests/unit/css-module-dts-loader/loader.ts
@@ -6,9 +6,9 @@ import '../../../src/css-module-dts-loader/loader';
 const { assert } = intern.getPlugin('chai');
 const { afterEach, beforeEach, describe, it } = intern.getInterface('bdd');
 
-const cssFilePath = './file.css';
-const cssFilePath2 = 'path/to/file2.css';
-const cssFilePath3 = '/path/to/file3.css';
+const cssFilePath = './file.m.css';
+const cssFilePath2 = 'path/to/file2.m.css';
+const cssFilePath3 = '/path/to/file3.m.css';
 
 const cssContent = `
 	.foo: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Only generate dts files for css modules.
