### PR TITLE
Fix revisiting bug for cached paths

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -747,7 +747,15 @@ ${blockCacheEntry}`
 					const result = this._cache.pages[this._currentPath];
 					renderResults.push(result);
 					if (result.paths) {
-						paths.push(...result.paths);
+						for (let i = 0; i < result.paths.length; i++) {
+							const newPath = result.paths[i];
+							if (pageManifest.indexOf(newPath) === -1 && this._excludedPaths.indexOf(newPath) === -1) {
+								if (!this._onDemand) {
+									paths.push(newPath);
+								}
+								pageManifest.push(newPath);
+							}
+						}
 					}
 				} else {
 					let page = await this._createPage(browser);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Fixes a bug where the cache can continuously re-add already visited pages, results in a loop of death.
