### PR TITLE
Code split top level routes in defined in an Outlet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dojo/framework": {
-      "version": "7.0.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.12.tgz",
-      "integrity": "sha512-47wdtawvOo5/T0lx/pZsI4T7UoMV+ng8aBgMLw0f4B/c9TyGrpYq4loKxT1WeKjLGEGctq0f/OBYLOmuKOb/Ug==",
+      "version": "7.0.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.15.tgz",
+      "integrity": "sha512-CCBTgFih8CmZb0rvyoelOdZ0C28RAcQUn6F5w0eegca4HWDwet5zn1mhTc9TOeedaSUVVQ+RXjdvKDjK9ty+qg==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
@@ -391,9 +391,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
-      "integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.3.tgz",
+      "integrity": "sha512-sHEsvEzjqN+zLbqP+8OXTipc10yH1QLR+hnr5uw29gi9AhCAAAdri8ClNV7iMdrJrIzXIQtlkPvq8tJGhj3QJQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -572,9 +572,9 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
-      "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.5.tgz",
+      "integrity": "sha512-L7EbSkhSaWBpkl+PZAEAqZTqtTeIsq7s/oX/q0LNnxxJoRVKQE0T81XDVyaxjiiKQwiV2vhVeYRqxdRNqGOGJw==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -1635,13 +1635,14 @@
       }
     },
     "browserslist": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-      "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+      "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
       "requires": {
-        "caniuse-lite": "^1.0.30001030",
-        "electron-to-chromium": "^1.3.363",
-        "node-releases": "^1.1.50"
+        "caniuse-lite": "^1.0.30001038",
+        "electron-to-chromium": "^1.3.390",
+        "node-releases": "^1.1.53",
+        "pkg-up": "^2.0.0"
       }
     },
     "buffer": {
@@ -1673,8 +1674,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -1862,9 +1862,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001035",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-      "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
+      "version": "1.0.30001039",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
+      "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3067,11 +3067,27 @@
       "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q=="
     },
     "csso": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
-      "integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.3.tgz",
+      "integrity": "sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==",
       "requires": {
-        "css-tree": "1.0.0-alpha.37"
+        "css-tree": "1.0.0-alpha.39"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.0.0-alpha.39",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
+          "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
+          "requires": {
+            "mdn-data": "2.0.6",
+            "source-map": "^0.6.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
+          "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA=="
+        }
       }
     },
     "cssom": {
@@ -3159,9 +3175,9 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
       "dev": true,
       "requires": {
         "decompress-tar": "^4.0.0",
@@ -3245,15 +3261,6 @@
         "yauzl": "^2.4.2"
       },
       "dependencies": {
-        "fd-slicer": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-          "dev": true,
-          "requires": {
-            "pend": "~1.2.0"
-          }
-        },
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
@@ -3275,16 +3282,6 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
-        },
-        "yauzl": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-          "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-          "dev": true,
-          "requires": {
-            "buffer-crc32": "~0.2.3",
-            "fd-slicer": "~1.1.0"
-          }
         }
       }
     },
@@ -3578,16 +3575,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.30",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-          "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
+          "version": "12.12.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
+          "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g=="
         }
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.378",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
-      "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
+      "version": "1.3.398",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.398.tgz",
+      "integrity": "sha512-BJjxuWLKFbM5axH3vES7HKMQgAknq9PZHBkMK/rEXUQG9i1Iw5R+6hGkm6GtsQSANjSUrh/a6m32nzCNDNo/+w=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -3665,9 +3662,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -4166,14 +4163,14 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -4182,6 +4179,19 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -4217,9 +4227,9 @@
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
@@ -4484,9 +4494,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
@@ -4533,7 +4543,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "bundled": true,
           "optional": true
         },
@@ -4683,7 +4693,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.5",
           "bundled": true,
           "optional": true
         },
@@ -4705,11 +4715,11 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -4718,7 +4728,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.4.0",
+          "version": "2.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -4745,7 +4755,7 @@
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -4767,12 +4777,13 @@
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.7",
+          "version": "1.4.8",
           "bundled": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npmlog": {
