### PR TITLE
Register minimum language id for all supported locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1907,9 +1907,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001099",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-      "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA=="
+      "version": "1.0.30001100",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001100.tgz",
+      "integrity": "sha512-0eYdp1+wFCnMlCj2oudciuQn2B9xAFq3WpgpcBIZTxk/1HNA/O2YA7rpeYhnOqsqAJq1AHUgx6i1jtafg7m2zA=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3648,9 +3648,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.497",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.497.tgz",
-      "integrity": "sha512-sPdW5bUDZwiFtoonuZCUwRGzsZmKzcLM0bMVhp6SMCfUG+B3faENLx3cE+o+K0Jl+MPuNA9s9cScyFjOlixZpQ=="
+      "version": "1.3.498",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.498.tgz",
+      "integrity": "sha512-W1hGwaQEU8j9su2jeAr3aabkPuuXw+j8t73eajGAkEJWbfWiwbxBwQN/8Qmv2qCy3uCDm2rOAaZneYQM8VGC4w=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -3841,9 +3841,9 @@
       }
     },
     "escalade": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
-      "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
+      "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ=="
     },
     "escape-html": {
       "version": "1.0.3",

--- a/src/cldr/loader.ts
+++ b/src/cldr/loader.ts
@@ -52,6 +52,7 @@ export default function(this: webpack.loader.LoaderContext) {
 		},
 		[] as string[]
 	);
