### PR TITLE
Test for cldr-data correctly

### DIFF
--- a/src/cldr/loader.ts
+++ b/src/cldr/loader.ts
@@ -27,9 +27,9 @@ function generateCldr(cldrData: any, locales: string[], includeInverse = false) 
 function getValidCldrDataLocale(locale: string): string {
 	const cldr = new Cldr(locale);
 	try {
-		require('cldr-data/main/${locale}/ca-gregorian.json');
+		require(`cldr-data/main/${locale}/ca-gregorian.json`);
 	} catch {
-		locale = cldr.attributes.minLanguageId;
+		locale = cldr.attributes.language;
 	}
 	return locale;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The test for CLDR-DATA should use the locale (not the string locale) and then use the language not the min  language id.