@@ -4842,17 +4853,10 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "2.3.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -5148,14 +5152,6 @@
         "roarr": "^2.15.2",
         "semver": "^7.1.2",
         "serialize-error": "^5.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
-          "optional": true
-        }
       }
     },
     "global-tunnel-ng": {
@@ -7579,12 +7575,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.52",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
-      "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
-      "requires": {
-        "semver": "^6.3.0"
-      }
+      "version": "1.1.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+      "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
     },
     "node-status-codes": {
       "version": "1.0.0",
@@ -8303,9 +8296,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pidtree": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
-      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
     },
     "pify": {
@@ -8330,6 +8323,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "requires": {
+        "find-up": "^2.1.0"
+      }
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "requires": {
         "find-up": "^2.1.0"
       }
@@ -9139,9 +9140,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -9764,9 +9765,9 @@
       }
     },
     "roarr": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
-      "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.3.tgz",
+      "integrity": "sha512-AEjYvmAhlyxOeB9OqPUzQCo3kuAkNfuDk/HqWbZdFsqDFpapkTjiw+p4svNEoRLvuqNTxqfL+s+gtD4eDgZ+CA==",
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
@@ -9879,9 +9880,10 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.1.tgz",
+      "integrity": "sha512-aHhm1pD02jXXkyIpq25qBZjr3CQgg8KST8uX0OWXch3xE6jw+1bfbWnCjzMwojsTquroUmKFHNzU6x26mEiRxw==",
+      "optional": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -10061,9 +10063,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -10466,22 +10468,42 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+    "string.prototype.trimend": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
+      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
+      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
@@ -10878,9 +10900,9 @@
       }
     },
     "ts-node": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
-      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.8.2.tgz",
+      "integrity": "sha512-duVj6BpSpUpD/oM4MfhO98ozgkp3Gt9qIp3jGxwU2DFvl/3IRaEAvbLa8G60uS7C77457e/m5TMowjedeRxI1Q==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
@@ -11040,9 +11062,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
+      "integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -11098,9 +11120,9 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.0.tgz",
+      "integrity": "sha512-kVx7CDAsdBSWVf404Mw7oI9i09w5/mTT/Ruk+RWa64PLYKvsAucLLFHvQtnvjeADM4ZizxrvG5SHnF4Te4T2Cg==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",
@@ -11420,12 +11442,12 @@
       }
     },
     "watchpack": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
