### PR TITLE
Set document title for build time rendered pages

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -26,6 +26,7 @@ import { parse } from 'node-html-parser';
 
 export interface RenderResult {
 	path?: string | BuildTimePath;
+	title: string;
 	content: string;
 	styles: string;
 	script: string;
@@ -137,6 +138,7 @@ export default class BuildTimeRender {
 
 	private async _writeIndexHtml({
 		content,
+		title,
 		script,
 		path = '',
 		styles,
@@ -178,6 +180,9 @@ export default class BuildTimeRender {
 
 			styles = await this._processCss(styles);
 			html = html.replace(`</head>`, `<style>${styles}</style></head>`);
+			if (title) {
+				html = html.replace(/<title>.*<\/title>/, title);
+			}
 			if (this._static || staticPath) {
 				html = html.replace(this._createScripts(), '');
 			} else {
@@ -274,6 +279,7 @@ export default class BuildTimeRender {
 		const classes: any[] = await getClasses(page);
 		let pathValue = typeof path === 'object' ? path.path : path;
 		let content = await getForSelector(page, `#${this._root}`);
+		let title = await getForSelector(page, 'title');
 		let styles = this._filterCss(classes);
 		let script = '';
 
@@ -288,6 +294,7 @@ export default class BuildTimeRender {
 			styles,
 			script,
 			path,
+			title,
 			blockScripts: [],
 			additionalScripts: [],
 			additionalCss: []
@@ -342,6 +349,7 @@ export default class BuildTimeRender {
 			styles: combined.styles,
 			content: this._originalRoot,
 			script,
+			title: '',
 			blockScripts: combined.blockScripts,
 			additionalScripts: combined.additionalScripts,
 			additionalCss: combined.additionalCss

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -98,7 +98,11 @@ export async function getRenderHooks(page: any, scope: string): Promise<any> {
 }
 
 export async function getForSelector(page: any, selector: string) {
-	return page.$eval(selector, (element: Element) => element.outerHTML);
+	try {
+		return await page.$eval(selector, (element: Element) => element.outerHTML);
+	} catch {
+		return '';
+	}
 }
 
 export async function getPageLinks(page: any) {

--- a/tests/support/fixtures/build-time-render/state-static/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/expected/my-path/index.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<link rel="manifest" href="manifest.json" />
+		<title>Hello my-path</title>
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}</div></div>

--- a/tests/support/fixtures/build-time-render/state-static/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/expected/my-path/other/index.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<link rel="manifest" href="manifest.json" />
+		<title>Hello my-path/other</title>
 	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
 	<body>
 		<div id="app"><div class="other">Other</div></div>

--- a/tests/support/fixtures/build-time-render/state-static/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/expected/other/index.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<link rel="manifest" href="manifest.json" />
+		<title>Hello home</title>
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"></div></div>

--- a/tests/support/fixtures/build-time-render/state-static/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/index.html
@@ -2,6 +2,7 @@
 	<head>
 		<link rel="manifest" href="manifest.json" />
 		<link href="main.css" rel="stylesheet">
+		<title>Original Title</title>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/tests/support/fixtures/build-time-render/state-static/main.js
+++ b/tests/support/fixtures/build-time-render/state-static/main.js
@@ -30,18 +30,22 @@
 	}
 
 	if (route === '/') {
+		document.title = "Hello home";
 		renderDefault();
 	} else if (route === '/my-path') {
+		document.title = "Hello my-path";
 		div = document.createElement('div');
 		div.classList.add('hello', 'another');
 		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
 		app.appendChild(div);
 	} else if (route === '/my-path/other') {
+		document.title = "Hello my-path/other";
 		div = document.createElement('div');
 		div.classList.add('other');
 		div.innerHTML = 'Other';
 		app.appendChild(div);
 	} else {
+		document.title = "Hello home";
 		renderDefault();
 	}
 	window.test = {


### PR DESCRIPTION
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Sets the document title for pages built with BTR based on the title of the rendered output.