### PR TITLE
Add es2019-array flag to modern features

### DIFF
--- a/src/static-build-loader/features/modern.json
+++ b/src/static-build-loader/features/modern.json
@@ -19,6 +19,7 @@
 	"es6-symbol": true,
 	"es6-weakmap": true,
 	"es7-array": true,
+	"es2019-array": true,
 	"fetch": true,
 	"filereader": true,
 	"float32array": true,

--- a/tests/unit/static-build-loader/getFeatures.ts
+++ b/tests/unit/static-build-loader/getFeatures.ts
@@ -31,6 +31,7 @@ registerSuite('getFeatures', {
 			'es6-symbol': true,
 			'es6-weakmap': true,
 			'es7-array': true,
+			'es2019-array': true,
 			fetch: true,
 			filereader: true,
 			float32array: true,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add `es2019-array` to modern features