### PR TITLE
Allow paths to be excluded from path auto-discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -392,9 +392,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
-      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
+      "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -876,9 +876,9 @@
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.0.tgz",
+      "integrity": "sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==",
       "dev": true
     },
     "alphanum-sort": {
@@ -1680,14 +1680,14 @@
       }
     },
     "browserslist": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
-      "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.1.tgz",
+      "integrity": "sha512-WMjXwFtPskSW1pQUDJRxvRKRkeCr7usN0O/Za76N+F4oadaTdQHotSGcX9jT/Hs7mSKPkyMFNvqawB/1HzYDKQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001043",
-        "electron-to-chromium": "^1.3.413",
-        "node-releases": "^1.1.53",
-        "pkg-up": "^2.0.0"
+        "caniuse-lite": "^1.0.30001088",
+        "electron-to-chromium": "^1.3.481",
+        "escalade": "^3.0.1",
+        "node-releases": "^1.1.58"
       }
     },
     "buffer": {
@@ -1907,9 +1907,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001084",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001084.tgz",
-      "integrity": "sha512-ftdc5oGmhEbLUuMZ/Qp3mOpzfZLCxPYKcvGv6v2dJJ+8EdqcvZRbAGOiLmkM/PV1QGta/uwBs8/nCl6sokDW6w=="
+      "version": "1.0.30001088",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001088.tgz",
+      "integrity": "sha512-6eYUrlShRYveyqKG58HcyOfPgh3zb2xqs7NvT2VVtP3hEUeeWvc3lqhpeMTxYWBBeeaT9A4bKsrtjATm66BTHg=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3648,9 +3648,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.474",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.474.tgz",
-      "integrity": "sha512-fPkSgT9IBKmVJz02XioNsIpg0WYmkPrvU1lUJblMMJALxyE7/32NGvbJQKKxpNokozPvqfqkuUqVClYsvetcLw=="
+      "version": "1.3.483",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.483.tgz",
+      "integrity": "sha512-+05RF8S9rk8S0G8eBCqBRBaRq7+UN3lDs2DAvnG8SBSgQO3hjy0+qt4CmRk5eiuGbTcaicgXfPmBi31a+BD3lg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -3659,9 +3659,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -3840,6 +3840,11 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "escalade": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
+      "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA=="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -3851,9 +3856,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.2.tgz",
-      "integrity": "sha512-InuOIiKk8wwuOFg6x9BQXbzjrQhtyXh46K9bqVTPzSo2FnyMBaYGBMC6PhQy7yxxil9vIedFBweQBMK74/7o8A==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -7443,9 +7448,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -7958,14 +7963,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "requires": {
-        "find-up": "^2.1.0"
-      }
-    },
-    "pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "requires": {
         "find-up": "^2.1.0"
       }
@@ -10685,23 +10682,11 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
-      "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
+      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        }
-      }
+      "optional": true
     },
     "uglifyjs-webpack-plugin": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,12 +1680,12 @@
       }
     },
     "browserslist": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.1.tgz",
-      "integrity": "sha512-WMjXwFtPskSW1pQUDJRxvRKRkeCr7usN0O/Za76N+F4oadaTdQHotSGcX9jT/Hs7mSKPkyMFNvqawB/1HzYDKQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.2.tgz",
+      "integrity": "sha512-MfZaeYqR8StRZdstAK9hCKDd2StvePCYp5rHzQCPicUjfFliDgmuaBNPHYUTpAywBN8+Wc/d7NYVFkO0aqaBUw==",
       "requires": {
         "caniuse-lite": "^1.0.30001088",
-        "electron-to-chromium": "^1.3.481",
+        "electron-to-chromium": "^1.3.483",
         "escalade": "^3.0.1",
         "node-releases": "^1.1.58"
       }
@@ -1907,9 +1907,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001088",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001088.tgz",
-      "integrity": "sha512-6eYUrlShRYveyqKG58HcyOfPgh3zb2xqs7NvT2VVtP3hEUeeWvc3lqhpeMTxYWBBeeaT9A4bKsrtjATm66BTHg=="
+      "version": "1.0.30001091",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001091.tgz",
+      "integrity": "sha512-ECd8gfBBpv0GKsEYY5052+8PBjExiugDoi3dfkJcxujh2mf7kiuDvb1o27GXlOOGopKiIPYEX8XDPYj7eo3E9w=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -11072,9 +11072,9 @@
           }
         },
         "binary-extensions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
           "dev": true,
           "optional": true
         },

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/index.html
@@ -3,7 +3,7 @@
 		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
-		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<a href="my-path/other"></a></div></div>
+		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<a href="my-path/other"></a><a href="excluded"></a><a href="/other/excluded"></a></div></div>
 		<script>
 	if (!window['test']) {
 		window['test'].publicPath = window.location.pathname.replace(/(\/)?my-path(\/)?$/, '/');

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/main.js
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/main.js
@@ -54,6 +54,12 @@
 		const link = document.createElement('a');
 		link.setAttribute('href', 'my-path/other');
 		div.appendChild(link);
+		const excludedLinkOne = document.createElement('a');
+		excludedLinkOne.setAttribute('href', 'excluded')
+		const excludedLinkTwo = document.createElement('a');
+		excludedLinkTwo.setAttribute('href', '/other/excluded')
+		div.appendChild(excludedLinkOne);
+		div.appendChild(excludedLinkTwo);
 		app.appendChild(div);
 	} else if (route === '/my-path/other') {
 		div = document.createElement('div');

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -213,7 +213,17 @@ describe('build-time-render', () => {
 				root: 'app',
 				puppeteerOptions: { args: ['--no-sandbox'] },
 				scope: 'test',
-				onDemand: true
+				onDemand: true,
+				paths: [
+					{
+						path: 'excluded',
+						exclude: true
+					},
+					{
+						path: '/other/excluded/',
+						exclude: true
+					}
+				]
 			});
 			btr.apply(compiler);
 			assert.isTrue(pluginRegistered);
@@ -983,7 +993,17 @@ describe('build-time-render', () => {
 					entries: ['runtime', 'main'],
 					root: 'app',
 					puppeteerOptions: { args: ['--no-sandbox'] },
-					scope: 'test'
+					scope: 'test',
+					paths: [
+						{
+							path: 'excluded',
+							exclude: true
+						},
+						{
+							path: '/other/excluded/',
+							exclude: true
+						}
+					]
 				});
 				btr.apply(compiler);
 				assert.isTrue(pluginRegistered);
@@ -2280,7 +2300,17 @@ describe('build-time-render', () => {
 					root: 'app',
 					puppeteerOptions: { args: ['--no-sandbox'] },
 					scope: 'test',
-					renderer: 'jsdom'
+					renderer: 'jsdom',
+					paths: [
+						{
+							path: 'excluded',
+							exclude: true
+						},
+						{
+							path: '/other/excluded/',
+							exclude: true
+						}
+					]
 				});
 				btr.apply(compiler);
 				assert.isTrue(pluginRegistered);
@@ -2423,7 +2453,17 @@ describe('build-time-render', () => {
 				const btr = new Btr({
 					basePath: '',
 					useHistory: true,
-					paths: ['other'],
+					paths: [
+						'other',
+						{
+							path: 'excluded',
+							exclude: true
+						},
+						{
+							path: '/other/excluded/',
+							exclude: true
+						}
+					],
 					discoverPaths: false,
 					entries: ['runtime', 'main'],
 					root: 'app',


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds an additional, optional configuration property for paths to exclude the path from auto-discovery during build time rendering.

Resolves #285 
