### PR TITLE
Do not statically set fetch to true in modern

### DIFF
--- a/src/static-build-loader/features/modern.json
+++ b/src/static-build-loader/features/modern.json
@@ -21,7 +21,6 @@
 	"es6-weakmap": true,
 	"es7-array": true,
 	"es2019-array": true,
-	"fetch": true,
 	"filereader": true,
 	"float32array": true,
 	"formdata": true,

--- a/tests/unit/static-build-loader/getFeatures.ts
+++ b/tests/unit/static-build-loader/getFeatures.ts
@@ -33,7 +33,6 @@ registerSuite('getFeatures', {
 			'es6-weakmap': true,
 			'es7-array': true,
 			'es2019-array': true,
-			fetch: true,
 			filereader: true,
 			float32array: true,
 			formdata: true,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This change removes `fetch` from the modern feature set and allows the has sniff to work dynamically at runtime - this is inline with the other browser api shims such as intersection observer as they shims are split into sep bundles and only loaded for a user if the application uses the shim _and_ the users environment requires the the shim.

This should resolve issues with build time rendering when an application imports dojo's fetch shim.
