### PR TITLE
Only add existing script and link tags when transferring the document head

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7145,9 +7145,9 @@
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "node-html-parser": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.1.11.tgz",
-      "integrity": "sha512-KOjvmbk0yWuy/cN8uqk6bVYS0Lue+jVWcLO/zmnCtz8FPXhj00apBN376FoM6QmFMMbJwXQdKf5ko6G1S6bnrw==",
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.2.20.tgz",
+      "integrity": "sha512-1fUpYjAducDrrBSE0etRUV1tM+wSFTudmrslMXuk35wL/L29E7e1CLQn4CNzFLnqtYpmDlWhkD6VUloyHA0dwA==",
       "requires": {
         "he": "1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "precommit": "lint-staged",
     "prettier": "prettier --write \"{src,tests}/**/*.{ts,tsx}\"",
     "release": "run-s lint clean build \"dojo-release -- {@}\" --",
-    "test": "NODE_OPTIONS=--max_old_space_size=4096 run-s lint build intern",
+    "test": "NODE_OPTIONS=--max_old_space_size=4096 run-s lint build \"intern -- {@}\" --",
     "uploadCoverage": "codecov --file=coverage/coverage.json",
     "watch:ts": "dojo-tsc-watcher -p tsconfig.json -- dojo-package",
     "watch": "run-p watch:ts \"build:static:** -- --watch\""
@@ -71,7 +71,7 @@
     "lodash": "4.17.4",
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",
-    "node-html-parser": "1.1.11",
+    "node-html-parser": "1.2.20",
     "opener": "1.4.3",
     "postcss": "7.0.7",
     "puppeteer": "1.11.0",

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<a href="my-path/other"></a></div></div>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/other/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
 	<body>
 		<div id="app"><div class="other">Other</div></div>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/other/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"><a href="my-path"></a><a href="other"></a><a href="mailto:me@email.com"></a><a href="file://file.location"></a></div></div>

--- a/tests/support/fixtures/build-time-render/state-static-no-paths/expected/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-no-paths/expected/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"></div></div>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}</div></div>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/other/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
 	<body>
 		<div id="app"><div class="other">Other</div></div>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/expected/other/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"></div></div>

--- a/tests/support/fixtures/build-time-render/state-static/btr-index.html
+++ b/tests/support/fixtures/build-time-render/state-static/btr-index.html
@@ -1,8 +1,50 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json" />
-		<link href="main.css" rel="stylesheet">
-		<title>Original Title</title>
+		<meta charset="utf-8" />
+		<meta name="theme-color" content="#222127" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="icon" type="image/png" href="favicon.png" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
+		<link rel="preconnect" href="https://www.google-analytics.com" />
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title="SitePen RSS Feed"
+			href="https://www.sitepen.com/rss.xml"
+		/>
+		<link
+			rel="alternate"
+			type="application/atom+xml"
+			title="SitePen Atom Feed"
+			href="https://www.sitepen.com/atom.xml"
+		/>
+		<link
+			rel="preload"
+			as="style"
+			href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+		/>
+		<link
+			href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+			rel="stylesheet"
+			media="print"
+			onload="this.media='all'"
+		/>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-3242977-2"></script>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<style>
+			.sticky {
+				background-color: rgb(9, 19, 31) !important;
+				padding-top: 2px !important;
+				padding-bottom: 2px !important;
+			}
+		</style>
+		<link rel="manifest" href="manifest.json">
 	</head>
 	<body>
 		<div id="app"></div>

--- a/tests/support/fixtures/build-time-render/state-static/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/expected/my-path/index.html
@@ -1,8 +1,48 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<meta charset="utf-8">
+		<meta name="theme-color" content="#222127">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<style>
+			.sticky {
+				background-color: rgb(9, 19, 31) !important;
+				padding-top: 2px !important;
+				padding-bottom: 2px !important;
+			}
+		</style>
 		<title>Hello my-path</title>
 		<meta name="description" content="my-path">
+		<link rel="icon" type="image/png" href="favicon.png" >
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin >
+		<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin >
+		<link rel="preconnect" href="https://www.google-analytics.com" >
+		<link rel="alternate"
+			type="application/rss+xml"
+			title="SitePen RSS Feed"
+			href="https://www.sitepen.com/rss.xml"
+		>
+		<link rel="alternate"
+			type="application/atom+xml"
+			title="SitePen Atom Feed"
+			href="https://www.sitepen.com/atom.xml"
+		>
+		<link rel="preload"
+			as="style"
+			href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+		>
+		<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+			rel="stylesheet"
+			media="print"
+			onload="this.media='all'"
+		>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-3242977-2"></script>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<link rel="manifest" href="manifest.json">
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}</div></div>

--- a/tests/support/fixtures/build-time-render/state-static/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/expected/my-path/other/index.html
@@ -1,8 +1,48 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<meta charset="utf-8">
+		<meta name="theme-color" content="#222127">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<style>
+			.sticky {
+				background-color: rgb(9, 19, 31) !important;
+				padding-top: 2px !important;
+				padding-bottom: 2px !important;
+			}
+		</style>
 		<title>Hello my-path/other</title>
 		<meta name="description" content="my-path other">
