### PR TITLE
Updating element transformer to pull in properties even if properties…

### DIFF
--- a/src/element-transformer/ElementTransformer.ts
+++ b/src/element-transformer/ElementTransformer.ts
@@ -137,15 +137,13 @@ export default function elementTransformer<T extends ts.Node>(
 
 				if (parameters.length) {
 					const callback = checker.getTypeOfSymbolAtLocation(parameters[0], factoryIdentifier) as
-						| ts.ObjectType
+						| ts.TypeReference
 						| undefined;
-					if (callback) {
-						if (callback.objectFlags & ts.ObjectFlags.Reference) {
-							const typeArguments = (callback as ts.TypeReference).typeArguments;
+					if (callback && callback.objectFlags & ts.ObjectFlags.Reference) {
+						const typeArguments = callback.typeArguments;
 
-							if (typeArguments) {
-								return typeArguments[0];
-							}
+						if (typeArguments) {
+							return typeArguments[0];
 						}
 					}
 				}

--- a/tests/unit/element-transformer/ElementTransformer.ts
+++ b/tests/unit/element-transformer/ElementTransformer.ts
@@ -227,18 +227,10 @@ describe('element-transformer', () => {
 	describe('function-based widgets', () => {
 		it('does not touch function-based widgets that are not the default export', () => {
 			const source = `
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
+import {create} from '@dojo/framework/core/vdom';
 
-		interface DojoInputProperties {}
-		const render = create().properties<DojoInputProperties>();
-		export const DojoInput = render(({ properties }) => 'foo');
+const render = create();
+export const DojoInput = render(() => 'foo');
 		`;
 			assertCompile(
 				{
@@ -258,35 +250,19 @@ describe('element-transformer', () => {
 
 		it('it modifies function-based widgets that are explicitly the default export', () => {
 			const source = `
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
+		import {create} from '@dojo/framework/core/vdom';
 
-		interface DojoInputProperties {}
-		const render = create().properties<DojoInputProperties>();
-		const DojoInput = render(({ properties }) => 'foo');
+		const render = create();
+		const DojoInput = render(() => 'foo');
 		export default DojoInput;
 		`;
 			const expected = `
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
+		import {create} from '@dojo/framework/core/vdom';
 
-		interface DojoInputProperties {}
-		const render = create().properties<DojoInputProperties>();
+		const render = create();
 		const DojoInput = (() => {
-			var temp_1 = render(({ properties }) => 'foo');
-			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: [], properties: [], events: [] }, ...temp_1.__customElementDescriptor || {} };	
+			var temp_1 = render(() => 'foo');
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["key"], properties: [], events: [] }, ...temp_1.__customElementDescriptor || {} };
 			return temp_1;
 		})()
 		export default DojoInput;
@@ -309,18 +285,10 @@ describe('element-transformer', () => {
 
 		it('it does not modify function-based widgets that are not listed in files', () => {
 			const source = `
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
+		import {create} from '@dojo/framework/core/vdom';
 
-		interface DojoInputProperties {}
-		const render = create().properties<DojoInputProperties>();
-		const DojoInput = render(({ properties }) => 'foo');
+		const render = create();
+		const DojoInput = render(() => 'foo');
 		export default DojoInput;
 		`;
 			assertCompile(
@@ -336,18 +304,11 @@ describe('element-transformer', () => {
 
 		it('it adds attributes, properties, and events', () => {
 			const source = `
+		import {create} from '@dojo/framework/core/vdom';
+
 		enum StringEnum { value1 = 'value1', value2 = 'value2' };
 		enum IntEnum { value1 = 0, value 2 = 1 };
 		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
 		interface DojoInputProperties {
 			attribute: string;
 			property: boolean;
@@ -358,22 +319,15 @@ describe('element-transformer', () => {
 			stringOrNumber: stringOrNumber;
 		}
 		const render = create().properties<DojoInputProperties>();
-		const DojoInput = render(({ properties }) => 'foo');
+		const DojoInput = render(() => 'foo');
 		export default DojoInput;
 		`;
 			const expected = `
+		import {create} from '@dojo/framework/core/vdom';
+
 		enum StringEnum { value1 = 'value1', value2 = 'value2' };
 		enum IntEnum { value1 = 0, value 2 = 1 };
 		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
 		interface DojoInputProperties {
 			attribute: string;
 			property: boolean;
@@ -385,81 +339,8 @@ describe('element-transformer', () => {
 		}
 		const render = create().properties<DojoInputProperties>();
 		const DojoInput = (() => {
-			var temp_1 = render(({ properties }) => 'foo')
-			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };
-			return temp_1;
-		})();
-		export default DojoInput;
-		`;
-			assertCompile(
-				{
-					[actualPath]: source,
-					[expectedPath]: expected
-				},
-				(program) => ({
-					before: [
-						elementTransformer(program, {
-							elementPrefix: 'widget',
-							customElementFiles: [{ file: actualPath }]
-						})
-					]
-				})
-			);
-		});
-
-		it('it handles a combined type', () => {
-			const source = `
-		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
-		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
-		interface DojoInputProperties {
-			attribute: string;
-			property: boolean;
-			onClick: () => void;
-			onChange(value: string): void;
-			stringEnum: StringEnum;
-			intEnum?: IntEnum;
-			stringOrNumber: stringOrNumber;
-		}
-		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
-		const DojoInput = render(({ properties }) => 'foo');
-		export default DojoInput;
-		`;
-			const expected = `
-		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
-		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
-		interface DojoInputProperties {
-			attribute: string;
-			property: boolean;
-			onClick: () => void;
-			onChange(value: string): void;
-			stringEnum: StringEnum;
-			intEnum?: IntEnum;
-			stringOrNumber: stringOrNumber;
-		}
-		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
-		const DojoInput = (() => {
-			var temp_1 = render(({ properties }) => 'foo');
-			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };	
+			var temp_1 = render(() => 'foo')
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["key", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };
 			return temp_1;
 		})();
 		export default DojoInput;
@@ -482,17 +363,11 @@ describe('element-transformer', () => {
 
 		it('it handles a direct export type', () => {
 			const source = `
+		import {create} from '@dojo/framework/core/vdom';
+
 		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
+		enum IntEnum { value1 = 0, value2 = 1 };
 		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
 
 		interface DojoInputProperties {
 			attribute: string;
@@ -503,23 +378,18 @@ describe('element-transformer', () => {
 			intEnum?: IntEnum;
 			stringOrNumber: stringOrNumber;
 		}
-		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
-		export default render(function DojoInput({ properties }) {
-			return 'foo'
-		});
+
+		const foo = create().properties<{ foo?: string; }>()(() => ({}));
+
+		const render = create({ foo }).properties<DojoInputProperties>();
+		export default render(function DojoInput(){ return 'foo'; });
 		`;
 			const expected = `
+		import {create} from '@dojo/framework/core/vdom';
+
 		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
+		enum IntEnum { value1 = 0, value2 = 1 };
 		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
 
 		interface DojoInputProperties {
 			attribute: string;
@@ -530,12 +400,13 @@ describe('element-transformer', () => {
 			intEnum?: IntEnum;
 			stringOrNumber: stringOrNumber;
 		}
-		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
-		export default (() => {
-			var temp_1 = render(function DojoInput({ properties }) {
-				return 'foo'
-			});
-			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };	
+
+		const foo = create().properties<{ foo?: string; }>()(() => ({}));
+
+		const render = create({ foo }).properties<DojoInputProperties>();
+		export default (() {
+			var temp_1 = render(function DojoInput() { return 'foo'; });
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["key", "attribute", "stringEnum", "stringOrNumber", "foo"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };
 			return temp_1;
 		})();
 		`;
@@ -557,17 +428,11 @@ describe('element-transformer', () => {
 
 		it('it handles a direct export with no function name', () => {
 			const source = `
+		import {create} from '@dojo/framework/core/vdom';
+
 		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
+		enum IntEnum { value1 = 0, value2 = 1 };
 		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
 
 		interface DojoInputProperties {
 			attribute: string;
@@ -578,21 +443,18 @@ describe('element-transformer', () => {
 			intEnum?: IntEnum;
 			stringOrNumber: stringOrNumber;
 		}
-		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
-		export default render(({ properties }) => 'foo');
+
+		const foo = create().properties<{ foo?: string; }>()(() => ({}));
+
+		const render = create({ foo }).properties<DojoInputProperties>();
+		export default render(() => 'foo');
 		`;
 			const expected = `
+		import {create} from '@dojo/framework/core/vdom';
+
 		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
+		enum IntEnum { value1 = 0, value2 = 1 };
 		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
 
 		interface DojoInputProperties {
 			attribute: string;
@@ -603,130 +465,15 @@ describe('element-transformer', () => {
 			intEnum?: IntEnum;
 			stringOrNumber: stringOrNumber;
 		}
-		const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+
+		const foo = create().properties<{ foo?: string; }>()(() => ({}));
+
+		const render = create({ foo }).properties<DojoInputProperties>();
 		export default (() => {
-			var temp_1 = render(({ properties }) => 'foo');
-			temp_1.__customElementDescriptor = { ...{ tagName: "widget-actual", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };	
+			var temp_1 = render(() => 'foo');
+			temp_1.__customElementDescriptor = { ...{ tagName: "widget-actual", attributes: ["key", "attribute", "stringEnum", "stringOrNumber", "foo"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };
 			return temp_1;
 		})();
-		`;
-			assertCompile(
-				{
-					[actualPath]: source,
-					[expectedPath]: expected
-				},
-				(program) => ({
-					before: [
-						elementTransformer(program, {
-							elementPrefix: 'widget',
-							customElementFiles: [{ file: actualPath }]
-						})
-					]
-				})
-			);
-		});
-
-		it('it handles an explicit type', () => {
-			const source = `
-		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
-		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
-		const render = create().properties();
-		const DojoInput = render(({ properties }: { properties: () => { bar: string; } }) => 'foo');
-		export default DojoInput;
-		`;
-			const expected = `
-		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
-		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
-		const render = create().properties();
-		const DojoInput = (() => {
-			var temp_1 = render(({ properties }: { properties: () => { bar: string; } }) => 'foo');	
-			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...temp_1.__customElementDescriptor || {} };	
-			return temp_1;
-		})();
-		export default DojoInput;
-		`;
-			assertCompile(
-				{
-					[actualPath]: source,
-					[expectedPath]: expected
-				},
-				(program) => ({
-					before: [
-						elementTransformer(program, {
-							elementPrefix: 'widget',
-							customElementFiles: [{ file: actualPath }]
-						})
-					]
-				})
-			);
-		});
-
-		it('handles using variables and types in widget creation', () => {
-			const source = `
-		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
-		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
-		const render = create().properties();
-		type Props = () => { bar: string; };
-		type Options = { properties: Props };
-		type Callback = (options: Options) => any;
-		const callback: Callback = () => 'foo';
-		const DojoInput = render(callback);
-		export default DojoInput;
-		`;
-			const expected = `
-		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
-		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
-		const render = create().properties();
-		type Props = () => { bar: string; };
-		type Options = { properties: Props };
-		type Callback = (options: Options) => any;
-		const callback: Callback = () => 'foo';
-		const DojoInput = (() => {
-			var temp_1 = render(callback);
-			temp_1.__customElementDescriptor = { ...{ tagName: "widget-dojo-input", attributes: ["bar"], properties: [], events: [] }, ...temp_1.__customElementDescriptor || {} };	
-			return temp_1;
-		})();
-		export default DojoInput;
 		`;
 			assertCompile(
 				{
@@ -746,46 +493,12 @@ describe('element-transformer', () => {
 
 		it('ignores default exports that have the wrong signature', () => {
 			const source = `
-		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
-		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: () => { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
-		const render = create().properties();
-		type Props = () => { bar: string; };
-		type Options = () => { properties: Props };
-		type Callback = (options: Options) => any;
-		const callback: Callback = () => 'foo';
-		const DojoInput = render(callback);
-		export default DojoInput;
+			const DojoInput = () => 'foo';
+			export default DojoInput;
 		`;
 			const expected = `
-		enum StringEnum { value1 = 'value1', value2 = 'value2' };
-		enum IntEnum { value1 = 0, value 2 = 1 };
-		type stringOrNumber = string | number;
-		function create<A = any, B = {}>() {
-    		return {
-        		properties: <T>() =>
-            		function render(callback: (options: () => { properties: () => B & T }) => string) {
-                		return (properties: B & T) => '';
-            	}
-    		};
-		}
-
-		const render = create().properties();
-		type Props = () => { bar: string; };
-		type Options = () => { properties: Props };
-		type Callback = (options: Options) => any;
-		const callback: Callback = () => 'foo';
-		const DojoInput = render(callback);
-		export default DojoInput;
+			const DojoInput = () => 'foo';
+			export default DojoInput;
 		`;
 			assertCompile(
 				{
@@ -837,12 +550,13 @@ describe('element-transformer', () => {
 	enum StringEnum { value1 = 'value1', value2 = 'value2' };
 	enum IntEnum { value1 = 0, value 2 = 1 };
 	type stringOrNumber = string | number;
-	function create<A = any, B = {}>() {
-		return {
-			properties: <T>() =>
-				function render(callback: (options: { properties: () => B & T }) => string) {
-					return (properties: B & T) => '';
-			}
+	interface Callback<T extends {} = {}> {
+		(options: { properties: () => T}): string;
+	}
+
+	function create<T>() {
+		return function (callback: Callback<T>) {
+			return callback({ properties: {} as T });
 		};
 	}
 
@@ -855,19 +569,20 @@ describe('element-transformer', () => {
 		intEnum?: IntEnum;
 		stringOrNumber: stringOrNumber;
 	}
-	const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+	const render = create<DojoInputProperties>();
 	export default render(({ properties }) => 'foo');
 	`;
 		const expected = `
 	enum StringEnum { value1 = 'value1', value2 = 'value2' };
 	enum IntEnum { value1 = 0, value 2 = 1 };
 	type stringOrNumber = string | number;
-	function create<A = any, B = {}>() {
-		return {
-			properties: <T>() =>
-				function render(callback: (options: { properties: () => B & T }) => string) {
-					return (properties: B & T) => '';
-			}
+	interface Callback<T extends {} = {}> {
+		(options: { properties: () => T}): string;
+	}
+
+	function create<T>() {
+		return function (callback: Callback<T>) {
+			return callback({ properties: {} as T });
 		};
 	}
 
@@ -880,10 +595,10 @@ describe('element-transformer', () => {
 		intEnum?: IntEnum;
 		stringOrNumber: stringOrNumber;
 	}
-	const render = create<any, { foo: string }>().properties<DojoInputProperties>();
+	const render = create<DojoInputProperties>();
 	export default (() => {
 		var temp_1 = render(({ properties }) => 'foo');
-		temp_1.__customElementDescriptor = { ...{ tagName: "widget-foo-bar", attributes: ["foo", "attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };	
+		temp_1.__customElementDescriptor = { ...{ tagName: "widget-foo-bar", attributes: ["attribute", "stringEnum", "stringOrNumber"], properties: ["property", "intEnum"], events: ["onClick", "onChange"] }, ...temp_1.__customElementDescriptor || {} };
 		return temp_1;
 	})();
 	`;
@@ -939,31 +654,41 @@ function assertCompile(
 }
 
 function testCompilerHost(inputs: Record<string, string>, outputs: Record<string, string>): ts.CompilerHost {
+	const compilerHost = ts.createCompilerHost({});
+
 	return {
+		...compilerHost,
 		getSourceFile,
-		getDefaultLibFileName: () => 'lib.d.ts',
 		writeFile: (fileName: string, content: string) => {
 			const split = fileName.split(/[/\\]/);
 			outputs[split[split.length - 1]] = content;
 		},
-		getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
-		getDirectories: (path) => ts.sys.getDirectories(path),
-		getCanonicalFileName: (fileName) => (ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase()),
-		getNewLine: () => ts.sys.newLine,
-		useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
-		fileExists,
-		readFile
+		resolveModuleNames(moduleNames: string[], containingFile: string): (ts.ResolvedModule | undefined)[] {
+			const resolvedModules = [];
+
+			for (const moduleName of moduleNames) {
+				let result = ts.resolveModuleName(moduleName, containingFile, {}, compilerHost);
+
+				if (result.resolvedModule) {
+					resolvedModules.push(result.resolvedModule);
+				} else {
+					let result = ts.resolveModuleName(
+						path.resolve(__dirname, '../node_modules', moduleName),
+						containingFile,
+						{},
+						compilerHost
+					);
+					resolvedModules.push(result.resolvedModule);
+				}
+			}
+
+			return resolvedModules;
+		}
 	};
 
-	function fileExists(fileName: string): boolean {
-		return !!inputs[fileName] || !!outputs[fileName];
-	}
-
-	function readFile(fileName: string): string | undefined {
-		return inputs[fileName];
-	}
-
 	function getSourceFile(fileName: string, languageVersion: ts.ScriptTarget, onError?: (message: string) => void) {
-		return inputs[fileName] ? ts.createSourceFile(fileName, inputs[fileName], languageVersion) : undefined;
+		return inputs[fileName]
+			? ts.createSourceFile(fileName, inputs[fileName], languageVersion)
+			: compilerHost.getSourceFile(fileName, languageVersion, onError);
 	}
 }


### PR DESCRIPTION
… are not used in the render. (#254)

**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Updating the custom element transformer to look at the type of the render callback, rather than the type of the `properties` being used by render. This should let us discover properties applied by the middleware but never pulled into a widget.

Resolves #254 
