### PR TITLE
Support typescript 4 in the registry transformer

### DIFF
--- a/src/registry-transformer/index.ts
+++ b/src/registry-transformer/index.ts
@@ -25,9 +25,24 @@ interface VisitorOptions {
 	sync: boolean;
 }
 
+const {
+	createSignatureDeclaration,
+	createCall,
+	createLiteral,
+	createToken,
+	createCallExpression,
+	createStringLiteral
+} =
+	(ts as any).factory || ts;
+
 function createArrowFuncForDefaultImport(modulePath: string) {
-	return ts.createCall((ts as any).createSignatureDeclaration(ts.SyntaxKind.ImportKeyword), undefined, [
-		ts.createLiteral(`${modulePath}`)
+	if (createSignatureDeclaration) {
+		return createCall(createSignatureDeclaration(ts.SyntaxKind.ImportKeyword), undefined, [
+			createLiteral(`${modulePath}`)
+		]);
+	}
+	return createCallExpression(createToken(ts.SyntaxKind.ImportKeyword), undefined, [
+		createStringLiteral(`${modulePath}`)
 	]);
 }
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The TS apis have changed for typescript 4, this change conditionally uses the correct apis depending on what is available.