### PR TITLE
Move request counter to instance variable of the custom resource class

### DIFF
--- a/src/build-time-render/Renderer.ts
+++ b/src/build-time-render/Renderer.ts
@@ -3,6 +3,31 @@ const { JSDOM, ResourceLoader } = jsdom;
 
 export type Renderer = 'puppeteer' | 'jsdom';
 
+class CustomResourceLoader extends ResourceLoader {
+	private _requestCount = 0;
+
+	get requestCount() {
+		return this._requestCount;
+	}
+
+	fetch(url: string, options: any) {
+		if (options.element && options.element.localName === 'iframe') {
+			return null;
+		}
+		this._requestCount++;
+		const response = super.fetch(url.replace(/#.*/, ''), options);
+		response.then(
+			() => {
+				this._requestCount--;
+			},
+			() => {
+				this._requestCount--;
+			}
+		);
+		return response;
+	}
+}
+
 export default (renderer: Renderer = 'jsdom') => {
 	if (renderer === 'puppeteer') {
 		try {
@@ -22,25 +47,6 @@ export default (renderer: Renderer = 'jsdom') => {
 				newPage: () => {
 					const beforeParseFuncs: any[] = [];
 					let window: any;
-					let requestCount = 0;
-					class CustomResourceLoader extends ResourceLoader {
-						fetch(url: string, options: any) {
-							if (options.element && options.element.localName === 'iframe') {
-								return null;
-							}
-							requestCount++;
-							const response = super.fetch(url.replace(/#.*/, ''), options);
-							response.then(
-								() => {
-									requestCount--;
-								},
-								() => {
-									requestCount--;
-								}
-							);
-							return response;
-						}
-					}
 					return {
 						evaluate: (func: () => any, ...args: any[]) => {
 							return new Promise((resolve) => {
@@ -64,10 +70,11 @@ export default (renderer: Renderer = 'jsdom') => {
 							return Promise.resolve(func(nodes));
 						},
 						goto: async (url: string, options: any) => {
+							const resources = new CustomResourceLoader();
 							const jsdomOptions: any = {
 								runScripts: 'dangerously',
 								pretendToBeVisual: true,
-								resources: new CustomResourceLoader()
+								resources
 							};
 
 							jsdomOptions.beforeParse = (win: any) => {
@@ -85,7 +92,7 @@ export default (renderer: Renderer = 'jsdom') => {
 								timeout = true;
 							}, 30000);
 							await new Promise((resolve) => setTimeout(resolve, 10));
-							while (requestCount && !timeout) {
+							while (resources.requestCount && !timeout) {
 								await new Promise((resolve) => setTimeout(resolve, 10));
 							}
 							if (timeout) {

--- a/src/build-time-render/Renderer.ts
+++ b/src/build-time-render/Renderer.ts
@@ -15,25 +15,6 @@ export default (renderer: Renderer = 'jsdom') => {
 	}
 	return {
 		launch: (options: any) => {
-			let requestCount = 0;
-			class CustomResourceLoader extends ResourceLoader {
-				fetch(url: string, options: any) {
-					if (options.element && options.element.localName === 'iframe') {
-						return null;
-					}
-					requestCount++;
-					const response = super.fetch(url.replace(/#.*/, ''), options);
-					response.then(
-						() => {
-							requestCount--;
-						},
-						() => {
-							requestCount--;
-						}
-					);
-					return response;
-				}
-			}
 			return Promise.resolve({
 				close: () => {
 					return Promise.resolve();
@@ -41,7 +22,25 @@ export default (renderer: Renderer = 'jsdom') => {
 				newPage: () => {
 					const beforeParseFuncs: any[] = [];
 					let window: any;
-					requestCount = 0;
+					let requestCount = 0;
+					class CustomResourceLoader extends ResourceLoader {
+						fetch(url: string, options: any) {
+							if (options.element && options.element.localName === 'iframe') {
+								return null;
+							}
+							requestCount++;
+							const response = super.fetch(url.replace(/#.*/, ''), options);
+							response.then(
+								() => {
+									requestCount--;
+								},
+								() => {
+									requestCount--;
+								}
+							);
+							return response;
+						}
+					}
 					return {
 						evaluate: (func: () => any, ...args: any[]) => {
 							return new Promise((resolve) => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

There are occasions when the request counter can get to negative value which means that a page incorrectly times out. The request counter should always have been an instance variable, this moves the class out of the renderer and makes the counter an instance variable so it is isolated to each page visit.