+      "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
+        "chokidar": "^2.1.8",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       }
@@ -11966,11 +11988,12 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "watch": "run-p watch:ts \"build:static:** -- --watch\""
   },
   "dependencies": {
-    "@dojo/framework": "7.0.0-alpha.12",
+    "@dojo/framework": "7.0.0-alpha.15",
     "acorn": "6.1.1",
     "acorn-dynamic-import": "4.0.0",
     "acorn-walk": "6.1.1",

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -11,7 +11,6 @@ const outletImportPath = '@dojo/framework/routing/Outlet';
 const routeRendererName = 'renderer';
 const routeIdName = 'id';
 const routeName = 'Route';
-// const outletIdName = 'id';;
 const outletName = 'Outlet';
 
 interface VisitorOptions {
@@ -233,7 +232,7 @@ class Visitor {
 			this.log(text, targetPath);
 			let routeName = this.routeName ? this.getRouteName(node) : undefined;
 			if (!routeName && this.outletName) {
-				routeName = this.getOutletName(node);
+				routeName = this.getOutletRouteName(node);
 			}
 			if (
 				this.all ||
@@ -318,7 +317,7 @@ class Visitor {
 
 		let routeName = this.routeName ? this.getRouteName(node) : undefined;
 		if (!routeName && this.outletName) {
-			routeName = this.getOutletName(node);
+			routeName = this.getOutletRouteName(node);
 		}
 		this.ctorCountMap.set(text, (this.ctorCountMap.get(text) || 0) + 1);
 		this.log(text, targetPath);
@@ -424,7 +423,7 @@ class Visitor {
 		return undefined;
 	}
 
-	private getOutletName(node: ts.Node): string | undefined {
+	private getOutletRouteName(node: ts.Node): string | undefined {
 		let parent = node.parent;
 		let text: string | undefined;
 		while (parent) {

--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -424,13 +424,21 @@ class Visitor {
 	private getOutletName(node: ts.Node): string | undefined {
         let parent = node.parent;
         let text: string | undefined;
+        let isOutletChild = false;
         while (parent) {
-            if (ts.isPropertyAssignment(parent)) {
+            if (ts.isPropertyAssignment(parent) && !text) {
                 text = parent.name.getText().replace(/^'/, '').replace(/'$/, '');
+            }
+            if (ts.isCallExpression(parent) && parent.expression.getText() === this.wPragma && !isOutletChild) {
+                if (ts.isIdentifier(parent.arguments[0]) && parent.arguments[0].getText() === this.outletName) {
+                    isOutletChild = true;
+                } else {
+                    return undefined;
+                }
             }
             parent = parent.parent;
         }
-        return text;
+        return isOutletChild ? text : undefined;
 	}
 }
 

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -689,8 +689,11 @@ export class Foo extends WidgetBase {
 						<div>child</div>
                     </Baz>
                     <Something>{{
-                        'my-bar-route': <Baz />,
+                        'my-bar-route': <Baz />
                     }}</Something>
+                    <Outlet id="main">{{
+                        'other': <Something>{{ 'my-bar-route': <Baz /> }}</Something>
+                    }}</Outlet>
                     <Outlet id="main">{{
                         'my-bar-route': <Bar />,
                         'my-blah-route': () => <Blah />
@@ -732,8 +735,11 @@ export class Foo extends WidgetBase {
 						<div>child</div>
                     </Baz>
                     <Something>{{
-            'my-bar-route': <Baz />,
+            'my-bar-route': <Baz />
         }}</Something>
+                    <Outlet id="main">{{
+            'other': <Something>{{ 'my-bar-route': <Baz /> }}</Something>
+        }}</Outlet>
                     <Outlet id="main">{{
             'my-bar-route': <Loadable__ __autoRegistryItem={{ label: "__autoRegistryItem_Bar", registryItem: __autoRegistryItems.Bar }}/>,
             'my-blah-route': () => <Loadable__ __autoRegistryItem={{ label: "__autoRegistryItem_Blah", registryItem: __autoRegistryItems.Blah }}/>

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -675,6 +675,7 @@ import WidgetBase from '@dojo/framework/core/WidgetBase';
 import Bar from './widgets/Bar';
 import Baz from './Baz';
 import Blah from './Qux';
+import Something from './Something';
 import Outlet from '@dojo/framework/routing/Outlet';
 
 export class Foo extends WidgetBase {
@@ -687,6 +688,9 @@ export class Foo extends WidgetBase {
 					<Baz>
 						<div>child</div>
                     </Baz>
+                    <Something>{{
+                        'my-bar-route': <Baz />,
+                    }}</Something>
                     <Outlet id="main">{{
                         'my-bar-route': <Bar />,
                         'my-blah-route': () => <Blah />
@@ -714,6 +718,7 @@ export class Foo extends WidgetBase {
 		const expected = `import WidgetBase from '@dojo/framework/core/WidgetBase';
 import Baz from './Baz';
 import Blah from './Qux';
+import Something from './Something';
 import Outlet from '@dojo/framework/routing/Outlet';
 var Loadable__ = { type: "registry" };
 var __autoRegistryItems = { Bar: () => import("./widgets/Bar"), Blah: () => import("./Qux") };
@@ -726,6 +731,9 @@ export class Foo extends WidgetBase {
 					<Baz>
 						<div>child</div>
                     </Baz>
+                    <Something>{{
+            'my-bar-route': <Baz />,
+        }}</Something>
                     <Outlet id="main">{{
             'my-bar-route': <Loadable__ __autoRegistryItem={{ label: "__autoRegistryItem_Bar", registryItem: __autoRegistryItems.Bar }}/>,
             'my-blah-route': () => <Loadable__ __autoRegistryItem={{ label: "__autoRegistryItem_Blah", registryItem: __autoRegistryItems.Blah }}/>
@@ -740,7 +748,8 @@ export class Foo extends WidgetBase {
 			all: {
 				Bar: 'widgets/Bar',
 				Baz: 'Baz',
-				Blah: 'Qux'
+                Blah: 'Qux',
+                Something: 'Something'
 			},
 			modules: {
 				__autoRegistryItem_Bar: { path: 'widgets/Bar', routeName: ['my-bar-route'] },

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -494,7 +494,8 @@ export default HelloWorld;
 		import Bar from './widgets/Bar';
 		import Baz from './Baz';
 		import Quz from './Quz';
-		import Blah from './Qux';
+        import Blah from './Qux';
+        import WithChildren from './WithChildren';
 		import Something from './Something';
 
 		export class Foo extends WidgetBase {
@@ -506,6 +507,9 @@ export default HelloWorld;
                         'my-foo-route':  w(Something, {}),
                         'my-blah-route': () => w(Blah, {})
 
+                    }]),
+                    w(WithChildren, {}, [{
+                        'my-foo-route': w(Baz, {})
                     }]),
 					w(Bar, {}),
 					w(Baz, {})
@@ -544,6 +548,7 @@ import WidgetBase from '@dojo/framework/core/WidgetBase';
 import { Outlet } from '@dojo/framework/routing/Outlet';
 import Baz from './Baz';
 import Blah from './Qux';
+import WithChildren from './WithChildren';
 var __autoRegistryItems = { Something: () => import("./Something"), Blah: () => import("./Qux"), Bar: () => import("./widgets/Bar"), Quz: () => import("./Quz") };
 export class Foo extends WidgetBase {
     render() {
@@ -552,6 +557,9 @@ export class Foo extends WidgetBase {
             w(Outlet, { id: 'main' }, [{
                     'my-foo-route': w({ label: "__autoRegistryItem_Something", registryItem: __autoRegistryItems.Something }, {}),
                     'my-blah-route': () => w({ label: "__autoRegistryItem_Blah", registryItem: __autoRegistryItems.Blah }, {})
+                }]),
+            w(WithChildren, {}, [{
+                    'my-foo-route': w(Baz, {})
                 }]),
             w({ label: "__autoRegistryItem_Bar", registryItem: __autoRegistryItems.Bar }, {}),
             w(Baz, {})]);
@@ -573,7 +581,8 @@ export default HelloWorld;
 				Baz: 'Baz',
 				Blah: 'Qux',
 				Quz: 'Quz',
-				Something: 'Something'
+                Something: 'Something',
+                WithChildren: 'WithChildren'
 			},
 			modules: {
 				__autoRegistryItem_Bar: { path: 'widgets/Bar', routeName: [] },

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -754,8 +754,8 @@ export class Foo extends WidgetBase {
 			all: {
 				Bar: 'widgets/Bar',
 				Baz: 'Baz',
-                Blah: 'Qux',
-                Something: 'Something'
+				Blah: 'Qux',
+				Something: 'Something'
 			},
 			modules: {
 				__autoRegistryItem_Bar: { path: 'widgets/Bar', routeName: ['my-bar-route'] },

--- a/tests/unit/registry-transformer/RegistryTransformer.ts
+++ b/tests/unit/registry-transformer/RegistryTransformer.ts
@@ -366,18 +366,18 @@ export default HelloWorld;
 				Quz: 'Quz'
 			},
 			modules: {
-				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: [] },
-				__autoRegistryItem_Baz: { path: 'Baz', outletName: [] },
-				__autoRegistryItem_Quz: { path: 'Quz', outletName: [] }
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', routeName: [] },
+				__autoRegistryItem_Baz: { path: 'Baz', routeName: [] },
+				__autoRegistryItem_Quz: { path: 'Quz', routeName: [] }
 			}
 		});
 	});
 
-	it('can distinguish widgets in an outlet renderer', () => {
+	it('can distinguish widgets in an route renderer', () => {
 		const source = `
 		import { v, w } from '@dojo/framework/core/vdom';
 		import WidgetBase from '@dojo/framework/core/WidgetBase';
-		import { Outlet } from '@dojo/framework/routing/Outlet';
+		import { Route } from '@dojo/framework/routing/Route';
 		import Bar from './widgets/Bar';
 		import Baz from './Baz';
 		import Quz from './Quz';
@@ -389,14 +389,14 @@ export default HelloWorld;
 				return v('div' [
 					v('div', ['Foo']),
 					w(Blah, {}),
-					w(Outlet, {
-						id: 'my-foo-outlet',
+					w(Route, {
+						id: 'my-foo-route',
 						renderer: () => {
 							return w(Something, {});
 						}
 					}),
-					w(Outlet, {
-						id: 'my-blah-outlet',
+					w(Route, {
+						id: 'my-blah-route',
 						renderer() {
 							return w(Blah, {});
 						}
@@ -419,8 +419,8 @@ export default HelloWorld;
 		export default HelloWorld;
 		`;
 		const transformer = registryTransformer(process.cwd(), ['widgets/Bar', 'Quz'], false, [
-			'my-foo-outlet',
-			'my-blah-outlet'
+			'my-foo-route',
+			'my-blah-route'
 		]);
 		const result = ts.transpileModule(source, {
 			compilerOptions: {
@@ -435,7 +435,7 @@ export default HelloWorld;
 
 		const expected = `import { v, w } from '@dojo/framework/core/vdom';
 import WidgetBase from '@dojo/framework/core/WidgetBase';
-import { Outlet } from '@dojo/framework/routing/Outlet';
+import { Route } from '@dojo/framework/routing/Route';
 import Baz from './Baz';
 import Blah from './Qux';
 var __autoRegistryItems = { Something: () => import("./Something"), Blah: () => import("./Qux"), Bar: () => import("./widgets/Bar"), Quz: () => import("./Quz") };
@@ -443,14 +443,14 @@ export class Foo extends WidgetBase {
     render() {
         return v('div'[v('div', ['Foo']),
             w(Blah, {}),
-            w(Outlet, {
-                id: 'my-foo-outlet',
+            w(Route, {
+                id: 'my-foo-route',
                 renderer: () => {
                     return w({ label: "__autoRegistryItem_Something", registryItem: __autoRegistryItems.Something }, {});
                 }
             }),
-            w(Outlet, {
-                id: 'my-blah-outlet',
+            w(Route, {
+                id: 'my-blah-route',
                 renderer() {
                     return w({ label: "__autoRegistryItem_Blah", registryItem: __autoRegistryItems.Blah }, {});
                 }
@@ -478,21 +478,21 @@ export default HelloWorld;
 				Something: 'Something'
 			},
 			modules: {
-				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: [] },
-				__autoRegistryItem_Blah: { path: 'Qux', outletName: ['my-blah-outlet'] },
-				__autoRegistryItem_Quz: { path: 'Quz', outletName: [] },
-				__autoRegistryItem_Something: { outletName: ['my-foo-outlet'], path: 'Something' }
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', routeName: [] },
+				__autoRegistryItem_Blah: { path: 'Qux', routeName: ['my-blah-route'] },
+				__autoRegistryItem_Quz: { path: 'Quz', routeName: [] },
+				__autoRegistryItem_Something: { routeName: ['my-foo-route'], path: 'Something' }
 			}
 		});
 	});
 
-	it('can distinguish widgets in an outlet renderer tsx', () => {
+	it('can distinguish widgets in an route renderer tsx', () => {
 		const source = `
 import WidgetBase from '@dojo/framework/core/WidgetBase';
 import Bar from './widgets/Bar';
 import Baz from './Baz';
 import Blah from './Qux';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 
 export class Foo extends WidgetBase {
 	protected render() {
@@ -504,15 +504,15 @@ export class Foo extends WidgetBase {
 					<Baz>
 						<div>child</div>
 					</Baz>
-					<Outlet id="my-bar-outlet" renderer={ () => (<Bar />) } />
-					<Outlet id="my-blah-outlet" renderer={ () => (<Blah />) } />
+					<Route id="my-bar-route" renderer={ () => (<Bar />) } />
+					<Route id="my-blah-route" renderer={ () => (<Blah />) } />
 				</div>
 			</div>
 		);
 	}
 }
 `;
-		const transformer = registryTransformer(process.cwd(), [], false, ['my-bar-outlet', 'my-blah-outlet']);
+		const transformer = registryTransformer(process.cwd(), [], false, ['my-bar-route', 'my-blah-route']);
 		const result = ts.transpileModule(source, {
 			compilerOptions: {
 				importHelpers: true,
@@ -529,7 +529,7 @@ export class Foo extends WidgetBase {
 		const expected = `import WidgetBase from '@dojo/framework/core/WidgetBase';
 import Baz from './Baz';
 import Blah from './Qux';
-import Outlet from '@dojo/framework/routing/Outlet';
+import Route from '@dojo/framework/routing/Route';
 var Loadable__ = { type: "registry" };
 var __autoRegistryItems = { Bar: () => import("./widgets/Bar"), Blah: () => import("./Qux") };
 export class Foo extends WidgetBase {
@@ -541,8 +541,8 @@ export class Foo extends WidgetBase {
 					<Baz>
 						<div>child</div>
 					</Baz>
-					<Outlet id="my-bar-outlet" renderer={() => (<Loadable__ __autoRegistryItem={{ label: "__autoRegistryItem_Bar", registryItem: __autoRegistryItems.Bar }}/>)}/>
-					<Outlet id="my-blah-outlet" renderer={() => (<Loadable__ __autoRegistryItem={{ label: "__autoRegistryItem_Blah", registryItem: __autoRegistryItems.Blah }}/>)}/>
+					<Route id="my-bar-route" renderer={() => (<Loadable__ __autoRegistryItem={{ label: "__autoRegistryItem_Bar", registryItem: __autoRegistryItems.Bar }}/>)}/>
+					<Route id="my-blah-route" renderer={() => (<Loadable__ __autoRegistryItem={{ label: "__autoRegistryItem_Blah", registryItem: __autoRegistryItems.Blah }}/>)}/>
 				</div>
 			</div>);
     }
@@ -556,8 +556,8 @@ export class Foo extends WidgetBase {
 				Blah: 'Qux'
 			},
 			modules: {
-				__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: ['my-bar-outlet'] },
-				__autoRegistryItem_Blah: { path: 'Qux', outletName: ['my-blah-outlet'] }
+				__autoRegistryItem_Bar: { path: 'widgets/Bar', routeName: ['my-bar-route'] },
+				__autoRegistryItem_Blah: { path: 'Qux', routeName: ['my-blah-route'] }
 			}
 		});
 	});
@@ -601,9 +601,9 @@ export default HelloWorld;
 `;
 		assert.equal(nl(result.outputText), expected);
 		assert.deepEqual(shared.modules, {
-			__autoRegistryItem_Bar: { path: 'widgets/Bar', outletName: [] },
-			__autoRegistryItem_Baz: { path: 'Baz', outletName: [] },
-			__autoRegistryItem_Quz: { path: 'Quz', outletName: [] }
+			__autoRegistryItem_Bar: { path: 'widgets/Bar', routeName: [] },
+			__autoRegistryItem_Baz: { path: 'Baz', routeName: [] },
+			__autoRegistryItem_Quz: { path: 'Quz', routeName: [] }
 		});
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Updated to reflect the changes from @dojo/framework that changes the concept of an `Outlet` in Dojo. The existing `Outlet` behaviour is now available using `Route` and `Outlet` defines routes as keys in the children object.

Existing functionality for code-splitting updated from `Outlet` to `Route`. Added additional code-splitting based on the routes defined in outlet children.

Related to https://github.com/dojo/framework/issues/715