+	const registeredCldrLocales: string[] = [];
 
 	likelySubtags.supplemental.likelySubtags = generateCldr(likelySubtags.supplemental.likelySubtags, locales, true);
 	plurals.supplemental['plurals-type-cardinal'] = generateCldr(
@@ -61,6 +62,10 @@ export default function(this: webpack.loader.LoaderContext) {
 
 	function loadLocaleCldrTemplate(locale: string) {
 		locale = getValidCldrDataLocale(locale);
+		if (registeredCldrLocales.indexOf(locale) !== -1) {
+			return '';
+		}
+		registeredCldrLocales.push(locale);
 		return `
 cldrData.push(require('cldr-data/main/${locale}/ca-gregorian.json'));
 cldrData.push(require('cldr-data/main/${locale}/dateFields.json'));

--- a/src/cldr/loader.ts
+++ b/src/cldr/loader.ts
@@ -36,9 +36,23 @@ function getValidCldrDataLocale(locale: string): string {
 
 export default function(this: webpack.loader.LoaderContext) {
 	const { locale, supportedLocales = [], sync } = getOptions(this);
-	const locales = [locale, ...supportedLocales];
 
 	Cldr.load(likelySubtags);
+	const definedLocales: string[] = [locale, ...supportedLocales];
+	const locales = definedLocales.reduce(
+		(calculatedLocales, locale) => {
+			const cldr = new Cldr(locale);
+			if (
+				cldr.attributes.minLanguageId !== locale &&
+				definedLocales.indexOf(cldr.attributes.minLanguageId) === -1
+			) {
+				return [...calculatedLocales, locale, cldr.attributes.minLanguageId];
+			}
+			return [...calculatedLocales, locale];
+		},
+		[] as string[]
+	);
+
 	likelySubtags.supplemental.likelySubtags = generateCldr(likelySubtags.supplemental.likelySubtags, locales, true);
 	plurals.supplemental['plurals-type-cardinal'] = generateCldr(
 		plurals.supplemental['plurals-type-cardinal'],

--- a/tests/support/fixtures/cldr/expectedMultipleLocaleBootstrapSync.js
+++ b/tests/support/fixtures/cldr/expectedMultipleLocaleBootstrapSync.js
@@ -12,14 +12,6 @@ var cldrData = [weekData, ordinals, numberingSystems, parentLocales, likelySubta
 
 
 
-cldrData.push(require('cldr-data/main/en/ca-gregorian.json'));
-cldrData.push(require('cldr-data/main/en/dateFields.json'));
-cldrData.push(require('cldr-data/main/en/timeZoneNames.json'));
-cldrData.push(require('cldr-data/main/en/currencies.json'));
-cldrData.push(require('cldr-data/main/en/numbers.json'));
-cldrData.push(require('cldr-data/main/en/units.json'));
-
-
 cldrData.push(require('cldr-data/main/fr/ca-gregorian.json'));
 cldrData.push(require('cldr-data/main/fr/dateFields.json'));
 cldrData.push(require('cldr-data/main/fr/timeZoneNames.json'));
@@ -35,8 +27,17 @@ cldrData.push(require('cldr-data/main/ja/currencies.json'));
 cldrData.push(require('cldr-data/main/ja/numbers.json'));
 cldrData.push(require('cldr-data/main/ja/units.json'));
 
+
+cldrData.push(require('cldr-data/main/en/ca-gregorian.json'));
+cldrData.push(require('cldr-data/main/en/dateFields.json'));
+cldrData.push(require('cldr-data/main/en/timeZoneNames.json'));
+cldrData.push(require('cldr-data/main/en/currencies.json'));
+cldrData.push(require('cldr-data/main/en/numbers.json'));
+cldrData.push(require('cldr-data/main/en/units.json'));
+
+
 Globalize.load(cldrData)
-i18n.setCldrLoaders({ 'en': true,'fr': true,'ja': true, fallback: true, supplemental: true });
-i18n.setSupportedLocales(["en","fr","ja"]);
-i18n.setDefaultLocale('en');
+i18n.setCldrLoaders({ 'fr': true,'ja': true,'en-US': true,'en': true, fallback: true, supplemental: true });
+i18n.setSupportedLocales(["fr","ja","en-US","en"]);
+i18n.setDefaultLocale('fr');
 export default i18n.setLocale({ default: true });

--- a/tests/support/fixtures/cldr/expectedSingleUnknownLocaleBootstrap.js
+++ b/tests/support/fixtures/cldr/expectedSingleUnknownLocaleBootstrap.js
@@ -30,6 +30,35 @@ i18n.setCldrLoaders({ 'zh-CN': function() {
 	}
 
 	return Promise.all(promises);
+},'zh': function() {
+	var promises = [];
+
+	if (has('__i18n_date__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/date-time" */ 'cldr-data/main/zh/ca-gregorian.json')
+		);
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/date-time" */ 'cldr-data/main/zh/dateFields.json')
+		);
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/date-time" */ 'cldr-data/main/zh/timeZoneNames.json')
+		);
+	}
+	if (has('__i18n_number__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/currency" */ 'cldr-data/main/zh/currencies.json')
+		);
+	}
+	if (has('__i18n_date__') || has('__i18n_number__') || has('__i18n_unit__')) {
+		promises.push(
+			import(/* webpackChunkName: "i18n/zh/common" */ 'cldr-data/main/zh/numbers.json')
+		);
+	}
+	if (has('__i18n_unit__')) {
+		promises.push(import(/* webpackChunkName: "i18n/zh/unit" */ 'cldr-data/main/zh/units.json'));
+	}
+
+	return Promise.all(promises);
 }, fallback: function () {
 		return Promise.all([
 			import(/* webpackChunkName: "i18n/supplemental/fallback" */ 'cldr-core/supplemental/likelySubtags.json'),
@@ -68,6 +97,6 @@ i18n.setCldrLoaders({ 'zh-CN': function() {
 
 	return Promise.all(promises);
 } });
-i18n.setSupportedLocales(["zh-CN"]);
+i18n.setSupportedLocales(["zh-CN","zh"]);
 i18n.setDefaultLocale('zh-CN');
 export default i18n.setLocale({ default: true });

--- a/tests/unit/cldr/loader.ts
+++ b/tests/unit/cldr/loader.ts
@@ -62,8 +62,8 @@ describe('cldr loader', () => {
 		});
 		it('should generate loaders for the all supported locales', () => {
 			mockLoaderUtils.getOptions.returns({
-				locale: 'en',
-				supportedLocales: ['fr', 'ja'],
+				locale: 'fr',
+				supportedLocales: ['ja', 'en-US'],
 				sync: true
 			});
 			const cldrLoaderOutput = mockModule.getModuleUnderTest().default();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

For all supported locales defined in the `dojorc` register the minimum language id using cldrjs to ensure that message bundles are appropriately loaded.

Resolves #293 
