### PR TITLE
Bugfix/main css in main chunk

### DIFF
--- a/src/bootstrap-plugin/BootstrapPlugin.ts
+++ b/src/bootstrap-plugin/BootstrapPlugin.ts
@@ -8,7 +8,7 @@ export interface ShimModules {
 
 export interface BootstrapPluginOptions {
 	entryPath: string;
-	cssPath: string;
+	cssPath: string | null;
 	shimModules: ShimModules[];
 }
 
@@ -19,7 +19,7 @@ const shimModuleRegExp = /@dojo(\/|\\)framework(\/|\\)shim/;
 export class BootstrapPlugin {
 	public flagMap: { [index: string]: boolean };
 	private _entryPath: string;
-	private _cssPath: string;
+	private _cssPath: string | null;
 	private _shimModules: ShimModules[];
 	private _defineConfiguration: { [index: string]: string } = {
 		__dojoframeworkshimIntersectionObserver: JSON.stringify('no-bootstrap'),

--- a/src/bootstrap-plugin/BootstrapPlugin.ts
+++ b/src/bootstrap-plugin/BootstrapPlugin.ts
@@ -8,6 +8,7 @@ export interface ShimModules {
 
 export interface BootstrapPluginOptions {
 	entryPath: string;
+	cssPath: string;
 	shimModules: ShimModules[];
 }
 
@@ -18,6 +19,7 @@ const shimModuleRegExp = /@dojo(\/|\\)framework(\/|\\)shim/;
 export class BootstrapPlugin {
 	public flagMap: { [index: string]: boolean };
 	private _entryPath: string;
+	private _cssPath: string;
 	private _shimModules: ShimModules[];
 	private _defineConfiguration: { [index: string]: string } = {
 		__dojoframeworkshimIntersectionObserver: JSON.stringify('no-bootstrap'),
@@ -29,8 +31,9 @@ export class BootstrapPlugin {
 	};
 
 	constructor(options: BootstrapPluginOptions) {
-		const { shimModules, entryPath } = options;
+		const { shimModules, entryPath, cssPath } = options;
 		this._entryPath = entryPath;
+		this._cssPath = cssPath;
 		this._shimModules = shimModules;
 		this.flagMap = shimModules.reduce(
 			(flags, module) => {
@@ -42,6 +45,7 @@ export class BootstrapPlugin {
 			} as any
 		);
 		this._defineConfiguration.__MAIN_ENTRY = JSON.stringify(this._entryPath);
+		this._defineConfiguration.__MAIN_CSS_ENTRY = JSON.stringify(this._cssPath);
 		shimModules.forEach((shimModule) => {
 			this._defineConfiguration[`__${shimModule.module.replace(/(\/|@)/g, '')}`] = JSON.stringify(
 				shimModule.has.toLowerCase()

--- a/src/bootstrap-plugin/async.js
+++ b/src/bootstrap-plugin/async.js
@@ -1,3 +1,6 @@
+
+__MAIN_CSS_ENTRY && import(/* webpackChunkName: "main" */ __MAIN_CSS_ENTRY);
+
 var has = require('@dojo/framework/core/has');
 var cldrLoader = require('../cldr/bootstrap').default;
 require('./common');
@@ -40,8 +43,6 @@ if (!has.default('dom-pointer-events')) {
 }
 
 modules.push(cldrLoader);
-
-__MAIN_CSS_ENTRY && import(/* webpackChunkName: "main" */ __MAIN_CSS_ENTRY);
 
 module.exports = Promise.all(modules).then(function() {
 	return import(/* webpackChunkName: "main" */ __MAIN_ENTRY);

--- a/src/bootstrap-plugin/async.js
+++ b/src/bootstrap-plugin/async.js
@@ -41,7 +41,8 @@ if (!has.default('dom-pointer-events')) {
 
 modules.push(cldrLoader);
 
+__MAIN_CSS_ENTRY && import(/* webpackChunkName: "main" */ __MAIN_CSS_ENTRY);
+
 module.exports = Promise.all(modules).then(function() {
-	__MAIN_CSS_ENTRY && import(/* webpackChunkName: "main" */ __MAIN_CSS_ENTRY);
 	return import(/* webpackChunkName: "main" */ __MAIN_ENTRY);
 });

--- a/src/bootstrap-plugin/async.js
+++ b/src/bootstrap-plugin/async.js
@@ -42,6 +42,6 @@ if (!has.default('dom-pointer-events')) {
 modules.push(cldrLoader);
 
 module.exports = Promise.all(modules).then(function() {
-	import(/* webpackChunkName: "main" */ __MAIN_CSS_ENTRY);
+	__MAIN_CSS_ENTRY && import(/* webpackChunkName: "main" */ __MAIN_CSS_ENTRY);
 	return import(/* webpackChunkName: "main" */ __MAIN_ENTRY);
 });

--- a/src/bootstrap-plugin/async.js
+++ b/src/bootstrap-plugin/async.js
@@ -42,5 +42,6 @@ if (!has.default('dom-pointer-events')) {
 modules.push(cldrLoader);
 
 module.exports = Promise.all(modules).then(function() {
+	import(/* webpackChunkName: "main" */ __MAIN_CSS_ENTRY);
 	return import(/* webpackChunkName: "main" */ __MAIN_ENTRY);
 });

--- a/tests/unit/bootstrap-plugin/BootstrapPlugin.ts
+++ b/tests/unit/bootstrap-plugin/BootstrapPlugin.ts
@@ -48,6 +48,7 @@ describe('bootstrap-plugin', () => {
 		const BootstrapPlugin = mockModule.getModuleUnderTest().default;
 		const bootstrapPlugin = new BootstrapPlugin({
 			entryPath: 'main',
+			cssPath: null,
 			shimModules: [
 				{
 					module: '@dojo/framework/shim/Foo',
@@ -123,6 +124,163 @@ window.DojoHasEnvironment = { staticFeatures: shimFeatures };`
 
 		assert.isTrue(defineStub.calledOnce);
 		assert.deepEqual(defineStub.firstCall.args[0], {
+			__MAIN_CSS_ENTRY: null,
+			__MAIN_ENTRY: '"main"',
+			__dojoframeworkshimIntersectionObserver: '"no-bootstrap"',
+			__dojoframeworkshimWebAnimations: '"no-bootstrap"',
+			__dojoframeworkshimResizeObserver: '"no-bootstrap"',
+			__dojoframeworkshimfetch: '"no-bootstrap"',
+			__dojoframeworkshiminert: '"no-bootstrap"',
+			__dojoframeworkshimFoo: '"foo"',
+			__dojoframeworkshimBar: '"bar"',
+			__dojoBuildBlocks: '"build-blocks"',
+			__dojoframeworkshimBaz: '"baz"'
+		});
+		const [normalReplacementTest, normalReplaceCallback] = normalReplacementStub.firstCall.args;
+		const expectedTest = new RegExp('@dojo(/|\\\\)framework(/|\\\\)shim');
+		assert.strictEqual(normalReplacementTest.toString(), expectedTest.toString());
+		const bootstrapResource = {
+			resourceResolveData: {
+				context: {
+					issuer: path.normalize('foo/bar/@dojo/webpack-contrib/bootstrap-plugin/async')
+				}
+			},
+			request: path.normalize('foo!bar!@dojo/webpack-contrib/static-build-loader!resource'),
+			loaders: [
+				{
+					loader: 'foo'
+				},
+				{
+					loader: path.normalize('@dojo/webpack-contrib/static-build-loader')
+				}
+			]
+		};
+		normalReplaceCallback(bootstrapResource);
+		assert.deepEqual(bootstrapResource, {
+			resourceResolveData: {
+				context: { issuer: path.normalize('foo/bar/@dojo/webpack-contrib/bootstrap-plugin/async') }
+			},
+			request: 'foo!bar!resource',
+			loaders: [{ loader: 'foo' }]
+		});
+		const nonBootstrapResource = {
+			resourceResolveData: {
+				context: {
+					issuer: path.normalize('foo/bar/other')
+				}
+			},
+			request: path.normalize('foo!bar!@dojo/webpack-contrib/static-build-loader!resource'),
+			loaders: [
+				{
+					loader: 'foo'
+				},
+				{
+					loader: path.normalize('@dojo/webpack-contrib/static-build-loader')
+				}
+			]
+		};
+		normalReplaceCallback(nonBootstrapResource);
+		assert.deepEqual(nonBootstrapResource, {
+			resourceResolveData: {
+				context: {
+					issuer: path.normalize('foo/bar/other')
+				}
+			},
+			request: path.normalize('foo!bar!@dojo/webpack-contrib/static-build-loader!resource'),
+			loaders: [
+				{
+					loader: 'foo'
+				},
+				{
+					loader: path.normalize('@dojo/webpack-contrib/static-build-loader')
+				}
+			]
+		});
+	});
+
+	it('bootstrap with css', () => {
+		const wrapperStub = mockModule.getMock('wrapper-webpack-plugin');
+		wrapperStub.ctor.returns({ apply: () => {} });
+		const BootstrapPlugin = mockModule.getModuleUnderTest().default;
+		const bootstrapPlugin = new BootstrapPlugin({
+			entryPath: 'main',
+			cssPath: 'main.css',
+			shimModules: [
+				{
+					module: '@dojo/framework/shim/Foo',
+					has: 'foo'
+				},
+				{
+					module: '@dojo/framework/shim/Bar',
+					has: 'bar'
+				},
+				{
+					module: '@dojo/framework/shim/Baz',
+					has: 'baz'
+				}
+			]
+		});
+		bootstrapPlugin.apply(compiler);
+		runner['BootstrapPlugin']({
+			hooks: {
+				seal: {
+					tap: tapStub
+				}
+			},
+			modules: [
+				{
+					issuer: {
+						userRequest: path.normalize('foo/bar')
+					},
+					userRequest: path.normalize('foo/bar/@dojo/framework/shim/Foo')
+				},
+				{
+					issuer: {
+						userRequest: path.normalize('foo/bar/@dojo/webpack-contrib/bootstrap-plugin/async')
+					},
+					userRequest: path.normalize('foo/bar/@dojo/framework/shim/Bar')
+				},
+				{
+					issuer: {
+						userRequest: path.normalize('foo/bar')
+					},
+					userRequest: path.normalize('foo/bar/@dojo/framework/core/Bar')
+				},
+				{
+					issuer: {
+						userRequest: path.normalize('some/other/module')
+					},
+					userRequest: path.normalize(`foo/bar?modulePath='foo/bar.block'`)
+				}
+			]
+		});
+		runner['BootstrapPlugin']();
+
+		assert.deepEqual(bootstrapPlugin.flagMap, {
+			bar: false,
+			baz: false,
+			foo: true,
+			'build-blocks': true,
+			'no-bootstrap': true
+		});
+
+		assert.isTrue(wrapperStub.ctor.calledOnce);
+		const header = wrapperStub.ctor.firstCall.args[0].header;
+
+		assert.strictEqual(
+			header(),
+			`var shimFeatures = {"no-bootstrap":true,"foo":true,"bar":false,"baz":false,"build-blocks":true};
+if (window.DojoHasEnvironment && window.DojoHasEnvironment.staticFeatures) {
+	Object.keys(window.DojoHasEnvironment.staticFeatures).forEach(function (key) {
+		shimFeatures[key] = window.DojoHasEnvironment.staticFeatures[key];
+	});
+}
+window.DojoHasEnvironment = { staticFeatures: shimFeatures };`
+		);
+
+		assert.isTrue(defineStub.calledOnce);
+		assert.deepEqual(defineStub.firstCall.args[0], {
+			__MAIN_CSS_ENTRY: '"main.css"',
 			__MAIN_ENTRY: '"main"',
 			__dojoframeworkshimIntersectionObserver: '"no-bootstrap"',
 			__dojoframeworkshimWebAnimations: '"no-bootstrap"',

--- a/tests/unit/bootstrap-plugin/BootstrapPlugin.ts
+++ b/tests/unit/bootstrap-plugin/BootstrapPlugin.ts
@@ -15,6 +15,9 @@ let normalReplacementStub = stub();
 
 describe('bootstrap-plugin', () => {
 	beforeEach(() => {
+		defineStub.reset();
+		normalReplacementStub.reset();
+
 		mockModule = new MockModule('../../../src/bootstrap-plugin/BootstrapPlugin', require);
 		mockModule.dependencies(['wrapper-webpack-plugin']);
 
@@ -124,7 +127,7 @@ window.DojoHasEnvironment = { staticFeatures: shimFeatures };`
 
 		assert.isTrue(defineStub.calledOnce);
 		assert.deepEqual(defineStub.firstCall.args[0], {
-			__MAIN_CSS_ENTRY: null,
+			__MAIN_CSS_ENTRY: 'null',
 			__MAIN_ENTRY: '"main"',
 			__dojoframeworkshimIntersectionObserver: '"no-bootstrap"',
 			__dojoframeworkshimWebAnimations: '"no-bootstrap"',


### PR DESCRIPTION
**Type:** bug
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Bootstrap plugin will now import the `main.css` file when the path is provided from `cli-build-app` (aka `main.css` exists).

Resolves https://github.com/dojo/cli-build-app/issues/228