### PR TITLE
Only process js or mjs files in emit all plugin

### DIFF
--- a/src/build-time-render/helpers.ts
+++ b/src/build-time-render/helpers.ts
@@ -18,7 +18,7 @@ export async function serve(directory: string, base: string): Promise<ServeDetai
 			index: '/btr-index.html'
 		})
 	);
-	app.use(base, express.static(directory));
+	app.use(base, express.static(directory) as any);
 	app.use(
 		base,
 		history({
@@ -45,7 +45,7 @@ export async function serve(directory: string, base: string): Promise<ServeDetai
 			]
 		})
 	);
-	app.use(base, express.static(directory));
+	app.use(base, express.static(directory) as any);
 	const promise = new Promise<ServeDetails>((resolve) => {
 		const server = app.listen(port, () => {
 			resolve({ server, port });

--- a/src/emit-all-plugin/EmitAllPlugin.ts
+++ b/src/emit-all-plugin/EmitAllPlugin.ts
@@ -102,7 +102,6 @@ export default class EmitAllPlugin {
 						const extension = legacy ? '.js' : '.mjs';
 						const source = module.originalSource().source();
 						const assetName = resource.replace(basePath, '').replace(/\.ts(x)?$/, extension);
-
 						if (assetName.includes('.css')) {
 							await Promise.all(
 								module.dependencies.map(async ({ identifier, content, sourceMap }: any) => {

--- a/src/emit-all-plugin/EmitAllPlugin.ts
+++ b/src/emit-all-plugin/EmitAllPlugin.ts
@@ -120,7 +120,7 @@ export default class EmitAllPlugin {
 									}
 								})
 							);
-						} else {
+						} else if (assetName.includes('.mjs') || assetName.includes('.js')) {
 							const sourceMap = (module.originalSource() as any)._sourceMap;
 							let js = source;
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Only process`js` and `mjs` files in emit all plugin

Resolves https://github.com/dojo/cli-build-widget/issues/104
