### PR TITLE
Support locales that do not have cldr-data by falling back to the minimum locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -797,6 +797,12 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -829,6 +835,12 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
+    },
+    "adm-zip": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
+      "dev": true
     },
     "agent-base": {
       "version": "4.3.0",
@@ -1995,6 +2007,158 @@
       "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-36.0.0.tgz",
       "integrity": "sha512-QLnAjt20rZe38c8h8OJ9jPND+O4o5O8Nw0TK/P3KpNn1cmOhMu0rk6Kc3ap96c5OStQ9gAngs9+Be2sum26NOw=="
     },
+    "cldr-data": {
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-data/-/cldr-data-36.0.0.tgz",
+      "integrity": "sha512-F3n+9DUs41vhys8eF/hsCgkmYlgXMCiwaE75uGZjUbS/jkszBnLylXj7xW3bBlMU1d2IuAptpoNAb6lTCu/RSg==",
+      "dev": true,
+      "requires": {
+        "cldr-data-downloader": "0.3.x",
+        "glob": "5.x.x"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "cldr-data-downloader": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/cldr-data-downloader/-/cldr-data-downloader-0.3.5.tgz",
+      "integrity": "sha512-uyIMa1K98DAp/PE7dYpq2COIrkWn681Atjng1GgEzeJzYb1jANtugtp9wre6+voE+qzVC8jtWv6E/xZ1GTJdlw==",
+      "dev": true,
+      "requires": {
+        "adm-zip": "0.4.11",
+        "mkdirp": "0.5.0",
+        "nopt": "3.0.x",
+        "progress": "1.1.8",
+        "q": "1.0.1",
+        "request": "~2.87.0",
+        "request-progress": "0.3.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "q": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
+          "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
+    },
     "cldrjs": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.1.tgz",
@@ -2056,6 +2220,12 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "coa": {
       "version": "2.0.2",
@@ -7421,6 +7591,15 @@
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-newline/-/normalize-newline-3.0.0.tgz",
@@ -9443,6 +9622,15 @@
         }
       }
     },
+    "request-progress": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+      "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
+      "dev": true,
+      "requires": {
+        "throttleit": "~0.0.2"
+      }
+    },
     "request-promise-core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
@@ -10520,6 +10708,12 @@
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
       }
+    },
+    "throttleit": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "precommit": "lint-staged",
     "prettier": "prettier --write \"{src,tests}/**/*.{ts,tsx}\"",
     "release": "run-s lint clean build \"dojo-release -- {@}\" --",
-    "test": "run-s lint build intern",
+    "test": "NODE_OPTIONS=--max_old_space_size=4096 run-s lint build intern",
     "uploadCoverage": "codecov --file=coverage/coverage.json",
     "watch:ts": "dojo-tsc-watcher -p tsconfig.json -- dojo-package",
     "watch": "run-p watch:ts \"build:static:** -- --watch\""

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "chai": "4.1.2",
     "chai-subset": "1.6.0",
     "classnames": "2.2.5",
+    "cldr-data": "36.0.0",
     "codecov": "~3.0.4",
     "cpx": "~1.5.0",
     "css-loader": "1.0.1",

--- a/src/cldr/loader.ts
+++ b/src/cldr/loader.ts
@@ -24,6 +24,16 @@ function generateCldr(cldrData: any, locales: string[], includeInverse = false) 
 	);
 }
 
