### PR TITLE
Add mailto and file protocol exception to href follows

### DIFF
--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -122,7 +122,7 @@ export async function getPageLinks(page: any) {
 				.toLowerCase();
 		})
 	);
-	links = [...new Set(links.filter((link) => /^http(s)?:\/\//.test(link) === false))];
+	links = [...new Set(links.filter((link) => /^(http(s)?:\/\/)|(mailto:)/.test(link) === false))];
 	return links;
 }
 

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -122,7 +122,7 @@ export async function getPageLinks(page: any) {
 				.toLowerCase();
 		})
 	);
-	links = [...new Set(links.filter((link) => /^(http(s)?:\/\/)|(mailto:)/.test(link) === false))];
+	links = [...new Set(links.filter((link) => /^(http(s)?:\/\/)|(mailto:)|(file:)/.test(link) === false))];
 	return links;
 }
 

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/other/index.html
@@ -3,7 +3,7 @@
 		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
-		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"><a href="my-path"></a><a href="other"></a></div></div>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"><a href="my-path"></a><a href="other"></a><a href="mailto:me@email.com"></a><a href="file://file.location"></a></div></div>
 		<script>
 	if (!window['test']) {
 		window['test'].publicPath = window.location.pathname.replace(/(\/)?other(\/)?$/, '/');

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/main.js
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/main.js
@@ -11,6 +11,8 @@
 		const imgFive = document.createElement('img');
 		const linkOne = document.createElement('a');
 		const linkTwo = document.createElement('a');
+		const linkMailto = document.createElement('a');
+		const linkFile = document.createElement('a');
 		div.classList.add('hello', 'another');
 		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);
 		app.appendChild(div);
@@ -35,6 +37,12 @@
 
 		linkTwo.setAttribute('href', 'other');
 		div.appendChild(linkTwo);
+
+		linkMailto.setAttribute('href', 'mailto:me@email.com');
+		div.appendChild(linkMailto);
+
+		linkFile.setAttribute('href', 'file://file.location');
+		div.appendChild(linkFile);
 	}
 
 	if (route === '/') {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds `mailto` and `file:` to href filter.

Resolves #273 
