### PR TITLE
[WIP] Use workers to render pages in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,12 @@
             "has-flag": "^3.0.0"
           }
         },
+        "typescript": {
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+          "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+          "dev": true
+        },
         "y18n": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
@@ -7216,6 +7222,11 @@
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
     },
+    "node-worker-threads-pool": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/node-worker-threads-pool/-/node-worker-threads-pool-1.4.1.tgz",
+      "integrity": "sha512-vyDXDVP/fppE4miayWbiN0H0NOOlECPnxDUg4byx4Qm8lK2RyypxWj5iisPjZTuXbKlFIKoIYvTmkzruoAlX0g=="
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -10629,9 +10640,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10640,9 +10640,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "sinon": "~4.5.0",
     "stream-combiner2": "1.1.1",
     "style-loader": "0.23.1",
-    "typescript": "4.0.2",
+    "typescript": "3.8.3",
     "webpack": "4.25.1"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",
     "node-html-parser": "1.2.20",
+    "node-worker-threads-pool": "1.4.1",
     "opener": "1.4.3",
     "postcss": "7.0.7",
     "puppeteer": "1.11.0",
@@ -123,7 +124,7 @@
     "sinon": "~4.5.0",
     "stream-combiner2": "1.1.1",
     "style-loader": "0.23.1",
