### PR TITLE
Do not consider polyfills as additional scripts

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -775,9 +775,10 @@ ${blockCacheEntry}`
 						({ rendering, blocksPending } = await getRenderHooks(page, this._scope));
 					}
 					const scripts = await getScriptSources(page, app.port);
-					const additionalScripts = scripts.filter(
-						(script) => script && this._entries.every((entry) => !script.endsWith(originalManifest[entry]))
-					);
+					const additionalScripts = scripts.filter((script) => {
+						const isRuntime = script.indexOf('runtime/') !== -1 && script.indexOf('runtime/blocks') === -1;
+						return script && !isRuntime && this._entries.every((entry) => !script.endsWith(originalManifest[entry]));
+					});
 					const additionalCss = (await getPageStyles(page))
 						.filter((url: string) =>
 							this._entries.every(

--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -777,7 +777,11 @@ ${blockCacheEntry}`
 					const scripts = await getScriptSources(page, app.port);
 					const additionalScripts = scripts.filter((script) => {
 						const isRuntime = script.indexOf('runtime/') !== -1 && script.indexOf('runtime/blocks') === -1;
-						return script && !isRuntime && this._entries.every((entry) => !script.endsWith(originalManifest[entry]));
+						return (
+							script &&
+							!isRuntime &&
+							this._entries.every((entry) => !script.endsWith(originalManifest[entry]))
+						);
 					});
 					const additionalCss = (await getPageStyles(page))
 						.filter((url: string) =>


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

We should not be preloading polyfills as they are determined by clients browser. Preloading means that unnecessary scripts would be loaded for every user.