+function getValidCldrDataLocale(locale: string): string {
+	const cldr = new Cldr(locale);
+	try {
+		require('cldr-data/main/${locale}/ca-gregorian.json');
+	} catch {
+		locale = cldr.attributes.minLanguageId;
+	}
+	return locale;
+}
+
 export default function(this: webpack.loader.LoaderContext) {
 	const { locale, supportedLocales = [], sync } = getOptions(this);
 	const locales = [locale, ...supportedLocales];
@@ -36,6 +46,7 @@ export default function(this: webpack.loader.LoaderContext) {
 	);
 
 	function loadLocaleCldrTemplate(locale: string) {
+		locale = getValidCldrDataLocale(locale);
 		return `
 cldrData.push(require('cldr-data/main/${locale}/ca-gregorian.json'));
 cldrData.push(require('cldr-data/main/${locale}/dateFields.json'));
@@ -113,6 +124,7 @@ ${loadLocaleCldrTemplate(locale)}`;
 	}`;
 
 	function createLocaleCldrTemplate(locale: string) {
+		locale = getValidCldrDataLocale(locale);
 		if (sync) {
 			return 'true';
 		}

--- a/tests/support/fixtures/cldr/expectedSingleUnknownLocaleBootstrap.js
+++ b/tests/support/fixtures/cldr/expectedSingleUnknownLocaleBootstrap.js
@@ -1,0 +1,73 @@
+var has = require('@dojo/framework/core/has').default;
+var i18n = require('@dojo/framework/i18n/i18n');
+
+i18n.setCldrLoaders({ 'zh-CN': function() {
+	var promises = [];
+
+	if (has('__i18n_date__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/date-time" */ 'cldr-data/main/zh/ca-gregorian.json')
+		);
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/date-time" */ 'cldr-data/main/zh/dateFields.json')
+		);
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/date-time" */ 'cldr-data/main/zh/timeZoneNames.json')
+		);
+	}
+	if (has('__i18n_number__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/currency" */ 'cldr-data/main/zh/currencies.json')
+		);
+	}
+	if (has('__i18n_date__') || has('__i18n_number__') || has('__i18n_unit__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/common" */ 'cldr-data/main/zh/numbers.json')
+		);
+	}
+	if (has('__i18n_unit__')) {
+		promises.push(import(/* webpackChunkName: "i18n/zh/unit" */ 'cldr-data/main/zh/units.json'));
+	}
+
+	return Promise.all(promises);
+}, fallback: function () {
+		return Promise.all([
+			import(/* webpackChunkName: "i18n/supplemental/fallback" */ 'cldr-core/supplemental/likelySubtags.json'),
+			import(/* webpackChunkName: "i18n/supplemental/fallback" */ 'cldr-core/supplemental/plurals.json')
+		]);
+	}, supplemental: function() {
+	var promises = [
+		Promise.resolve({ default: {"supplemental":{"version":{"_unicodeVersion":"12.1.0","_cldrVersion":"36"},"parentLocales":{"parentLocale":{"en-150":"en-001","en-AG":"en-001","en-AI":"en-001","en-AU":"en-001","en-BB":"en-001","en-BM":"en-001","en-BS":"en-001","en-BW":"en-001","en-BZ":"en-001","en-CA":"en-001","en-CC":"en-001","en-CK":"en-001","en-CM":"en-001","en-CX":"en-001","en-CY":"en-001","en-DG":"en-001","en-DM":"en-001","en-ER":"en-001","en-FJ":"en-001","en-FK":"en-001","en-FM":"en-001","en-GB":"en-001","en-GD":"en-001","en-GG":"en-001","en-GH":"en-001","en-GI":"en-001","en-GM":"en-001","en-GY":"en-001","en-HK":"en-001","en-IE":"en-001","en-IL":"en-001","en-IM":"en-001","en-IN":"en-001","en-IO":"en-001","en-JE":"en-001","en-JM":"en-001","en-KE":"en-001","en-KI":"en-001","en-KN":"en-001","en-KY":"en-001","en-LC":"en-001","en-LR":"en-001","en-LS":"en-001","en-MG":"en-001","en-MO":"en-001","en-MS":"en-001","en-MT":"en-001","en-MU":"en-001","en-MW":"en-001","en-MY":"en-001","en-NA":"en-001","en-NF":"en-001","en-NG":"en-001","en-NR":"en-001","en-NU":"en-001","en-NZ":"en-001","en-PG":"en-001","en-PH":"en-001","en-PK":"en-001","en-PN":"en-001","en-PW":"en-001","en-RW":"en-001","en-SB":"en-001","en-SC":"en-001","en-SD":"en-001","en-SG":"en-001","en-SH":"en-001","en-SL":"en-001","en-SS":"en-001","en-SX":"en-001","en-SZ":"en-001","en-TC":"en-001","en-TK":"en-001","en-TO":"en-001","en-TT":"en-001","en-TV":"en-001","en-TZ":"en-001","en-UG":"en-001","en-VC":"en-001","en-VG":"en-001","en-VU":"en-001","en-WS":"en-001","en-ZA":"en-001","en-ZM":"en-001","en-ZW":"en-001","en-AT":"en-150","en-BE":"en-150","en-CH":"en-150","en-DE":"en-150","en-DK":"en-150","en-FI":"en-150","en-NL":"en-150","en-SE":"en-150","en-SI":"en-150","es-AR":"es-419","es-BO":"es-419","es-BR":"es-419","es-BZ":"es-419","es-CL":"es-419","es-CO":"es-419","es-CR":"es-419","es-CU":"es-419","es-DO":"es-419","es-EC":"es-419","es-GT":"es-419","es-HN":"es-419","es-MX":"es-419","es-NI":"es-419","es-PA":"es-419","es-PE":"es-419","es-PR":"es-419","es-PY":"es-419","es-SV":"es-419","es-US":"es-419","es-UY":"es-419","es-VE":"es-419","pt-AO":"pt-PT","pt-CH":"pt-PT","pt-CV":"pt-PT","pt-FR":"pt-PT","pt-GQ":"pt-PT","pt-GW":"pt-PT","pt-LU":"pt-PT","pt-MO":"pt-PT","pt-MZ":"pt-PT","pt-ST":"pt-PT","pt-TL":"pt-PT","az-Arab":"root","az-Cyrl":"root","blt-Latn":"root","bm-Nkoo":"root","bs-Cyrl":"root","byn-Latn":"root","cu-Glag":"root","dje-Arab":"root","dyo-Arab":"root","en-Dsrt":"root","en-Shaw":"root","ff-Adlm":"root","ff-Arab":"root","ha-Arab":"root","iu-Latn":"root","kk-Arab":"root","ku-Arab":"root","ky-Arab":"root","ky-Latn":"root","ml-Arab":"root","mn-Mong":"root","ms-Arab":"root","pa-Arab":"root","sd-Deva":"root","sd-Khoj":"root","sd-Sind":"root","shi-Latn":"root","so-Arab":"root","sr-Latn":"root","sw-Arab":"root","tg-Arab":"root","ug-Cyrl":"root","uz-Arab":"root","uz-Cyrl":"root","vai-Latn":"root","wo-Arab":"root","yo-Arab":"root","yue-Hans":"root","zh-Hant":"root","zh-Hant-MO":"zh-Hant-HK"}}}} }),
+		Promise.resolve({ default: {"supplemental":{"version":{"_unicodeVersion":"12.1.0","_cldrVersion":"36"},"likelySubtags":{"und-030":"zh-Hans-CN","und-142":"zh-Hans-CN","und-Bopo":"zh-Bopo-TW","und-CN":"zh-Hans-CN","und-Hanb":"zh-Hanb-TW","und-Hani":"zh-Hani-CN","und-Hans":"zh-Hans-CN","und-Hant":"zh-Hant-TW","und-HK":"zh-Hant-HK","und-MO":"zh-Hant-MO","und-Nshu":"zhx-Nshu-CN","und-TW":"zh-Hant-TW","zh":"zh-Hans-CN","zh-AU":"zh-Hant-AU","zh-BN":"zh-Hant-BN","zh-Bopo":"zh-Bopo-TW","zh-GB":"zh-Hant-GB","zh-GF":"zh-Hant-GF","zh-Hanb":"zh-Hanb-TW","zh-Hant":"zh-Hant-TW","zh-HK":"zh-Hant-HK","zh-ID":"zh-Hant-ID","zh-MO":"zh-Hant-MO","zh-MY":"zh-Hant-MY","zh-PA":"zh-Hant-PA","zh-PF":"zh-Hant-PF","zh-PH":"zh-Hant-PH","zh-SR":"zh-Hant-SR","zh-TH":"zh-Hant-TH","zh-TW":"zh-Hant-TW","zh-US":"zh-Hant-US","zh-VN":"zh-Hant-VN","zhx":"zhx-Nshu-CN"}}} }),
+		Promise.resolve({ default: {"supplemental":{"version":{"_unicodeVersion":"12.1.0","_cldrVersion":"36"},"plurals-type-cardinal":{"zh":{"pluralRule-count-other":" @integer 0~15, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"}}}} })
+	];
+
+	if (has('__i18n_date__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/supplemental/date-time" */ 'cldr-core/supplemental/weekData.json')
+		);
+		promises.push(
+			import(/* webpackChunkName: "i18n/supplemental/date-time" */ 'cldr-core/supplemental/timeData.json')
+		);
+	}
+	if (has('__i18n_number__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/supplemental/currency" */ 'cldr-core/supplemental/currencyData.json')
+		);
+	}
+	if (has('__i18n_date__') || has('__i18n_number__') || has('__i18n_unit__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/supplemental/common" */ 'cldr-core/supplemental/ordinals.json')
+		);
+		promises.push(
+			import(
+				/* webpackChunkName: "i18n/supplemental/common" */ 'cldr-core/supplemental/numberingSystems.json'
+			)
+		);
+	}
+
+	return Promise.all(promises);
+} });
+i18n.setSupportedLocales(["zh-CN"]);
+i18n.setDefaultLocale('zh-CN');
+export default i18n.setLocale({ default: true });

--- a/tests/unit/cldr/loader.ts
+++ b/tests/unit/cldr/loader.ts
@@ -39,6 +39,15 @@ describe('cldr loader', () => {
 			const expected = fs.readFileSync(path.join(basePath, 'expectedMultipleLocaleBootstrap.js'), 'utf8');
 			assert.strictEqual(cldrLoaderOutput, expected);
 		});
+
+		it('should generate loaders for locales that do not have specific cldr data', () => {
+			mockLoaderUtils.getOptions.returns({
+				locale: 'zh-CN'
+			});
+			const cldrLoaderOutput = mockModule.getModuleUnderTest().default();
+			const expected = fs.readFileSync(path.join(basePath, 'expectedSingleUnknownLocaleBootstrap.js'), 'utf8');
+			assert.strictEqual(cldrLoaderOutput, expected);
+		});
 	});
 
 	describe('sync', () => {
@@ -51,7 +60,6 @@ describe('cldr loader', () => {
 			const expected = fs.readFileSync(path.join(basePath, 'expectedSingleLocaleBootstrapSync.js'), 'utf8');
 			assert.strictEqual(cldrLoaderOutput, expected);
 		});
-
 		it('should generate loaders for the all supported locales', () => {
 			mockLoaderUtils.getOptions.returns({
 				locale: 'en',


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Not all valid locales have cldr-data, therefore if a locale like `zh-CN` is used then the cldr loader should load the cldr-data for the minimum locale, in this case it would be `zh`. It should still be loaded by changing locale to `zh-CN`.

Resolves #252 
