### PR TITLE
Allow blocks to change on watch

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -109,6 +109,7 @@ export default class BuildTimeRender {
 	private _manifest: any;
 	private _manifestContent: any = {};
 	private _buildBridgeResult: any = {};
+	private _blockEntries: string[] = [];
 	private _output?: string;
 	private _jsonpName?: string;
 	private _paths: (BuildTimePath | string)[];
@@ -457,12 +458,15 @@ __webpack_require__.r(__webpack_exports__);
 					scripts.push(`${chunkName}.js`);
 				}
 
-				if (this._manifestContent[blockChunk].indexOf(blockCacheEntry) === -1) {
-					this._manifestContent[blockChunk] = this._manifestContent[blockChunk].replace(
-						'APPEND_BLOCK_CACHE_ENTRY **/',
-						`APPEND_BLOCK_CACHE_ENTRY **/
+				if (this._blockEntries.indexOf(blockCacheEntry) === -1) {
+					this._blockEntries.push(blockCacheEntry);
+					if (this._manifestContent[blockChunk].indexOf(blockCacheEntry) === -1) {
+						this._manifestContent[blockChunk] = this._manifestContent[blockChunk].replace(
+							'APPEND_BLOCK_CACHE_ENTRY **/',
+							`APPEND_BLOCK_CACHE_ENTRY **/
 ${blockCacheEntry}`
-					);
+						);
+					}
 					this._manifest[`${chunkName}.js`] = `${chunkName}.js`;
 					if (mainHash) {
 						const newBlockHash = genHash(this._manifestContent[blockChunk]);
@@ -546,6 +550,7 @@ ${blockCacheEntry}`
 
 	private async _run(compilation: compilation.Compilation | MockCompilation, callback: Function, path?: string) {
 		this._buildBridgeResult = {};
+		this._blockEntries = [];
 		this._blockErrors = [];
 		if (!this._output || compilation.errors.length > 0) {
 			return Promise.resolve().then(() => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

With on-demand BTR when javascript is enabled, if the result of the block changes but the arguments don't (common) then the new block content is not written. This tracks the blocks written per build and only adds the block entry if it doesn't already exist.