### PR TITLE
Replace requires with empty object instead of undefined

### DIFF
--- a/src/static-build-loader/loader.ts
+++ b/src/static-build-loader/loader.ts
@@ -282,7 +282,7 @@ export default function loader(
 
 					if (comment && parentPath && typeof name !== 'undefined') {
 						const replacement = builders.variableDeclaration('var', [
-							builders.variableDeclarator(identifier, builders.identifier('undefined'))
+							builders.variableDeclarator(identifier, builders.objectExpression([]))
 						]);
 						setComment(node, path, comment, parentPath, name, replacement);
 

--- a/src/static-build-loader/recast.d.ts
+++ b/src/static-build-loader/recast.d.ts
@@ -24,7 +24,8 @@ declare module 'recast/main' {
 		SourceLocation,
 		SimpleCallExpression,
 		Super,
-		SpreadElement
+		SpreadElement,
+		ObjectExpression
 	} from 'estree';
 
 	namespace recast {
@@ -70,9 +71,10 @@ declare module 'recast/main' {
 				identifier(id: string): Identifier;
 				commentLine(comment: string, trailing?: boolean, leading?: boolean): Comment;
 				literal(value: boolean | string | number | null | RegExp): Literal;
-				variableDeclarator(id: Identifier, value: Literal | Identifier): VariableDeclarator;
+				variableDeclarator(id: Identifier, value: ObjectExpression | Literal | Identifier): VariableDeclarator;
 				variableDeclaration(value: string, declarators: VariableDeclarator[]): VariableDeclaration;
 				callExpression(callee: Expression | Super, args: Array<Expression | SpreadElement>): CallExpression;
+				objectExpression(properties: any[]): ObjectExpression;
 			};
 			export function visit(
 				ast: AST,

--- a/tests/support/fixtures/static-build-loader/static-has-foo-true-bar-false.js
+++ b/tests/support/fixtures/static-build-loader/static-has-foo-true-bar-false.js
@@ -22,7 +22,7 @@ require(foo);
 require('foo');
 // !has('baz')
 require("qat");
-var importedValue = undefined;
+var importedValue = {};
 var another = undefined, namedExport = undefined;
 
 // has('bar')


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

With requires they get used to reference by `obj.default` which means replacing the import with undefined leads to runtime errors for any checks on the elided import. For requires this should be an empty object, as default and named imports are referenced from an object.