### PR TITLE
Remove sibling selectors before check if class is used on page

### DIFF
--- a/src/build-time-render/BuildTimeRender.ts
+++ b/src/build-time-render/BuildTimeRender.ts
@@ -364,7 +364,9 @@ export default class BuildTimeRender {
 					parsedValue = parsedValue
 						.split('.')
 						.slice(0, 2)
-						.join('.');
+						.join('.')
+						.replace('+', '')
+						.replace('~', '');
 					const firstChar = parsedValue.substr(0, 1);
 					const noMatchingClass =
 						classes.indexOf(parsedValue) === -1 && classes.indexOf(parsedValue.replace('\\:', ':')) === -1;

--- a/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/other/index.html
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/expected/my-path/other/index.html
@@ -2,7 +2,7 @@
 	<head>
 		<base href="/">
 		<link rel="manifest" href="manifest.json">
-	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}span{width:100%}</style></head>
+	<style>.other.another{color:pink;background:url("relative.png");background:url("/root.png");background:url("./relative.png");background:url("../relative.png");background:url("https://example.com");background:url("http://example.com");background:url(https://example.com);background:url(http://example.com)}.other~.another{border-color:#0ff}span{width:100%}</style></head>
 	<body>
 		<div id="app"><div class="other">Other</div></div>
 		<script>

--- a/tests/support/fixtures/build-time-render/state-static-per-path/main.css
+++ b/tests/support/fixtures/build-time-render/state-static-per-path/main.css
@@ -20,6 +20,10 @@
 	background: url(http://example.com);
 }
 
+.other~.another {
+	border-color: aqua;
+}
+
 span {
 	width: 100%;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Selectors using `~` or `+` are not added to the BTR output even if the page uses the class. This change removes `+` and `~` before checking against the pages classes.