+		<link rel="icon" type="image/png" href="favicon.png" >
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin >
+		<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin >
+		<link rel="preconnect" href="https://www.google-analytics.com" >
+		<link rel="alternate"
+			type="application/rss+xml"
+			title="SitePen RSS Feed"
+			href="https://www.sitepen.com/rss.xml"
+		>
+		<link rel="alternate"
+			type="application/atom+xml"
+			title="SitePen Atom Feed"
+			href="https://www.sitepen.com/atom.xml"
+		>
+		<link rel="preload"
+			as="style"
+			href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+		>
+		<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+			rel="stylesheet"
+			media="print"
+			onload="this.media='all'"
+		>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-3242977-2"></script>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<link rel="manifest" href="manifest.json">
 	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
 	<body>
 		<div id="app"><div class="other">Other</div></div>

--- a/tests/support/fixtures/build-time-render/state-static/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/expected/other/index.html
@@ -1,8 +1,48 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<meta charset="utf-8">
+		<meta name="theme-color" content="#222127">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<style>
+			.sticky {
+				background-color: rgb(9, 19, 31) !important;
+				padding-top: 2px !important;
+				padding-bottom: 2px !important;
+			}
+		</style>
 		<title>Hello home</title>
 		<meta name="description" content="home">
+		<link rel="icon" type="image/png" href="favicon.png" >
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin >
+		<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin >
+		<link rel="preconnect" href="https://www.google-analytics.com" >
+		<link rel="alternate"
+			type="application/rss+xml"
+			title="SitePen RSS Feed"
+			href="https://www.sitepen.com/rss.xml"
+		>
+		<link rel="alternate"
+			type="application/atom+xml"
+			title="SitePen Atom Feed"
+			href="https://www.sitepen.com/atom.xml"
+		>
+		<link rel="preload"
+			as="style"
+			href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+		>
+		<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+			rel="stylesheet"
+			media="print"
+			onload="this.media='all'"
+		>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-3242977-2"></script>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<link rel="manifest" href="manifest.json">
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"></div></div>

--- a/tests/support/fixtures/build-time-render/state-static/index.html
+++ b/tests/support/fixtures/build-time-render/state-static/index.html
@@ -1,10 +1,50 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json" />
-		<link href="main.css" rel="stylesheet">
-		<script src="http://localhost:9999/main.js"></script>
-		<link href="http://localhost:9999/main.css" rel="stylesheet">
-		<title>Original Title</title>
+		<meta charset="utf-8" />
+		<meta name="theme-color" content="#222127" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="icon" type="image/png" href="favicon.png" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
+		<link rel="preconnect" href="https://www.google-analytics.com" />
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title="SitePen RSS Feed"
+			href="https://www.sitepen.com/rss.xml"
+		/>
+		<link
+			rel="alternate"
+			type="application/atom+xml"
+			title="SitePen Atom Feed"
+			href="https://www.sitepen.com/atom.xml"
+		/>
+		<link
+			rel="preload"
+			as="style"
+			href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+		/>
+		<link
+			href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Open+Sans:wght@400;700&display=swap"
+			rel="stylesheet"
+			media="print"
+			onload="this.media='all'"
+		/>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-3242977-2"></script>
+		<script>
+			window.isThisAScriptTag = true;
+		</script>
+		<style>
+			.sticky {
+				background-color: rgb(9, 19, 31) !important;
+				padding-top: 2px !important;
+				padding-bottom: 2px !important;
+			}
+		</style>
+		<link rel="manifest" href="manifest.json">
 	</head>
 	<body>
 		<div id="app"></div>

--- a/tests/support/fixtures/build-time-render/state-static/main.js
+++ b/tests/support/fixtures/build-time-render/state-static/main.js
@@ -42,6 +42,12 @@
 		meta.setAttribute('name', 'description');
 		meta.setAttribute('content', 'my-path');
 		document.head.appendChild(meta);
+		const link = document.createElement('link');
+		link.setAttribute('href', 'something');
+		const script = document.createElement('script');
+		script.setAttribute('src', 'external.js');
+		document.head.appendChild(link);
+		document.head.appendChild(script);
 		div = document.createElement('div');
 		div.classList.add('hello', 'another');
 		div.innerHTML = JSON.stringify(window.DojoHasEnvironment);

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}.another{background:red}.color{color:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another color">{"staticFeatures":{"build-time-render":true}}</div></div>

--- a/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/my-path/other/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
 	<body>
 		<div id="app"><div class="other">Other</div></div>

--- a/tests/support/fixtures/build-time-render/state/expected/other/index.html
+++ b/tests/support/fixtures/build-time-render/state/expected/other/index.html
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json" />
 	<style>.hello{background:red}span{width:100%}.another{background:red}</style></head>
 	<body>
 		<div id="app"><div class="hello another">{"staticFeatures":{"build-time-render":true}}<img src="https://example.com"><img src="http://example.com"><img src="/image.svg"><img src="./relative-image.svg"><img src="../other-relative-image.svg"></div></div>


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Only add `script` and `link` tags from the output index.html, instead of copying over the entire document head after build time rendering.

Resolves #287 
