### PR TITLE
Fixing path configuration for onDemand BTR

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -69,16 +69,14 @@ function genHash(content: string): string {
 		.substr(0, 20);
 }
 
-function normalizePath(path: string) {
-	return path
+function normalizePath(path: string, lowercase = true) {
+	path = path
 		.replace(/#.*/, '')
 		.replace(/\/$/, '')
-		.replace(/^\//, '')
-		.toLowerCase();
-}
+		.replace(/^\//, '');
 
-const trailingSlash = new RegExp(/\/$/);
-const leadingSlash = new RegExp(/^\//);
+	return lowercase ? path.toLowerCase() : path;
+}
 
 class MockAsset {
 	private _assetPath: string;
@@ -170,20 +168,15 @@ export default class BuildTimeRender {
 		const initialPath = typeof path === 'object' ? path.path : path;
 
 		this._basePath = basePath;
-		this._baseUrl = baseUrl;
-		if (!trailingSlash.test(this._baseUrl)) {
-			this._baseUrl = `${this._baseUrl}/`;
-		}
-		if (!leadingSlash.test(this._baseUrl)) {
-			this._baseUrl = `/${this._baseUrl}`;
-		}
+		this._baseUrl = `/${normalizePath(baseUrl, false)}/`.replace(/^\/{2,}/, '/');
+
 		this._renderer = renderer;
 		this._discoverPaths = discoverPaths;
 		this._puppeteerOptions = puppeteerOptions;
 		for (let i = 0; i < paths.length; i++) {
 			const path = paths[i];
 			if (typeof path === 'object' && path.exclude) {
-				this._excludedPaths.push(path.path.replace(trailingSlash, '').replace(leadingSlash, ''));
+				this._excludedPaths.push(normalizePath(path.path, false));
 			} else {
 				this._paths.push(path);
 			}

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -168,7 +168,8 @@ export default class BuildTimeRender {
 		const initialPath = typeof path === 'object' ? path.path : path;
 
 		this._basePath = basePath;
-		this._baseUrl = `/${normalizePath(baseUrl, false)}/`.replace(/^\/{2,}/, '/');
+		this._baseUrl = normalizePath(baseUrl, false);
+		this._baseUrl = this._baseUrl ? `/${this._baseUrl}/` : '/';
 
 		this._renderer = renderer;
 		this._discoverPaths = discoverPaths;


### PR DESCRIPTION
**Type:** bug
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

"on-demand" BTR does the initial build fine, but subsequent watched builds don't honor the path configuration you might have set up in your `.dojorc`. This has been fixed by taking the path name and matching it (if possible) against your path configuration.

Resolves #275  