### PR TITLE
Support colons in class names and not selectors

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -308,14 +308,19 @@ export default class BuildTimeRender {
 		return this._cssFiles.reduce((result, entry: string) => {
 			let filteredCss: string = filterCss(join(this._output!, entry), (context: string, value: string) => {
 				if (context === 'selector') {
-					value = value.replace(/(:| ).*/, '');
-					value = value
+					let parsedValue = value
+						.split('\\:')
+						.map((part) => part.replace(/((>?|~?):| ).*/, ''))
+						.join('\\:');
+					parsedValue = parsedValue
 						.split('.')
 						.slice(0, 2)
 						.join('.');
-					const firstChar = value.substr(0, 1);
+					const firstChar = parsedValue.substr(0, 1);
+					const noMatchingClass =
+						classes.indexOf(parsedValue) === -1 && classes.indexOf(parsedValue.replace('\\:', ':')) === -1;
 
-					return classes.indexOf(value) === -1 && ['.', '#'].indexOf(firstChar) !== -1;
+					return noMatchingClass && ['.', '#'].indexOf(firstChar) !== -1;
 				}
 			});
 

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/other/index.html
@@ -3,7 +3,7 @@
 		<link rel="manifest" href="manifest.json" />
 	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
 	<body>
-		<div id="app"><div class="other">Other</div></div>
+		<div id="app"><div class="other media:colon not other-not">Other</div></div>
 		<script>
 	if (!window['test']) {
 		window['test'].publicPath = window.location.pathname.replace(/(\/)?my-path\/other(\/)?$/, '/');

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/expected/my-path/other/index.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<link rel="manifest" href="manifest.json" />
-	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
+	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}.not~:not("span"),.other-not>:not("span"){color:#00f}@media (min-width:1280px){.media\:colon{color:purple}}</style></head>
 	<body>
 		<div id="app"><div class="other media:colon not other-not">Other</div></div>
 		<script>

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/main.css
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/main.css
@@ -24,4 +24,18 @@ span {
 	width: 100%;
 }
 
+.not~:not('span') {
+	color: blue;
+}
+
+.other-not>:not('span') {
+	color: blue;
+}
+
+@media (min-width: 1280px) {
+	.media\:colon {
+		color: purple;
+	}
+}
+
 /*# sourceMappingURL=main.16469ae7e579bf3f6af50cbfcb734efa.bundle.css.map*/

--- a/tests/support/fixtures/build-time-render/state-auto-discovery/main.js
+++ b/tests/support/fixtures/build-time-render/state-auto-discovery/main.js
@@ -64,6 +64,9 @@
 	} else if (route === '/my-path/other') {
 		div = document.createElement('div');
 		div.classList.add('other');
+		div.classList.add('media:colon');
+		div.classList.add('not');
+		div.classList.add('other-not');
 		div.innerHTML = 'Other';
 		app.appendChild(div);
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support colons in class names that are escaped and also `not` selectors with a preceding sibling (`~`) or child (`>`) selector, such as `>:not(something)`

Resolves #290 