### PR TITLE
Fix the per path static behaviour for build time rendering

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -186,10 +186,10 @@ export default class BuildTimeRender {
 		additionalScripts,
 		additionalCss
 	}: RenderResult) {
-		let staticPath = false;
+		let isStatic = this._static;
 		if (typeof path === 'object') {
 			if (this._useHistory) {
-				staticPath = !!path.static;
+				isStatic = path.static === undefined ? isStatic : path.static;
 			}
 			path = path.path;
 		} else {
@@ -223,7 +223,7 @@ export default class BuildTimeRender {
 			if (title) {
 				html = html.replace(/<title>.*<\/title>/, title);
 			}
-			if (this._static || staticPath) {
+			if (isStatic) {
 				html = html.replace(this._createScripts(), '');
 			} else {
 				html = html.replace(this._createScripts(), `${script}${css}${this._createScripts(false)}`);
@@ -266,7 +266,7 @@ export default class BuildTimeRender {
 				);
 			}
 		}
-		if (!this._static && !staticPath) {
+		if (!isStatic) {
 			blockScripts.forEach((blockScript, i) => {
 				writtenAssets.push(blockScript);
 				html = html.replace('</body>', `<script type="text/javascript" src="${blockScript}"></script></body>`);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Enable site's configured for static BTR to conditionally override the static flag per path.