-    "typescript": "~3.4.5",
+    "typescript": "4.0.2",
     "webpack": "4.25.1"
   },
   "lint-staged": {

--- a/src/build-time-render/Renderer.ts
+++ b/src/build-time-render/Renderer.ts
@@ -1,8 +1,8 @@
+import { Renderer } from './interfaces';
+
 const puppeteer = require('puppeteer');
 const jsdom = require('jsdom');
 const { JSDOM, ResourceLoader } = jsdom;
-
-export type Renderer = 'puppeteer' | 'jsdom';
 
 export default (renderer: Renderer = 'puppeteer') => {
 	if (renderer === 'puppeteer') {

--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -3,6 +3,7 @@ import * as getPort from 'get-port';
 import * as http from 'http';
 import * as url from 'url';
 import * as history from 'connect-history-api-fallback';
+import { BtrPath } from './interfaces';
 
 export interface ServeDetails {
 	server: http.Server;
@@ -178,4 +179,18 @@ export async function getPageStyles(page: any): Promise<string[]> {
 	);
 
 	return css.map((url: string) => url.replace(/http:\/\/localhost:\d+\//g, ''));
+}
+
+export function parseBtrPath(path: BtrPath) {
+	return typeof path === 'object' ? path.path : path;
+}
+
+export function createError(error: string | Error, currentPath?: BtrPath, type?: 'Runtime' | 'Block') {
+	const message = error instanceof Error ? error.message.replace('Error: ', '') : error;
+	const parsedPath = currentPath ? parseBtrPath(currentPath) : currentPath;
+	const pathString = parsedPath !== undefined ? ` (path: "${parsedPath || 'default path'}")` : '';
+	const errorType = type ? `${type} ` : '';
+	const btrError = new Error(`Build Time Render ${errorType}Error${pathString}: ${message}`);
+	btrError.stack = error instanceof Error ? error.stack : undefined;
+	return btrError;
 }

--- a/src/build-time-render/interfaces.ts
+++ b/src/build-time-render/interfaces.ts
@@ -1,0 +1,52 @@
+export type Renderer = 'puppeteer' | 'jsdom';
+
+export interface BtrPathOptions {
+	path: string;
+	match?: string[];
+	static?: boolean;
+	exclude?: boolean;
+}
+
+export type BtrPath = string | BtrPathOptions;
+
+export interface BlockOutput {
+	[index: string]: {
+		[index: string]: string;
+	};
+}
+
+export interface BtrResult {
+	path?: BtrPath;
+	head: string[];
+	content: string;
+	styles: string;
+	script: string;
+	blockScripts?: string[];
+	additionalScripts: string[];
+	additionalCss: string[];
+}
+
+export interface RenderWorkerData {
+	root: string;
+	scope: string;
+	output: string;
+	cssFiles: string[];
+	rendererType?: Renderer;
+	basePath: string;
+	baseUrl: string;
+	puppeteerOptions: any;
+	initialBtr: boolean;
+	entries: string[];
+	originalManifest: any;
+	discoverPaths: boolean;
+	useHistory: boolean;
+	onDemand: boolean;
+}
+
+export interface RenderWorkerResult {
+	discoveredPaths: string[];
+	blocksOutput: BlockOutput;
+	btrResult?: BtrResult;
+	warnings: Error[];
+	errors: Error[];
+}

--- a/src/build-time-render/render-worker.ts
+++ b/src/build-time-render/render-worker.ts
@@ -1,0 +1,189 @@
+import { parentPort, workerData, Worker } from 'worker_threads';
+import renderer from './Renderer';
+import {
+	serve,
+	parseBtrPath,
+	setupEnvironment,
+	getRenderHooks,
+	getScriptSources,
+	getPageStyles,
+	getClasses,
+	getForSelector,
+	getAllForSelector,
+	generateBasePath,
+	createError,
+	getPageLinks
+} from './helpers';
+import { ensureDirSync } from 'fs-extra';
+import { join } from 'path';
+import { BtrPath, RenderWorkerResult, RenderWorkerData } from './interfaces';
+
+const filterCss = require('filter-css');
+
+interface RenderWorkerOptions {
+	path: BtrPath;
+}
+
+const {
+	root,
+	scope,
+	output,
+	cssFiles,
+	rendererType,
+	basePath,
+	baseUrl,
+	puppeteerOptions,
+	entries,
+	originalManifest,
+	discoverPaths,
+	useHistory
+}: RenderWorkerData = workerData;
+
+export async function setup() {
+	if (!parentPort) {
+		throw new Error('Unable to detect worker to run build time rendering.');
+	}
+	const browser = await renderer(rendererType).launch(puppeteerOptions);
+	const app = await serve(output, baseUrl);
+	const screenshotDirectory = join(output, '..', 'info', 'screenshots');
+	ensureDirSync(screenshotDirectory);
+
+	parentPort.on('message', async ({ path }: RenderWorkerOptions) => {
+		const parsedPath = parseBtrPath(path);
+		const renderWorkerResult: RenderWorkerResult = {
+			errors: [],
+			warnings: [],
+			discoveredPaths: [],
+			blocksOutput: {}
+		};
+
+		async function buildBridge(modulePath: string, args: any[]) {
+			const promise = new Promise<any>((resolve, reject) => {
+				const worker = new Worker(join(__dirname, 'block-worker.js'), {
+					workerData: {
+						basePath,
+						modulePath,
+						args
+					}
+				});
+
+				worker.on('message', resolve);
+				worker.on('error', reject);
+				worker.on('exit', (code) => {
+					if (code !== 0) {
+						reject(new Error(`Worker stopped with exit code ${code}`));
+					}
+				});
+			});
+			try {
+				const { result, error } = await promise;
+				if (error) {
+					renderWorkerResult.errors.push(createError(error, parsedPath, 'Block'));
+				} else {
+					renderWorkerResult.blocksOutput[modulePath] = renderWorkerResult.blocksOutput[modulePath] || {};
+					renderWorkerResult.blocksOutput[modulePath][JSON.stringify(args)] = JSON.stringify(result);
+					return result;
+				}
+			} catch (error) {
+				renderWorkerResult.errors.push(createError(error, parsedPath, 'Block'));
+			}
+		}
+
+		try {
+			const reportError = (error: Error) => {
+				if (error.message.indexOf('http://localhost') !== -1) {
+					renderWorkerResult.errors.push(createError(error, parsedPath, 'Runtime'));
+				}
+			};
+			const page = await browser.newPage();
+			page.on('error', reportError);
+			page.on('pageerror', reportError);
+			await setupEnvironment(page, baseUrl, scope);
+			await page.exposeFunction('__dojoBuildBridge', buildBridge);
+
+			try {
+				await page.goto(`http://localhost:${app.port}${baseUrl}${parsedPath}`);
+				const pathDirectories = parsedPath.replace('#', '').split('/');
+				if (pathDirectories.length > 0) {
+					pathDirectories.pop();
+					ensureDirSync(join(screenshotDirectory, ...pathDirectories));
+				}
+				let { rendering, blocksPending } = await getRenderHooks(page, scope);
+				while (rendering || blocksPending) {
+					({ rendering, blocksPending } = await getRenderHooks(page, scope));
+				}
+				const scripts = await getScriptSources(page, app.port);
+				const additionalScripts = scripts.filter(
+					(script) => script && entries.every((entry) => !script.endsWith(originalManifest[entry]))
+				);
+				const pageStyles = await getPageStyles(page);
+				const additionalCss = pageStyles
+					.filter((url: string) =>
+						entries.every((entry) => !url.endsWith(originalManifest[entry.replace('.js', '.css')]))
+					)
+					.filter((url) => !/^http(s)?:\/\/.*/.test(url) || url.indexOf('localhost') !== -1);
+				await page.screenshot({
+					path: join(screenshotDirectory, `${parsedPath ? parsedPath.replace('#', '') : 'default'}.png`)
+				});
+				let content = await getForSelector(page, `#${root}`);
+				const classes = await getClasses(page);
+				const head = await getAllForSelector(page, 'head > *:not(script):not(link)');
+				const styles = cssFiles.reduce((result, entry: string) => {
+					let filteredCss: string = filterCss(join(output, entry), (context: string, value: string) => {
+						if (context === 'selector') {
+							let parsedValue = value
+								.split('\\:')
+								.map((part) => part.replace(/((>?|~?):| ).*/, ''))
+								.join('\\:');
+							parsedValue = parsedValue
+								.split('.')
+								.slice(0, 2)
+								.join('.');
+							const firstChar = parsedValue.substr(0, 1);
+							const noMatchingClass =
+								classes.indexOf(parsedValue) === -1 &&
+								classes.indexOf(parsedValue.replace('\\:', ':')) === -1;
+
+							return noMatchingClass && ['.', '#'].indexOf(firstChar) !== -1;
+						}
+					});
+
+					return `${result}${filteredCss}`;
+				}, '');
+				let script = '';
+
+				content = content.replace(/http:\/\/localhost:\d+\//g, '');
+				content = content.replace(new RegExp(baseUrl.slice(1), 'g'), '');
+				if (useHistory) {
+					script = generateBasePath(parsedPath, scope);
+				}
+
+				renderWorkerResult.btrResult = {
+					additionalCss,
+					additionalScripts,
+					content,
+					head,
+					path,
+					script,
+					styles
+				};
+
+				if (discoverPaths) {
+					const links = await getPageLinks(page);
+					for (let i = 0; i < links.length; i++) {
+						renderWorkerResult.discoveredPaths.push(links[i]);
+					}
+				}
+			} catch (error) {
+				renderWorkerResult.warnings.push(createError('Failed to visit path', parsedPath));
+			} finally {
+				await page.close();
+			}
+		} catch (error) {
+			renderWorkerResult.errors.push(createError(error, parsedPath));
+		}
+		parentPort!.postMessage(renderWorkerResult);
+	});
+}
+
+setup();

--- a/tests/unit/build-time-render/BuildTimeRender.ts
+++ b/tests/unit/build-time-render/BuildTimeRender.ts
@@ -46,6 +46,7 @@ const createCompilation = (
 		| 'build-bridge-blocks-only'
 ) => {
 	const errors: Error[] = [];
+	const warnings: Error[] = [];
 	const manifest = readFileSync(
 		path.join(__dirname, `./../../support/fixtures/build-time-render/${type}/manifest.json`),
 		'utf-8'
@@ -62,7 +63,7 @@ const createCompilation = (
 		assets[parsedManifest[key]] = { source: () => content };
 		return assets;
 	}, assets);
-	return { assets, errors };
+	return { assets, errors, warnings };
 };
 
 let normalModuleReplacementPluginStub: any;
@@ -554,10 +555,7 @@ describe('build-time-render', () => {
 						compilation.errors[1].message,
 						'Build Time Render Block Error (path: "default path"): Block error'
 					);
-					assert.strictEqual(
-						compilation.errors[2].message,
-						'Build Time Render Error (path: "default path"): Test Error'
-					);
+					assert.strictEqual(compilation.errors[2].message, 'Build Time Render Error: Test Error');
 				});
 			});
 		});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Moves the build time rendering logic into a pool of workers in order to increase the performance by rendering the pages in parallel.

Resolves #184 
